### PR TITLE
#176 dx: standardize subpackage __init__.py files

### DIFF
--- a/quantarhei/core/__init__.py
+++ b/quantarhei/core/__init__.py
@@ -1,3 +1,9 @@
 from ..utils.types import BasisManagedRealArray as BasisManagedRealArray
 from .managers import BasisManaged as BasisManaged
 from .managers import UnitsManaged as UnitsManaged
+
+__all__ = [
+    "BasisManaged",
+    "BasisManagedRealArray",
+    "UnitsManaged",
+]

--- a/quantarhei/core/conf/__init__.py
+++ b/quantarhei/core/conf/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/functions/__init__.py
+++ b/quantarhei/functions/__init__.py
@@ -1,2 +1,7 @@
 from .dfce1 import Cos as Cos
 from .dfce1 import Tukey as Tukey
+
+__all__ = [
+    "Cos",
+    "Tukey",
+]

--- a/quantarhei/implementations/__init__.py
+++ b/quantarhei/implementations/__init__.py
@@ -1,1 +1,3 @@
-
+# Internal package — optimised implementations (C, Cython, QuTiP) plugged in by
+# the Manager at runtime. Not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/implementations/aceto/__init__.py
+++ b/quantarhei/implementations/aceto/__init__.py
@@ -1,1 +1,3 @@
-
+# Internal package — optimised implementations (C, Cython, QuTiP) plugged in by
+# the Manager at runtime. Not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/implementations/cython/__init__.py
+++ b/quantarhei/implementations/cython/__init__.py
@@ -1,1 +1,3 @@
-
+# Internal package — optimised implementations (C, Cython, QuTiP) plugged in by
+# the Manager at runtime. Not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/implementations/python/__init__.py
+++ b/quantarhei/implementations/python/__init__.py
@@ -1,1 +1,3 @@
-
+# Internal package — optimised implementations (C, Cython, QuTiP) plugged in by
+# the Manager at runtime. Not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/implementations/python/accelerated/__init__.py
+++ b/quantarhei/implementations/python/accelerated/__init__.py
@@ -1,1 +1,3 @@
-
+# Internal package — optimised implementations (C, Cython, QuTiP) plugged in by
+# the Manager at runtime. Not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/implementations/python/parallel/__init__.py
+++ b/quantarhei/implementations/python/parallel/__init__.py
@@ -1,1 +1,3 @@
-
+# Internal package — optimised implementations (C, Cython, QuTiP) plugged in by
+# the Manager at runtime. Not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/implementations/qutip/__init__.py
+++ b/quantarhei/implementations/qutip/__init__.py
@@ -1,0 +1,3 @@
+# Internal package — optimised implementations (C, Cython, QuTiP) plugged in by
+# the Manager at runtime. Not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/models/spectral_densities/__init__.py
+++ b/quantarhei/models/spectral_densities/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/qm/corfunctions/__init__.py
+++ b/quantarhei/qm/corfunctions/__init__.py
@@ -4,3 +4,12 @@ from .correlationfunctions import LineshapeFunction as LineshapeFunction
 from .functionstorage import FastFunctionStorage as FastFunctionStorage
 from .functionstorage import FunctionStorage as FunctionStorage
 from .spectraldensities import SpectralDensity as SpectralDensity
+
+__all__ = [
+    "CorrelationFunction",
+    "CorrelationFunctionMatrix",
+    "FastFunctionStorage",
+    "FunctionStorage",
+    "LineshapeFunction",
+    "SpectralDensity",
+]

--- a/quantarhei/qm/hilbertspace/__init__.py
+++ b/quantarhei/qm/hilbertspace/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/qm/liouvillespace/__init__.py
+++ b/quantarhei/qm/liouvillespace/__init__.py
@@ -19,3 +19,6 @@
 
 # .. inheritance-diagram:: quantarhei.qm.liouvillespace.evolutionsuperoperator
 #   :parts: 1
+
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/qm/liouvillespace/integrodiff/__init__.py
+++ b/quantarhei/qm/liouvillespace/integrodiff/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/qm/liouvillespace/rates/__init__.py
+++ b/quantarhei/qm/liouvillespace/rates/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/qm/oscillators/__init__.py
+++ b/quantarhei/qm/oscillators/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/qm/propagators/__init__.py
+++ b/quantarhei/qm/propagators/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/scripts/__init__.py
+++ b/quantarhei/scripts/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/scripts/codelets/__init__.py
+++ b/quantarhei/scripts/codelets/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/spectroscopy/__init__.py
+++ b/quantarhei/spectroscopy/__init__.py
@@ -58,3 +58,25 @@ from .pathwayanalyzer import (
 from .pathwayanalyzer import (
     select_type as select_type,
 )
+
+__all__ = [
+    "X",
+    "Y",
+    "Z",
+    "get_TwoDSpectrumContainer_from_saved_pathways",
+    "get_TwoDSpectrum_from_pathways",
+    "get_TwoDSpectrum_from_saved_pathways",
+    "get_evolution_from_saved_pathways",
+    "get_prefactors_from_saved_pathways",
+    "load_pathways_by_t2",
+    "look_for_pathways",
+    "max_amplitude",
+    "order_by_amplitude",
+    "save_pathways_by_t2",
+    "select_amplitude_GT",
+    "select_by_states",
+    "select_frequency_window",
+    "select_omega2",
+    "select_sign",
+    "select_type",
+]

--- a/quantarhei/symbolic/__init__.py
+++ b/quantarhei/symbolic/__init__.py
@@ -1,1 +1,7 @@
+from .cumulant import GFInitiator as GFInitiator
+from .cumulant import evaluate_cumulant as evaluate_cumulant
 
+__all__ = [
+    "GFInitiator",
+    "evaluate_cumulant",
+]

--- a/quantarhei/testing/__init__.py
+++ b/quantarhei/testing/__init__.py
@@ -1,0 +1,2 @@
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/utils/__init__.py
+++ b/quantarhei/utils/__init__.py
@@ -14,3 +14,13 @@ from .types import array_property as array_property
 from .types import check_numpy_array as check_numpy_array
 from .types import derived_type as derived_type
 from .vectors import normalize2 as normalize2
+
+__all__ = [
+    "Bool",
+    "Float",
+    "Integer",
+    "array_property",
+    "check_numpy_array",
+    "derived_type",
+    "normalize2",
+]

--- a/quantarhei/wizard/__init__.py
+++ b/quantarhei/wizard/__init__.py
@@ -1,0 +1,2 @@
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/wizard/benchmarks/__init__.py
+++ b/quantarhei/wizard/benchmarks/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/wizard/input/__init__.py
+++ b/quantarhei/wizard/input/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/wizard/notebooks/__init__.py
+++ b/quantarhei/wizard/notebooks/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/wizard/simulations/__init__.py
+++ b/quantarhei/wizard/simulations/__init__.py
@@ -1,2 +1,7 @@
 from .excitondynamics import ExcitonDynamics as ExcitonDynamics
 from .twodpath import TwoDPathways as TwoDPathways
+
+__all__ = [
+    "ExcitonDynamics",
+    "TwoDPathways",
+]

--- a/quantarhei/wizard/templates/__init__.py
+++ b/quantarhei/wizard/templates/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr

--- a/quantarhei/wizard/tutorials/__init__.py
+++ b/quantarhei/wizard/tutorials/__init__.py
@@ -1,1 +1,2 @@
-
+# Internal implementation package — not part of the public API.
+# Import from quantarhei directly: import quantarhei as qr


### PR DESCRIPTION
## Summary

Establishes a consistent convention for all 31 subpackage `__init__.py` files.

**Rule 1 — Public subpackages get `__all__`** (7 files updated):

| Package | Names exported |
|---|---|
| `core/` | 3 |
| `functions/` | 2 |
| `qm/corfunctions/` | 6 |
| `spectroscopy/` | 19 |
| `symbolic/` | 2 (was empty — now re-exports `evaluate_cumulant`, `GFInitiator`) |
| `utils/` | 7 |
| `wizard/simulations/` | 2 |

**Rule 2 — Internal packages get a clarifying comment** (24 files updated):

All empty `__init__.py` files that were previously silent now state explicitly:
```python
# Internal implementation package — not part of the public API.
# Import from quantarhei directly: import quantarhei as qr
```

`implementations/` and its sub-dirs get a slightly more informative variant explaining the runtime-plugin role.

`qm/liouvillespace/` keeps its existing Sphinx inheritance-diagram docstring and gets the comment appended.

## Related issues
Closes #176