### PR TITLE
#204 fix: Operator.__add__ and RelaxationTensor.__add__ must not mutate left operand

### DIFF
--- a/quantarhei/qm/hilbertspace/operators.py
+++ b/quantarhei/qm/hilbertspace/operators.py
@@ -71,9 +71,8 @@ class Operator(MatrixData, BasisManaged, Saveable):
                 self.dim = dim
 
     def __add__(self, other: Operator) -> Operator:
-        """Addition of two operators. Returns self."""
-        self.data += other.data
-        return self
+        """Addition of two operators. Returns a new Operator."""
+        return Operator(data=self.data + other.data)
 
     def apply(self, obj: Any) -> Any:
         """Apply the operator to vector or operator on the right"""

--- a/quantarhei/qm/liouvillespace/relaxationtensor.py
+++ b/quantarhei/qm/liouvillespace/relaxationtensor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from typing import Any
 
 import numpy
@@ -307,11 +308,13 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
         return self.__mult__(scalar)
 
     def __add__(self, other: RelaxationTensor) -> RelaxationTensor:
-        self._data += other._data
-        return self
+        out = copy.copy(self)
+        out._data = self._data + other._data
+        return out
 
     def __iadd__(self, other: RelaxationTensor) -> RelaxationTensor:
-        return self.__add__(other)
+        self._data += other._data
+        return self
 
     def _rhs(self, rho: Any) -> Any:
         """Applies the tensor to a given matrix"""

--- a/tests/unit/qm/hilbertspace/test_operators.py
+++ b/tests/unit/qm/hilbertspace/test_operators.py
@@ -13,7 +13,7 @@ import numpy
 """
 
 from quantarhei import REAL, Molecule
-from quantarhei.qm import ReducedDensityMatrix
+from quantarhei.qm import Operator, ReducedDensityMatrix
 
 
 class TestReducedDensityMatrix(unittest.TestCase):
@@ -95,3 +95,36 @@ class TestReducedDensityMatrix(unittest.TestCase):
             rdm2 = rdm2.load(fid)  # , test=True)
 
         self.assertTrue(numpy.allclose(rdm2.data, rdm.data))
+
+
+class TestOperatorAdd(unittest.TestCase):
+    """Tests that Operator.__add__ does not mutate the left operand."""
+
+    def test_add_returns_new_object(self):
+        """op1 + op2 must not modify op1."""
+        op1 = Operator(data=numpy.array([[1.0, 0.0], [0.0, 2.0]]))
+        op2 = Operator(data=numpy.array([[3.0, 0.0], [0.0, 4.0]]))
+        original = op1.data.copy()
+
+        result = op1 + op2
+
+        # op1 must be unchanged
+        self.assertTrue(numpy.allclose(op1.data, original))
+        # result must equal the sum
+        self.assertTrue(numpy.allclose(result.data, original + op2.data))
+        # result must be a distinct object
+        self.assertIsNot(result, op1)
+
+    def test_add_chained(self):
+        """op1 + op2 + op3 must leave op1 and op2 unchanged."""
+        op1 = Operator(data=numpy.eye(2))
+        op2 = Operator(data=2.0 * numpy.eye(2))
+        op3 = Operator(data=3.0 * numpy.eye(2))
+        d1 = op1.data.copy()
+        d2 = op2.data.copy()
+
+        result = op1 + op2 + op3
+
+        self.assertTrue(numpy.allclose(op1.data, d1))
+        self.assertTrue(numpy.allclose(op2.data, d2))
+        self.assertTrue(numpy.allclose(result.data, 6.0 * numpy.eye(2)))

--- a/tests/unit/qm/liouvillespace/test_redfield.py
+++ b/tests/unit/qm/liouvillespace/test_redfield.py
@@ -147,3 +147,48 @@ class TestRedfield(unittest.TestCase):
         numpy.testing.assert_allclose(
             rhot1_e.data, rhot2_e.data, rtol=1.0e-5, atol=1.0e-12
         )
+
+
+class TestRelaxationTensorAdd(unittest.TestCase):
+    """Tests that RelaxationTensor.__add__ does not mutate the left operand."""
+
+    def setUp(self):
+        time = TimeAxis(0.0, 1000, 1.0)
+        with energy_units("1/cm"):
+            params = {
+                "ftype": "OverdampedBrownian",
+                "reorg": 30.0,
+                "T": 300.0,
+                "cortime": 100.0,
+            }
+            cf = CorrelationFunction(time, params)
+
+        cm = CorrelationFunctionMatrix(time, 2, 1)
+        cm.set_correlation_function(cf, [(0, 0), (1, 1)])
+
+        K = Operator(data=numpy.array([[1.0, 0.0], [0.0, 0.0]], dtype=REAL))
+        sbi = SystemBathInteraction([K, K], cm)
+
+        with energy_units("1/cm"):
+            H = Hamiltonian(data=[[0.0, 100.0], [100.0, 0.0]])
+
+        self.RT1 = RedfieldRelaxationTensor(H, sbi)
+        self.RT2 = RedfieldRelaxationTensor(H, sbi)
+
+    def test_add_does_not_mutate_left_operand(self):
+        """RT1 + RT2 must not modify RT1._data."""
+        original = self.RT1._data.copy()
+
+        result = self.RT1 + self.RT2
+
+        numpy.testing.assert_array_equal(self.RT1._data, original)
+        numpy.testing.assert_allclose(result._data, original + self.RT2._data)
+        self.assertIsNot(result, self.RT1)
+
+    def test_iadd_mutates_in_place(self):
+        """RT1 += RT2 must mutate RT1 (correct in-place semantics)."""
+        original = self.RT1._data.copy()
+
+        self.RT1 += self.RT2
+
+        numpy.testing.assert_allclose(self.RT1._data, original + self.RT2._data)


### PR DESCRIPTION
## Summary

Both `Operator.__add__` and `RelaxationTensor.__add__` were modifying `self` in-place and returning it, violating standard Python operator semantics (`a + b` must leave `a` unchanged).

**Before:**
```python
# Operator
def __add__(self, other):
    self.data += other.data  # mutates self!
    return self

# RelaxationTensor
def __add__(self, other):
    self._data += other._data  # mutates self!
    return self
```

**After:**
```python
# Operator
def __add__(self, other):
    return Operator(data=self.data + other.data)

# RelaxationTensor
def __add__(self, other):
    out = copy.copy(self)
    out._data = self._data + other._data
    return out

def __iadd__(self, other):  # unchanged — in-place mutation is correct here
    self._data += other._data
    return self
```

## Changes

- `quantarhei/qm/hilbertspace/operators.py`: fix `Operator.__add__`
- `quantarhei/qm/liouvillespace/relaxationtensor.py`: fix `RelaxationTensor.__add__`, move `import copy` to top of file, fix `__iadd__` to be the sole in-place path
- `tests/unit/qm/hilbertspace/test_operators.py`: add `TestOperatorAdd`
- `tests/unit/qm/liouvillespace/test_redfield.py`: add `TestRelaxationTensorAdd`

## Related issues
Closes #204