### PR TITLE
The changes to b777 and renger model

### DIFF
--- a/quantarhei/models/spectral_densities/renger_2002.py
+++ b/quantarhei/models/spectral_densities/renger_2002.py
@@ -2,23 +2,19 @@
 
 from quantarhei.models.spectdens import SpectralDensityDatabaseEntry 
 from quantarhei import SpectralDensity
-
 from quantarhei import energy_units
 
 
 class renger_2002a(SpectralDensityDatabaseEntry):
-    """Spectral density of bacteriochlorophyll in FMO complex 
-    
+    """
+    Spectral density of bacteriochlorophyll
+
     Spectral density derived in 
     
-    Markus Wendling, Tonu Pullerits, Milosz A. Przyjalgowski,
-    Simone I. E. Vulto, Thijs J. Aartsma, Rienk van Grondelle,
-    and Herbert van Amerongen, "Electron-Vibrational Coupling 
-    in the Fenna-Matthews-Olson Complex of Prosthecochloris aestuarii
-    Determined by Temperature-Dependent Absorption and Fluorescence
-    Line-Narrowing Measurements"
-    J. Phys. Chem. B, 2000, 104, 5825-5831
-    
+    T. Renger and R. A. Marcus, "On the relation of protein dynamics and 
+    exciton relaxation in pigment–protein complexes: An estimation of 
+    the spectral density and a theory for the calculation of optical 
+    spectra" Journal of Chemical Physics, 2002, 116, 9997-10017
     
     """
     def __init__(self):
@@ -28,55 +24,24 @@ class renger_2002a(SpectralDensityDatabaseEntry):
         
         
     def get_SpectralDensity(self, axis):
+    
+        # Calling the spec dens calculated from b777 in rengers paper
+        # alternative_form gives the polynomial version of the same spec dens
+        # Jang, Newton, Silbey, J Chem Phys. 2007.
+        params = {"ftype": "B777",
+                  "reorg": 102.0,
+                  "alternative_form": False}
 
-        #
-        # Data from the paper
-        #
-        omegas = [36,   70,   117, 173, 185, 195, 237, 260, 284, 327,
-                  365, 381, 479, 541, 565, 580, 635, 714, 723, 730,
-                  747, 759, 768, 777, 819, 859, 896, 1158, 1176, 1216]
-        fcfs   = [0.01, 0.01, 0.0055, 0.008, 0.008, 0.011, 0.005, 
-                  0.0025, 0.005, 0.0015,
-                  0.002, 0.002, 0.001, 0.001, 0.002, 0.001, 0.003,
-                  0.002, 0.003, 0.001, 0.002, 0.002, 0.004, 0.0015,
-                  0.002, 0.0025, 0.002, 0.004, 0.003, 0.002]
-        
-        #
-        # Guessed dephasing times of the oscillators
-        #
-        gammas = [1.0/3000.0]*30
-        
-        data = []
-        for i in range(len(omegas)):
-            data.append((omegas[i],fcfs[i],gammas[i]))
-            
-        #
-        # All contributions consist of underdamped harmonic oscillators
-        #
-        params = dict(ftype="UnderdampedBrownian")
-        
-        #
-        # Create and sum-up spectral densities
-        #
-        k = 0
-        for d in data:
-            
-            params["freq"] = d[0]
-            params["reorg"] = d[0]*d[1]
-            params["gamma"] = d[2] #1.0/3000.0
-            
-            with energy_units("1/cm"):
-                sd = SpectralDensity(axis, params)
-                
-            if k == 0:
-                ret = sd
-                ax = sd.axis
-            else:
-                sd.axis = ax
-                ret += sd
-            k +=1
+        # Option of varying the paramaters of the Renger spec dens
+        # values from the paper are set by default
+        # enter om1/2 as 1/cm (they are converted in SpectralDensity)
+        params.update({"om1": 0.56,
+                       "om2": 1.9,
+                        's1':   0.8,
+                        's2':   0.5,
+                        "S0":   0.5})
 
-        return ret
+        with energy_units("1/cm"):
+            sd = SpectralDensity(axis, params)
 
-
-
+        return sd

--- a/quantarhei/models/spectral_densities/renger_2002.py
+++ b/quantarhei/models/spectral_densities/renger_2002.py
@@ -34,12 +34,10 @@ class renger_2002a(SpectralDensityDatabaseEntry):
 
         # Option of varying the paramaters of the Renger spec dens
         # values from the paper are set by default
-        # enter om1/2 as 1/cm (they are converted in SpectralDensity)
-        params.update({"om1": 0.56,
-                       "om2": 1.9,
+        params.update({"freq1": 0.56,
+                       "freq2": 1.9,
                         's1':   0.8,
-                        's2':   0.5,
-                        "S0":   0.5})
+                        's2':   0.5})
 
         with energy_units("1/cm"):
             sd = SpectralDensity(axis, params)

--- a/quantarhei/qm/corfunctions/spectraldensities.py
+++ b/quantarhei/qm/corfunctions/spectraldensities.py
@@ -12,10 +12,11 @@ from ...core.dfunction import DFunction
 from ...core.managers import UnitsManaged
 from ...core.managers import energy_units
 from ...core.time import TimeAxis
-#from ...core.frequency import FrequencyAxis
+from ...core.frequency import FrequencyAxis
 from .correlationfunctions import CorrelationFunction
 from .correlationfunctions import FTCorrelationFunction
 from ...core.units import kB_int
+from ...core.units import convert
 
 #from .correlationfunctions import c2h
 
@@ -307,64 +308,75 @@ class SpectralDensity(DFunction, UnitsManaged):
         self.lim_omega[0] = 0.0
         self.lim_omega[1] = 4*(gamma*(omega0**2))/((omega0**2)**2)
         
-    #See Kell et al, 2013, J. Phys. Chem. B. 
-    #This spectral density requires two 'freq' parameters.
-    def _make_B777(self, params, values=None, use_alternative_form=True):
+    # See Renger, Journal of Chemical Physics 2002
+    # See Jang, Newton, Silbey, J Chem Phys. 2007 for alternate form
+    # (See Kell et al, 2013, J. Phys. Chem. B.) 
+    def _make_B777(self, params, values=None):
         
-        lamb = params["reorg"]
+        # Do not use 'freq1'/'freq2' (units issue when combining spec dens)
         try:
-            omega1 = params["freq1"]            
-            omega2 = params["freq2"]
+            omega1 = params["om1"]
+            omega2 = params["om2"]
             s = [params['s1'], params['s2']]
-            S0 = params["S0"]
-            freq = [omega1, omega2]
-
+            #S0 = params["S0"]
 
         except:
-            omega1 = self.manager.iu_energy(0.56,
-                                          units="1/cm")
-            omega2 = self.manager.iu_energy(1.9,
-                                          units="1/cm")
+            omega1 = 0.56
+            omega2 = 1.9
             s = [0.8, 0.5]
-            S0 = 0.5
-            freq = [omega1, omega2]
+            #S0 = 0.5
+        # These S0 paramaters are only used for the scaling factor (remove?)
 
+        lamb = params["reorg"]
+        freq = [convert(omega1, "1/cm", "int"), convert(omega2, "1/cm", "int")]
 
         with energy_units("int"):
             omega = self.axis.data
             cropped_omega = omega
-
-            j=0
+            cfce_renger=0
             for ii in range(2):
-                j = j + (s[ii]/(numpy.math.factorial(7) * 2*(freq[ii]**4)))*\
-                (cropped_omega**3)*(numpy.exp
-                    (-numpy.abs(cropped_omega/freq[ii])**0.5))
+        # Cropped_omega**2 converts the form of spec dens to same as alt form
+                cfce_renger = cfce_renger + (cropped_omega**2)\
+                *(s[ii]/(numpy.math.factorial(7) * 2*(freq[ii]**4)))*\
+                (cropped_omega**3)\
+                *(numpy.exp(-numpy.abs(cropped_omega/freq[ii])**0.5))
 
-#            
-        if use_alternative_form:
+        # Takes alternative from as default but can be edited in params
+        if "alternative_form" not in params or params["alternative_form"]:
             #This form is taken from Jang, Newton, Silbey, J Chem Phys. 2007.
             #It gives a polynomial form of the B777 spectral density
-            print('jang used')
-            omega1c = self.manager.iu_energy(170,
-                                      units="1/cm")
-            omega2c = self.manager.iu_energy(34,
-                                      units="1/cm")
-            omega3c = self.manager.iu_energy(69,
-                                      units="1/cm")
+            print('\nJang used\n')
+            omega1c = convert(170, "1/cm", "int")
+            omega2c = convert(34, "1/cm", "int")
+            omega3c = convert(69, "1/cm", "int")
+
             with energy_units("int"):
+                # (omega/(numpy.abs(omega))) in the second term ensures
+                # proper treatment of -ve frequencies
                 omega = self.axis.data
-                cfce = 0.22*omega*numpy.exp(-numpy.abs(omega/omega1c))\
-                +(omega/(numpy.abs(omega)))*0.78*((omega**2)/omega2c)*numpy.exp(-numpy.abs(omega/omega2c))\
-                +0.31*((omega**3)/(omega3c**2))*numpy.exp(-numpy.abs(omega/omega3c))
-#        #This factor was not in the  Jang, Newton, Silbey, J Chem Phys. 2007 article.
-#        #It is necessary for the original B777 spectral density, and the alternative form to be equal.
-                cfce = (numpy.amax(j*cropped_omega**2)/numpy.amax(cfce)) * cfce * numpy.pi*S0*(1/(s[0] + s[1])) 
-               
-        if values is not None:
-            self._make_me(self.axis, values)
+                cfce_jang = \
+                0.22*omega*numpy.exp(-numpy.abs(omega/omega1c))+\
+                0.78*(omega/(numpy.abs(omega)))*((omega**2)/omega2c)*numpy.exp\
+                                                  (-numpy.abs(omega/omega2c))+\
+                0.31*((omega**3)/(omega3c**2))*numpy.\
+                                                 exp(-numpy.abs(omega/omega3c))
+
+        # I presume this is relvant to converting between the forms of spec
+        # dens but they are the same without it and this factor of ~1.2 seems
+        # redundant. Maybe we can remove it?
+                #cfce_jang = (numpy.amax(cfce_renger)/numpy.amax(cfce_jang))\
+                #* cfce_jang #* numpy.pi*S0*(1/(s[0] + s[1]))
+
+            if values is not None:
+                self._make_me(self.axis, values)
+            else:
+                self._make_me(self.axis, cfce_jang)
         else:
-            self._make_me(self.axis, cfce)
-            
+            if values is not None:
+                self._make_me(self.axis, values)
+            else:
+                self._make_me(self.axis, cfce_renger)
+
         self.lamb = lamb            
         self.lim_omega = numpy.zeros(2)
         self.lim_omega[0] = 0.0

--- a/quantarhei/qm/corfunctions/spectraldensities.py
+++ b/quantarhei/qm/corfunctions/spectraldensities.py
@@ -12,7 +12,7 @@ from ...core.dfunction import DFunction
 from ...core.managers import UnitsManaged
 from ...core.managers import energy_units
 from ...core.time import TimeAxis
-from ...core.frequency import FrequencyAxis
+#from ...core.frequency import FrequencyAxis
 from .correlationfunctions import CorrelationFunction
 from .correlationfunctions import FTCorrelationFunction
 from ...core.units import kB_int
@@ -204,7 +204,7 @@ class SpectralDensity(DFunction, UnitsManaged):
                     
                 elif ftype == "B777":
                     
-                    self._make_B777(params)
+                    self._make_B777(prms)
                     
                 elif ftype == "CP29":
                     
@@ -313,22 +313,18 @@ class SpectralDensity(DFunction, UnitsManaged):
     # (See Kell et al, 2013, J. Phys. Chem. B.) 
     def _make_B777(self, params, values=None):
         
-        # Do not use 'freq1'/'freq2' (units issue when combining spec dens)
         try:
-            omega1 = params["om1"]
-            omega2 = params["om2"]
+            omega1 = params["freq1"]
+            omega2 = params["freq2"]
             s = [params['s1'], params['s2']]
-            #S0 = params["S0"]
 
         except:
-            omega1 = 0.56
-            omega2 = 1.9
+            omega1 = convert(0.56, "1/cm", "int")
+            omega2 = convert(1.9, "1/cm", "int")
             s = [0.8, 0.5]
-            #S0 = 0.5
-        # These S0 paramaters are only used for the scaling factor (remove?)
-
+        
         lamb = params["reorg"]
-        freq = [convert(omega1, "1/cm", "int"), convert(omega2, "1/cm", "int")]
+        freq = [omega1, omega2]
 
         with energy_units("int"):
             omega = self.axis.data
@@ -360,12 +356,6 @@ class SpectralDensity(DFunction, UnitsManaged):
                                                   (-numpy.abs(omega/omega2c))+\
                 0.31*((omega**3)/(omega3c**2))*numpy.\
                                                  exp(-numpy.abs(omega/omega3c))
-
-        # I presume this is relvant to converting between the forms of spec
-        # dens but they are the same without it and this factor of ~1.2 seems
-        # redundant. Maybe we can remove it?
-                #cfce_jang = (numpy.amax(cfce_renger)/numpy.amax(cfce_jang))\
-                #* cfce_jang #* numpy.pi*S0*(1/(s[0] + s[1]))
 
             if values is not None:
                 self._make_me(self.axis, values)


### PR DESCRIPTION
#from ...core.frequency import FrequencyAxis
can be re-commented out again

There was some issue with using freq1/freq2
If I use them and convert from cm to int, the combined spectral density seems to have the wrong units. If i do not convert them (and rely on the init conversion), the initial spec density has the wrong units but the combined one looks right :S. It feels like the units are being converted a second time when the spec dens is recalculated for combining but maybe not. Either way, using om1/om2 instead of freq1/freq2 makes it all work fine.

cfce = (numpy.amax(j*cropped_omega**2)/numpy.amax(cfce)) * cfce * numpy.pi*S0*(1/(s[0] + s[1]))
This factor is included originally. The cropped_omega**2 is obviously just the part that converts from one type of spec dens to the other. It is now included in the Renger part. the rest is strange. I can find nothing about it in the literature or in some books. the numpy.amax(j*)/numpy.amax(cfce) is just 1 and the rest is a factor is ~1.2. But the spec densities are the same without this factor and the ~1.2 just changes the polynomial form away from the Renger one. Maybe we can just delete?

If we can then we can also delete S0 variable as it is only used here.