### PR TITLE
#277 fix: StateVector.norm() correct for complex state vectors

### DIFF
--- a/quantarhei/qm/hilbertspace/statevector.py
+++ b/quantarhei/qm/hilbertspace/statevector.py
@@ -78,7 +78,8 @@ class StateVector(BasisManaged):
 
     def norm(self) -> Any:
         """Returns the norm of the StateVector"""
-        return numpy.sqrt(numpy.dot(numpy.conj(self.data), self.data)).real
+        # vdot conjugates its first argument: <data|data> = ||data||^2
+        return numpy.sqrt(numpy.vdot(self.data, self.data).real)
 
     def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
         """Transformation of the operator by a given matrix

--- a/quantarhei/qm/hilbertspace/statevector.py
+++ b/quantarhei/qm/hilbertspace/statevector.py
@@ -78,7 +78,7 @@ class StateVector(BasisManaged):
 
     def norm(self) -> Any:
         """Returns the norm of the StateVector"""
-        return numpy.sqrt(numpy.dot(self.data, self.data))
+        return numpy.sqrt(numpy.dot(numpy.conj(self.data), self.data)).real
 
     def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
         """Transformation of the operator by a given matrix

--- a/tests/unit/qm/hilbertspace/statevector_test.py
+++ b/tests/unit/qm/hilbertspace/statevector_test.py
@@ -88,3 +88,14 @@ class TestStateVector(unittest.TestCase):
         psi = StateVector(data=vec)
 
         self.assertAlmostEqual(psi.norm(), numpy.sqrt(13.0))
+
+    def test_norm_complex(self):
+        """Test StateVector norm for complex state vectors"""
+        import numpy
+
+        # |psi> = (1+i)|0> + (1-i)|1>  =>  norm = sqrt(2 + 2) = 2
+        vec = numpy.array([1 + 1j, 1 - 1j])
+        psi = StateVector(data=vec)
+
+        self.assertAlmostEqual(psi.norm(), 2.0)
+        self.assertIsInstance(psi.norm(), float)


### PR DESCRIPTION
## Summary

`StateVector.norm()` was computing `sqrt(dot(data, data))`, which gives wrong results for complex vectors — the dot product of a complex vector with itself is not the squared norm (it can be complex).

Fix: use `numpy.vdot(data, data).real`. `numpy.vdot` conjugates its first argument, implementing the inner product `⟨data|data⟩ = ||data||²` correctly. This matches the Dirac bra-ket convention and the Fortran convention.

## Example

```python
# |psi> = (1+i)|0> + (1-i)|1>  =>  correct norm = 2
vec = numpy.array([1+1j, 1-1j])
psi = StateVector(data=vec)
# before: returns wrong result for complex vectors
# after:  returns 2.0 — correct float
```

## Changes

- `quantarhei/qm/hilbertspace/statevector.py`: fix `norm()` to use `numpy.vdot`
- `tests/unit/qm/hilbertspace/statevector_test.py`: add `test_norm_complex`

## Related issues
Closes #277