### PR TITLE
#244 dx: allow import without installation via PackageNotFoundError fallback

### DIFF
--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
 import json
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 from importlib.resources import files
 
@@ -85,7 +86,10 @@ from .units import (
 class Manager(metaclass=Singleton):
     """Main package Manager"""
 
-    version = _pkg_version("quantarhei")
+    try:
+        version = _pkg_version("quantarhei")
+    except _PackageNotFoundError:
+        version = "unknown"
 
     # hard wired unit options
     allowed_utypes = [


### PR DESCRIPTION
## Summary

Closes #244.

Wraps `_pkg_version("quantarhei")` in `quantarhei/core/managers.py` with a `try/except PackageNotFoundError` fallback so that `import quantarhei` works from a plain checkout without requiring `uv sync` or `pip install -e .` first.

Before — crashes with `PackageNotFoundError` if not installed:

```python
version = _pkg_version("quantarhei")
```

After — falls back gracefully:

```python
try:
    version = _pkg_version("quantarhei")
except _PackageNotFoundError:
    version = "unknown"
```

## Context

`__init__.py` already had this fallback pattern (added in #162) but `managers.py` was missed. The flat layout means Python can resolve `import quantarhei` to the source tree directly when run from the repo root — the only thing blocking it was this unguarded `_pkg_version` call.

See https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/ for the tradeoffs between flat and src layout — we are intentionally keeping the flat layout.

## Merge order

**Independent** — single commit on master, no overlap with any other open PR.

## Test plan

- [x] `uv run pytest tests/unit` → 160 passed
- [x] `PackageNotFoundError` fallback returns `"unknown"` when package name is not found
- [x] `Manager().version` returns the real version string when the package is installed