### PR TITLE
#203 fix: cu_energy() wrong conversion factor when current units != 1/fs

### DIFF
--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -567,7 +567,7 @@ class Manager(metaclass=Singleton):
 
             cu = self.current_units["energy"]
             if cu != "1/fs":
-                y = conversion_facs_energy[units]
+                y = conversion_facs_energy[cu]
                 return i_val / y
 
             return i_val

--- a/tests/unit/core/test_energy_units.py
+++ b/tests/unit/core/test_energy_units.py
@@ -10,8 +10,8 @@ import unittest
 *******************************************************************************
 """
 
-from quantarhei import energy_units, set_current_units
-from quantarhei.core.units import cm2int
+from quantarhei import Manager, energy_units, set_current_units
+from quantarhei.core.units import cm2int, conversion_facs_energy
 
 # let us reuse a class from previous test
 from .test_UnitsManaged import UnitsManagedObject
@@ -93,3 +93,24 @@ class TestEnergyUnits(unittest.TestCase):
 
         self.assertEqual(self.u.get_value(), val2 * cm2int)
         self.assertEqual(w.get_value(), val1 * cm2int)
+
+    def test_cu_energy_roundtrip(self):
+        """cu_energy() must convert input units -> current units correctly.
+
+        100 1/cm expressed in eV, then cu_energy(..., units="eV") with
+        current_units="1/cm" must return 100.0.  Before the fix this
+        returned the original eV value unchanged (identity bug).
+        """
+        m = Manager()
+        cm_fac = conversion_facs_energy["1/cm"]
+        eV_fac = conversion_facs_energy["eV"]
+
+        # 100 1/cm in internal units, then expressed as eV
+        val_eV = (100.0 * cm_fac) / eV_fac
+
+        set_current_units({"energy": "1/cm"})
+        try:
+            result = m.cu_energy(val_eV, units="eV")
+            self.assertAlmostEqual(result, 100.0, places=8)
+        finally:
+            set_current_units()


### PR DESCRIPTION
## Summary

`Manager.cu_energy()` was using `conversion_facs_energy[units]` (the input-unit factor) on line 570 instead of `conversion_facs_energy[cu]` (the current-unit factor). This caused the method to divide `i_val` by the same factor it had just multiplied by, returning the original input value unchanged whenever `current_units["energy"] != "1/fs"`.

**Before:**
```python
y = conversion_facs_energy[units]  # wrong: same as x, cancels out
return i_val / y                   # = val (identity, silent wrong result)
```

**After:**
```python
y = conversion_facs_energy[cu]     # correct: factor for current units
return i_val / y
```

## Example

```python
# 100 1/cm expressed in eV — cu_energy should give back 100.0 in 1/cm
set_current_units({"energy": "1/cm"})
m.cu_energy(val_eV, units="eV")
# before fix: returns val_eV (unchanged)
# after fix:  returns 100.0
```

## Changes

- `quantarhei/core/managers.py`: one-line fix on the `cu_energy` branch
- `tests/unit/core/test_energy_units.py`: add `test_cu_energy_roundtrip`

## Related issues
Closes #203