### PR TITLE
#205 fix: context manager __exit__ methods leave Manager in inconsistent state on exception

### DIFF
--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -926,10 +926,12 @@ class energy_units(units_context_manager):
         self.manager._in_eu_count += 1
 
     def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
-        self.manager.set_current_units("energy", self.units_backup)
-        self.manager._in_eu_count -= 1
-        if self.manager._in_eu_count == 0:
-            self.manager._in_energy_units_context = False
+        try:
+            self.manager.set_current_units("energy", self.units_backup)
+        finally:
+            self.manager._in_eu_count -= 1
+            if self.manager._in_eu_count == 0:
+                self.manager._in_energy_units_context = False
 
 
 class frequency_units(energy_units):
@@ -1011,43 +1013,44 @@ class eigenbasis_of(basis_context_manager):
         if self.manager.warn_about_basis_change:
             print("\nQr >>> Returning from basis context manager. Cleaning ...")
 
-        # This is the basis we are leaving
-        bb = self.manager.basis_stack.pop()
-        # this is the transformation we got here with
-        SS = self.manager.basis_transformations.pop()
-        # This is the new basis
-        bss = len(self.manager.basis_stack)
-        nb = self.manager.basis_stack[bss - 1]
+        try:
+            # This is the basis we are leaving
+            bb = self.manager.basis_stack.pop()
+            # this is the transformation we got here with
+            SS = self.manager.basis_transformations.pop()
+            # This is the new basis
+            bss = len(self.manager.basis_stack)
+            nb = self.manager.basis_stack[bss - 1]
 
-        # inverse of the transformation matrix
-        S1 = numpy.linalg.inv(SS)
+            # inverse of the transformation matrix
+            S1 = numpy.linalg.inv(SS)
 
-        # transform all registered objects
-        operators = self.manager.basis_registered[bb]
+            # transform all registered objects
+            operators = self.manager.basis_registered[bb]
 
-        if nb != 0:
-            # operators registered with the context above this one
-            ops_above = self.manager.basis_registered[nb]
-
-        for op in operators:
-            # the operator might have been set to protected mode
-            # inside the context
-            if not op.is_basis_protected:
-                op.transform(S1, inv=SS)
-            op.set_current_basis(nb)
-
-            # operators which appeared in this context and where not
-            # register in the one above are now registerd
             if nb != 0:
-                if op not in ops_above:
-                    self.manager.register_with_basis(nb, op)
+                # operators registered with the context above this one
+                ops_above = self.manager.basis_registered[nb]
 
-        self.manager.remove_current_basis_operator()
+            for op in operators:
+                # the operator might have been set to protected mode
+                # inside the context
+                if not op.is_basis_protected:
+                    op.transform(S1, inv=SS)
+                op.set_current_basis(nb)
 
-        del self.manager.basis_registered[bb]
+                # operators which appeared in this context and where not
+                # register in the one above are now registerd
+                if nb != 0:
+                    if op not in ops_above:
+                        self.manager.register_with_basis(nb, op)
 
-        if len(self.manager.basis_stack) == 1:
-            self.manager._in_eigenbasis_of_context = False
+            self.manager.remove_current_basis_operator()
+
+            del self.manager.basis_registered[bb]
+        finally:
+            if len(self.manager.basis_stack) == 1:
+                self.manager._in_eigenbasis_of_context = False
 
         if self.manager.warn_about_basis_change:
             print("\nQr >>> ... cleaning done")

--- a/tests/unit/core/test_eigenbasis_of.py
+++ b/tests/unit/core/test_eigenbasis_of.py
@@ -250,6 +250,19 @@ class TestEigenbasisOf(unittest.TestCase):
             self.assertTrue(numpy.allclose(A.data, A0))
             self.assertTrue(numpy.allclose(B.data, B0))
 
+    def test_eigenbasis_of_state_restored_after_exception(self):
+        """eigenbasis_of.__exit__ must clear _in_eigenbasis_of_context even if body raises"""
+        manager = Manager()
+
+        try:
+            with eigenbasis_of(self.H):
+                raise RuntimeError("body error")
+        except RuntimeError:
+            pass
+
+        self.assertFalse(manager._in_eigenbasis_of_context)
+        self.assertEqual(len(manager.basis_stack), 1)
+
 
 def generate(only=-1):
     N = 16

--- a/tests/unit/core/test_energy_units.py
+++ b/tests/unit/core/test_energy_units.py
@@ -114,3 +114,33 @@ class TestEnergyUnits(unittest.TestCase):
             self.assertAlmostEqual(result, 100.0, places=8)
         finally:
             set_current_units()
+
+    def test_energy_units_state_restored_after_exception(self):
+        """energy_units.__exit__ must restore Manager state even if body raises"""
+        manager = Manager()
+
+        try:
+            with energy_units("1/cm"):
+                raise RuntimeError("body error")
+        except RuntimeError:
+            pass
+
+        self.assertEqual(manager._in_eu_count, 0)
+        self.assertFalse(manager._in_energy_units_context)
+
+    def test_energy_units_nested_state_restored_after_exception(self):
+        """Nested energy_units: inner exception must not corrupt outer counter"""
+        manager = Manager()
+
+        with energy_units("1/cm"):
+            try:
+                with energy_units("eV"):
+                    raise RuntimeError("inner error")
+            except RuntimeError:
+                pass
+
+            self.assertEqual(manager._in_eu_count, 1)
+            self.assertTrue(manager._in_energy_units_context)
+
+        self.assertEqual(manager._in_eu_count, 0)
+        self.assertFalse(manager._in_energy_units_context)


### PR DESCRIPTION
## Summary

Fixes https://github.com/tmancal74/quantarhei/issues/205.

- `energy_units.__exit__`: wrapped `set_current_units()` call in `try/finally` so `_in_eu_count` and `_in_energy_units_context` are always decremented/cleared even if the setter raises
- `eigenbasis_of.__exit__`: wrapped the entire cleanup body in `try/finally` so `_in_eigenbasis_of_context` is always reset to `False`, preventing the Manager from getting stuck in "inside eigenbasis context" state after an exception

`length_units.__exit__` has no counter state to protect, so no change needed there.

## Test plan

- `test_energy_units_state_restored_after_exception`: raises inside `with energy_units(...)`, asserts `_in_eu_count == 0` and `_in_energy_units_context == False` afterwards
- `test_energy_units_nested_state_restored_after_exception`: inner context raises, outer counter must remain correct
- `test_eigenbasis_of_state_restored_after_exception`: raises inside `with eigenbasis_of(...)`, asserts `_in_eigenbasis_of_context == False` and `basis_stack` has depth 1 afterwards
- All 167 existing unit tests continue to pass