### PR TITLE
#206 fix: make Parcel.save() atomic using write-to-temp-then-rename

### DIFF
--- a/quantarhei/core/parcel.py
+++ b/quantarhei/core/parcel.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import tempfile
 from typing import IO, Any
 
 import dill as pickle
@@ -32,8 +34,15 @@ class Parcel:
 
         """
         if isinstance(filename, str):
-            with open(filename, "wb") as f:
-                pickle.dump(self, f)
+            dest_dir = os.path.dirname(os.path.abspath(filename))
+            tmp_fd, tmp_path = tempfile.mkstemp(dir=dest_dir)
+            try:
+                with os.fdopen(tmp_fd, "wb") as f:
+                    pickle.dump(self, f)
+                os.replace(tmp_path, filename)
+            except:
+                os.unlink(tmp_path)
+                raise
         else:
             pickle.dump(self, filename)
 

--- a/tests/unit/core/test_saveable.py
+++ b/tests/unit/core/test_saveable.py
@@ -465,3 +465,30 @@ class TestSaveable(unittest.TestCase):
             self.assertEqual(info["version"], Manager().version)
         else:
             self.assertEqual(info["qrversion"], Manager().version)
+
+    def test_parcel_save_is_atomic(self):
+        """Parcel.save() must write to a temp file then rename — no partial writes"""
+        import os
+        import tempfile
+
+        from quantarhei.core.parcel import Parcel, load_parcel
+
+        obj = TSaveable()
+        obj.set_a(42.0)
+        obj.set_str("atomic", "test")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            fpath = os.path.join(tmpdir, "test.qrp")
+
+            p = Parcel()
+            p.set_content(obj)
+            p.save(fpath)
+
+            # file must exist and be readable after save
+            loaded = load_parcel(fpath)
+            self.assertAlmostEqual(loaded.a, 42.0)
+            self.assertEqual(loaded.text, "atomic")
+
+            # no temp files left in the directory
+            leftover = [f for f in os.listdir(tmpdir) if f != "test.qrp"]
+            self.assertEqual(leftover, [])


### PR DESCRIPTION
## Summary

Fixes https://github.com/tmancal74/quantarhei/issues/206.

- `Parcel.save()` now uses `tempfile.mkstemp()` in the same directory as the destination, writes there, then calls `os.replace()` (atomic on POSIX, best-effort on Windows)
- On any exception the temp file is unlinked so no partial files accumulate
- The file-object path (`isinstance(filename, IO)`) is unchanged — no temp file needed there since writes to in-memory or caller-managed file objects are already caller-controlled

## Test plan

- `test_parcel_save_is_atomic`: saves a `Parcel` to a real file path, verifies the file round-trips correctly, and checks no temp files are left behind in the directory
- All 165 unit tests continue to pass