### PR TITLE
#257 dx: add VS Code tasks mirroring Makefile targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 
 .spyderproject
 .spyproject
-.vscode
+.vscode/**
+!.vscode/tasks.json
 __pycache__
 
 build

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Sync dev dependencies",
       "type": "shell",
-      "command": "uv sync --extra dev",
+      "command": "make sync",
       "group": "build",
       "presentation": {
         "reveal": "always",
@@ -15,7 +15,7 @@
     {
       "label": "Run unit tests",
       "type": "shell",
-      "command": "uv run pytest -v --cov=quantarhei --cov-report=term --cov-report=xml:coverage1.xml --junit-xml=results-unit.xml tests/unit",
+      "command": "make unit",
       "group": {
         "kind": "test",
         "isDefault": true
@@ -29,7 +29,7 @@
     {
       "label": "Run doc tests",
       "type": "shell",
-      "command": "uv run pytest --doctest-modules -v --cov=quantarhei --cov-append --cov-report=xml:coverage2.xml --junit-xml=results-doctest.xml quantarhei/core quantarhei/builders quantarhei/qm/corfunctions quantarhei/spectroscopy quantarhei/qm/liouvillespace quantarhei/functions quantarhei/qm/hilbertspace quantarhei/qm/propagators quantarhei/qm/propagators/poppropagator.py",
+      "command": "make doctest",
       "group": "test",
       "presentation": {
         "reveal": "always",
@@ -40,7 +40,7 @@
     {
       "label": "Run integration tests",
       "type": "shell",
-      "command": "uv run coverage run --data-file=.coverage.behave $(uv run which behave) tests/behave/features && uv run coverage combine --data-file=.coverage.behave && uv run coverage xml --data-file=.coverage.behave -o coverage3.xml",
+      "command": "make behave",
       "group": "test",
       "presentation": {
         "reveal": "always",
@@ -51,7 +51,7 @@
     {
       "label": "Run all tests",
       "type": "shell",
-      "command": "uv run pytest -v --cov=quantarhei --cov-report=term --cov-report=xml:coverage1.xml --junit-xml=results-unit.xml tests/unit && uv run pytest --doctest-modules -v --cov=quantarhei --cov-append --cov-report=xml:coverage2.xml --junit-xml=results-doctest.xml quantarhei/core quantarhei/builders quantarhei/qm/corfunctions quantarhei/spectroscopy quantarhei/qm/liouvillespace quantarhei/functions quantarhei/qm/hilbertspace quantarhei/qm/propagators quantarhei/qm/propagators/poppropagator.py && uv run coverage run --data-file=.coverage.behave $(uv run which behave) tests/behave/features && uv run coverage combine --data-file=.coverage.behave && uv run coverage xml --data-file=.coverage.behave -o coverage3.xml",
+      "command": "make test",
       "group": "test",
       "presentation": {
         "reveal": "always",
@@ -62,7 +62,18 @@
     {
       "label": "Lint",
       "type": "shell",
-      "command": "uv run ruff format --check . && uv run pre-commit run --all-files",
+      "command": "make lint",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Lint and fix",
+      "type": "shell",
+      "command": "make lint-fix",
       "group": "build",
       "presentation": {
         "reveal": "always",
@@ -73,7 +84,7 @@
     {
       "label": "Run everything",
       "type": "shell",
-      "command": "uv sync --extra dev && uv run ruff format --check . && uv run pre-commit run --all-files && uv run pytest -v --cov=quantarhei --cov-report=term tests/unit",
+      "command": "make all",
       "group": "build",
       "presentation": {
         "reveal": "always",
@@ -84,7 +95,7 @@
     {
       "label": "Clean coverage",
       "type": "shell",
-      "command": "rm -f .coverage .coverage.* coverage*.xml && rm -rf htmlcov",
+      "command": "make clean-coverage",
       "group": "build",
       "presentation": {
         "reveal": "always",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,96 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Sync dev dependencies",
+      "type": "shell",
+      "command": "uv sync --extra dev",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run unit tests",
+      "type": "shell",
+      "command": "uv run pytest -v --cov=quantarhei --cov-report=term --cov-report=xml:coverage1.xml --junit-xml=results-unit.xml tests/unit",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run doc tests",
+      "type": "shell",
+      "command": "uv run pytest --doctest-modules -v --cov=quantarhei --cov-append --cov-report=xml:coverage2.xml --junit-xml=results-doctest.xml quantarhei/core quantarhei/builders quantarhei/qm/corfunctions quantarhei/spectroscopy quantarhei/qm/liouvillespace quantarhei/functions quantarhei/qm/hilbertspace quantarhei/qm/propagators quantarhei/qm/propagators/poppropagator.py",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run integration tests",
+      "type": "shell",
+      "command": "uv run coverage run --data-file=.coverage.behave $(uv run which behave) tests/behave/features && uv run coverage combine --data-file=.coverage.behave && uv run coverage xml --data-file=.coverage.behave -o coverage3.xml",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run all tests",
+      "type": "shell",
+      "command": "uv run pytest -v --cov=quantarhei --cov-report=term --cov-report=xml:coverage1.xml --junit-xml=results-unit.xml tests/unit && uv run pytest --doctest-modules -v --cov=quantarhei --cov-append --cov-report=xml:coverage2.xml --junit-xml=results-doctest.xml quantarhei/core quantarhei/builders quantarhei/qm/corfunctions quantarhei/spectroscopy quantarhei/qm/liouvillespace quantarhei/functions quantarhei/qm/hilbertspace quantarhei/qm/propagators quantarhei/qm/propagators/poppropagator.py && uv run coverage run --data-file=.coverage.behave $(uv run which behave) tests/behave/features && uv run coverage combine --data-file=.coverage.behave && uv run coverage xml --data-file=.coverage.behave -o coverage3.xml",
+      "group": "test",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Lint",
+      "type": "shell",
+      "command": "uv run ruff format --check . && uv run pre-commit run --all-files",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run everything",
+      "type": "shell",
+      "command": "uv sync --extra dev && uv run ruff format --check . && uv run pre-commit run --all-files && uv run pytest -v --cov=quantarhei --cov-report=term tests/unit",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Clean coverage",
+      "type": "shell",
+      "command": "rm -f .coverage .coverage.* coverage*.xml && rm -rf htmlcov",
+      "group": "build",
+      "presentation": {
+        "reveal": "always",
+        "panel": "shared"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: sync lint test unit doctest behave all clean-coverage
+.PHONY: sync lint lint-fix test unit doctest behave all clean-coverage
 
 sync:
 	uv sync --extra dev
@@ -6,6 +6,10 @@ sync:
 lint:
 	uv run ruff format --check .
 	uv run pre-commit run --all-files
+
+lint-fix:
+	uv run ruff format .
+	uv run ruff check quantarhei/ --fix
 
 unit:
 	uv run pytest -v \


### PR DESCRIPTION
## Summary

Closes #257.

Adds `.vscode/tasks.json` so contributors using VS Code can run developer tasks via **Terminal → Run Task** without touching the terminal. All tasks delegate to `make` targets — the Makefile remains the single source of truth, so changes there automatically apply in VS Code too.

Also adds a `lint-fix` target to the Makefile for local development (auto-fix mode, distinct from the check-only `lint` target used in CI).

## Merge order

**Independent** — can merge in any order relative to #256 and #260.

## Changes

### `.vscode/tasks.json` — new file

Each task calls the corresponding `make` target:

| VS Code task | Makefile target |
|---|---|
| Sync dev dependencies | `make sync` |
| Run unit tests *(default)* | `make unit` |
| Run doc tests | `make doctest` |
| Run integration tests | `make behave` |
| Run all tests | `make test` |
| Lint | `make lint` |
| Lint and fix | `make lint-fix` |
| Run everything | `make all` |
| Clean coverage | `make clean-coverage` |

### `Makefile` — add `lint-fix` target

```makefile
lint-fix:
	uv run ruff format .
	uv run ruff check quantarhei/ --fix
```

`lint` (check-only, used by CI and `make all`) is unchanged. `lint-fix` is for local use when you want to auto-apply fixes.

### `.gitignore` — track `tasks.json`

`.vscode` was fully ignored. Changed to `.vscode/**` + `!.vscode/tasks.json` so `tasks.json` is tracked as project configuration while personal VS Code files (settings, launch configs) remain ignored.

## Test plan

- [ ] **Terminal → Run Task** shows all tasks listed above
- [ ] `make lint-fix` auto-formats and fixes linting issues
- [ ] Updating a `make` target is immediately reflected in the VS Code task (no changes to `tasks.json` needed)
- [ ] CI passes on this PR