### PR TITLE
#249 release: validate version tag matches pyproject.toml before PyPI publish

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,19 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+  categories:
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: New Features & Enhancements
+      labels:
+        - enhancement
+    - title: Tests
+      labels:
+        - tests
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,6 +14,17 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v4
 
+      - name: Validate version tag matches pyproject.toml
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['version'])")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "ERROR: git tag v$TAG does not match pyproject.toml version $PKG"
+            echo "Update pyproject.toml to $TAG before tagging."
+            exit 1
+          fi
+          echo "Version check passed: $TAG == $PKG"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -65,3 +65,24 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    name: Create GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release with generated notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            --verify-tag

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Validate version tag matches pyproject.toml
         run: |
           TAG="${GITHUB_REF_NAME#v}"
-          PKG=$(python -c "import tomllib; d=tomllib.load(open('pyproject.toml','rb')); print(d['project']['version'])")
+          PKG=$(grep '^version' pyproject.toml | head -1 | sed 's/.*= *"\(.*\)"/\1/')
           if [ "$TAG" != "$PKG" ]; then
             echo "ERROR: git tag v$TAG does not match pyproject.toml version $PKG"
             echo "Update pyproject.toml to $TAG before tagging."


### PR DESCRIPTION
## Summary

Closes #249.

Two changes to harden the release process:

1. **Version tag validation** — publish workflow aborts before building if the git tag does not match the version in `pyproject.toml`
2. **Automated GitHub Releases** — after a successful PyPI publish, a GitHub Release is created automatically with notes listing all PRs merged since the previous tag, categorized by label

Also adds `.github/release.yml` to define PR categories in generated release notes (Bug Fixes / New Features & Enhancements / Tests / Other Changes).

## Merge order

**Independent** — can merge in any order relative to #259, #260, #262, and #263.

---

## Versioning convention

Quantarhei uses **semantic versioning**: `MAJOR.MINOR.PATCH` (e.g. `0.0.70`).

| Part | When to bump | Examples |
|---|---|---|
| `PATCH` | Bug fixes, tooling, CI, docs — nothing the user's code notices | `0.0.69 → 0.0.70` |
| `MINOR` | New public API, new features — backwards compatible | `0.0.70 → 0.1.0` |
| `MAJOR` | Breaking changes — existing user code may stop working | `0.1.0 → 1.0.0` |

While the version is `0.x.y`, breaking changes may ship as `MINOR` bumps by convention — stability guarantees only fully apply from `1.0.0` onwards.

---

## How releases work after this PR

### Release checklist (maintainer)

1. Merge all PRs intended for the release

2. Update the version in `pyproject.toml` (source of truth) and `setup.py` (legacy, slated for removal):

```bash
# pyproject.toml
# [project] version = "0.0.70"

# setup.py
# version='0.0.70'
```

All other version references (`quantarhei/__version__`, `Manager.version`, `docs/sphinx/conf.py`) are dynamic and update automatically — no manual change needed.

3. Commit and push:

```bash
git add pyproject.toml setup.py
git commit -m "Version changes to 0.0.70"
git push origin master
```

4. Create and push the tag:

```bash
git tag v0.0.70
git push origin v0.0.70
```

5. The publish workflow runs automatically:
   - Validates `v0.0.70` matches `pyproject.toml` version (fails fast if not)
   - Builds sdist + wheel
   - Publishes to PyPI
   - Creates a GitHub Release with auto-generated notes

### Editing the release notes after publish

The auto-generated notes are a starting point. To refine them:

- **In the browser:** go to the Releases page → find the new release → click **Edit** → update the markdown → **Update release**
- **Via CLI:** `gh release edit v0.0.70 --notes "your updated text" --repo tmancal74/quantarhei`

### What the auto-generated release notes look like

All PRs merged since the previous tag are listed automatically, grouped by label:

- **Bug Fixes** — PRs labelled `bug`
- **New Features & Enhancements** — PRs labelled `enhancement`
- **Tests** — PRs labelled `tests`
- **Other Changes** — everything else

PRs labelled `duplicate`, `invalid`, or `wontfix` are excluded.

### Optional: CI gating on tags (recommended)

Configure tag protection in **Settings → Rules → Rulesets → New ruleset**, targeting tags matching `v*` and requiring the `Quantarhei` CI status check. This prevents pushing a tag on a commit where tests have not passed.

---

## Test plan

> These items can only be verified during an actual release — the workflow only triggers on `v*` tag pushes.

- [ ] Pushing a matching tag (e.g. tag `v0.0.70`, `pyproject.toml` says `0.0.70`) → validation passes, build and publish proceed
- [ ] Pushing a mismatched tag (e.g. tag `v0.0.99`, `pyproject.toml` says `0.0.70`) → workflow fails at the validation step with a clear error, no build or publish occurs
- [ ] After successful publish, a GitHub Release is created with auto-generated PR notes
- [ ] CI passes on this PR