### PR TITLE
#213 feat: add units_state() inspector and warn on exception exit from units contexts

### DIFF
--- a/quantarhei/__init__.py
+++ b/quantarhei/__init__.py
@@ -252,6 +252,9 @@ from .core.managers import (
 from .core.managers import (
     set_current_units as set_current_units,
 )
+from .core.managers import (
+    units_state as units_state,
+)
 
 #
 # Parallelization

--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -926,10 +926,12 @@ class energy_units(units_context_manager):
         self.manager._in_eu_count += 1
 
     def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
-        self.manager.set_current_units("energy", self.units_backup)
-        self.manager._in_eu_count -= 1
-        if self.manager._in_eu_count == 0:
-            self.manager._in_energy_units_context = False
+        try:
+            self.manager.set_current_units("energy", self.units_backup)
+        finally:
+            self.manager._in_eu_count -= 1
+            if self.manager._in_eu_count == 0:
+                self.manager._in_energy_units_context = False
 
 
 class frequency_units(energy_units):
@@ -1011,43 +1013,44 @@ class eigenbasis_of(basis_context_manager):
         if self.manager.warn_about_basis_change:
             print("\nQr >>> Returning from basis context manager. Cleaning ...")
 
-        # This is the basis we are leaving
-        bb = self.manager.basis_stack.pop()
-        # this is the transformation we got here with
-        SS = self.manager.basis_transformations.pop()
-        # This is the new basis
-        bss = len(self.manager.basis_stack)
-        nb = self.manager.basis_stack[bss - 1]
+        try:
+            # This is the basis we are leaving
+            bb = self.manager.basis_stack.pop()
+            # this is the transformation we got here with
+            SS = self.manager.basis_transformations.pop()
+            # This is the new basis
+            bss = len(self.manager.basis_stack)
+            nb = self.manager.basis_stack[bss - 1]
 
-        # inverse of the transformation matrix
-        S1 = numpy.linalg.inv(SS)
+            # inverse of the transformation matrix
+            S1 = numpy.linalg.inv(SS)
 
-        # transform all registered objects
-        operators = self.manager.basis_registered[bb]
+            # transform all registered objects
+            operators = self.manager.basis_registered[bb]
 
-        if nb != 0:
-            # operators registered with the context above this one
-            ops_above = self.manager.basis_registered[nb]
-
-        for op in operators:
-            # the operator might have been set to protected mode
-            # inside the context
-            if not op.is_basis_protected:
-                op.transform(S1, inv=SS)
-            op.set_current_basis(nb)
-
-            # operators which appeared in this context and where not
-            # register in the one above are now registerd
             if nb != 0:
-                if op not in ops_above:
-                    self.manager.register_with_basis(nb, op)
+                # operators registered with the context above this one
+                ops_above = self.manager.basis_registered[nb]
 
-        self.manager.remove_current_basis_operator()
+            for op in operators:
+                # the operator might have been set to protected mode
+                # inside the context
+                if not op.is_basis_protected:
+                    op.transform(S1, inv=SS)
+                op.set_current_basis(nb)
 
-        del self.manager.basis_registered[bb]
+                # operators which appeared in this context and where not
+                # register in the one above are now registerd
+                if nb != 0:
+                    if op not in ops_above:
+                        self.manager.register_with_basis(nb, op)
 
-        if len(self.manager.basis_stack) == 1:
-            self.manager._in_eigenbasis_of_context = False
+            self.manager.remove_current_basis_operator()
+
+            del self.manager.basis_registered[bb]
+        finally:
+            if len(self.manager.basis_stack) == 1:
+                self.manager._in_eigenbasis_of_context = False
 
         if self.manager.warn_about_basis_change:
             print("\nQr >>> ... cleaning done")

--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -926,6 +926,13 @@ class energy_units(units_context_manager):
         self.manager._in_eu_count += 1
 
     def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+        if exc_val is not None and self.units != self.units_backup:
+            warnings.warn(
+                f"An exception exited a 'with energy_units(\"{self.units}\")' block. "
+                f"Unit state has been restored to '{self.units_backup}', but any "
+                f"intermediate results computed inside the block may be in unexpected units.",
+                stacklevel=2,
+            )
         try:
             self.manager.set_current_units("energy", self.units_backup)
         finally:
@@ -961,6 +968,13 @@ class length_units(units_context_manager):
         self.manager.set_current_units(self.utype, self.units)
 
     def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+        if exc_val is not None and self.units != self.units_backup:
+            warnings.warn(
+                f"An exception exited a 'with length_units(\"{self.units}\")' block. "
+                f"Unit state has been restored to '{self.units_backup}', but any "
+                f"intermediate results computed inside the block may be in unexpected units.",
+                stacklevel=2,
+            )
         self.manager.set_current_units("length", self.units_backup)
 
 
@@ -1080,3 +1094,28 @@ def set_current_units(units: dict[str, str] | None = None) -> None:
                 manager.set_current_units(utype, manager.internal_units[utype])
             else:
                 raise Exception(f"Unknown units type {utype}")
+
+
+def units_state() -> dict[str, str]:
+    """Returns a snapshot of the current global unit settings.
+
+    Useful for inspecting Manager state in notebooks or debugging
+    unexpected unit conversions.
+
+    Returns
+    -------
+    dict
+        Mapping of unit type to current unit string, e.g.
+        ``{'energy': '1/cm', 'frequency': '1/fs', 'length': 'A',
+        'temperature': 'Kelvin', 'dipolemoment': 'Debye'}``.
+
+    Examples
+    --------
+    >>> import quantarhei as qr
+    >>> state = qr.units_state()
+    >>> state['energy']
+    '1/fs'
+
+    """
+    manager = Manager()
+    return dict(manager.current_units)

--- a/tests/unit/core/test_eigenbasis_of.py
+++ b/tests/unit/core/test_eigenbasis_of.py
@@ -250,6 +250,19 @@ class TestEigenbasisOf(unittest.TestCase):
             self.assertTrue(numpy.allclose(A.data, A0))
             self.assertTrue(numpy.allclose(B.data, B0))
 
+    def test_eigenbasis_of_state_restored_after_exception(self):
+        """eigenbasis_of.__exit__ must clear _in_eigenbasis_of_context even if body raises"""
+        manager = Manager()
+
+        try:
+            with eigenbasis_of(self.H):
+                raise RuntimeError("body error")
+        except RuntimeError:
+            pass
+
+        self.assertFalse(manager._in_eigenbasis_of_context)
+        self.assertEqual(len(manager.basis_stack), 1)
+
 
 def generate(only=-1):
     N = 16

--- a/tests/unit/core/test_energy_units.py
+++ b/tests/unit/core/test_energy_units.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 """
 *******************************************************************************
@@ -10,7 +11,7 @@ import unittest
 *******************************************************************************
 """
 
-from quantarhei import Manager, energy_units, set_current_units
+from quantarhei import Manager, energy_units, set_current_units, units_state
 from quantarhei.core.units import cm2int, conversion_facs_energy
 
 # let us reuse a class from previous test
@@ -21,6 +22,8 @@ class TestEnergyUnits(unittest.TestCase):
     def setUp(self):
         # reusining class from previous test
         self.u = UnitsManagedObject()
+        # ensure units start at defaults regardless of test ordering
+        set_current_units()
 
     def test_using_different_units(self):
         """Testing that 'energy_units' context manager works"""
@@ -119,11 +122,13 @@ class TestEnergyUnits(unittest.TestCase):
         """energy_units.__exit__ must restore Manager state even if body raises"""
         manager = Manager()
 
-        try:
-            with energy_units("1/cm"):
-                raise RuntimeError("body error")
-        except RuntimeError:
-            pass
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            try:
+                with energy_units("1/cm"):
+                    raise RuntimeError("body error")
+            except RuntimeError:
+                pass
 
         self.assertEqual(manager._in_eu_count, 0)
         self.assertFalse(manager._in_energy_units_context)
@@ -133,14 +138,62 @@ class TestEnergyUnits(unittest.TestCase):
         manager = Manager()
 
         with energy_units("1/cm"):
-            try:
-                with energy_units("eV"):
-                    raise RuntimeError("inner error")
-            except RuntimeError:
-                pass
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                try:
+                    with energy_units("eV"):
+                        raise RuntimeError("inner error")
+                except RuntimeError:
+                    pass
 
             self.assertEqual(manager._in_eu_count, 1)
             self.assertTrue(manager._in_energy_units_context)
 
         self.assertEqual(manager._in_eu_count, 0)
         self.assertFalse(manager._in_energy_units_context)
+
+    def test_units_state_returns_current_units(self):
+        """units_state() returns the current global unit settings"""
+        state = units_state()
+        self.assertIsInstance(state, dict)
+        self.assertIn("energy", state)
+        self.assertIn("length", state)
+        self.assertIn("temperature", state)
+
+        with energy_units("1/cm"):
+            state_inside = units_state()
+            self.assertEqual(state_inside["energy"], "1/cm")
+
+        state_after = units_state()
+        self.assertEqual(state_after["energy"], "1/fs")
+
+    def test_units_state_is_a_copy(self):
+        """units_state() must return a copy, not a reference to Manager internals"""
+        state = units_state()
+        state["energy"] = "eV"
+        self.assertEqual(units_state()["energy"], "1/fs")
+
+    def test_energy_units_warns_on_exception_exit(self):
+        """energy_units.__exit__ emits a UserWarning when an exception exits the block"""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            try:
+                with energy_units("1/cm"):
+                    raise RuntimeError("body error")
+            except RuntimeError:
+                pass
+
+        unit_warns = [w for w in caught if issubclass(w.category, UserWarning)]
+        self.assertEqual(len(unit_warns), 1)
+        self.assertIn("energy_units", str(unit_warns[0].message))
+        self.assertIn("1/cm", str(unit_warns[0].message))
+
+    def test_energy_units_no_warn_on_clean_exit(self):
+        """energy_units.__exit__ must NOT warn when exiting cleanly"""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with energy_units("1/cm"):
+                pass
+
+        unit_warns = [w for w in caught if issubclass(w.category, UserWarning)]
+        self.assertEqual(len(unit_warns), 0)

--- a/tests/unit/core/test_energy_units.py
+++ b/tests/unit/core/test_energy_units.py
@@ -114,3 +114,33 @@ class TestEnergyUnits(unittest.TestCase):
             self.assertAlmostEqual(result, 100.0, places=8)
         finally:
             set_current_units()
+
+    def test_energy_units_state_restored_after_exception(self):
+        """energy_units.__exit__ must restore Manager state even if body raises"""
+        manager = Manager()
+
+        try:
+            with energy_units("1/cm"):
+                raise RuntimeError("body error")
+        except RuntimeError:
+            pass
+
+        self.assertEqual(manager._in_eu_count, 0)
+        self.assertFalse(manager._in_energy_units_context)
+
+    def test_energy_units_nested_state_restored_after_exception(self):
+        """Nested energy_units: inner exception must not corrupt outer counter"""
+        manager = Manager()
+
+        with energy_units("1/cm"):
+            try:
+                with energy_units("eV"):
+                    raise RuntimeError("inner error")
+            except RuntimeError:
+                pass
+
+            self.assertEqual(manager._in_eu_count, 1)
+            self.assertTrue(manager._in_energy_units_context)
+
+        self.assertEqual(manager._in_eu_count, 0)
+        self.assertFalse(manager._in_energy_units_context)


### PR DESCRIPTION
## Summary

Fixes https://github.com/tmancal74/quantarhei/issues/213.

- **`qr.units_state()`** — new public function that returns a copy of the current global unit settings as a `dict[str, str]` (e.g. `{'energy': '1/cm', 'frequency': '1/fs', ...}`). Useful for inspecting Manager state in Jupyter notebooks without reading internal attributes.

- **`energy_units.__exit__` warning** — emits a `UserWarning` when an exception exits a `with energy_units(...)` block while non-default units were active, so users are alerted that intermediate results inside the block may be in unexpected units.

- **`length_units.__exit__` warning** — same pattern for length units.

The warning fires only on exception exit (`exc_val is not None`) and only when the units inside the block differed from the backup (i.e. actually changed). Clean exits produce no warning.

## Test plan

- `test_units_state_returns_current_units`: verifies the dict keys are present and that the value changes correctly inside/outside `energy_units`
- `test_units_state_is_a_copy`: mutating the returned dict does not affect Manager state
- `test_energy_units_warns_on_exception_exit`: exception inside block produces exactly one `UserWarning` containing `"energy_units"` and the unit name
- `test_energy_units_no_warn_on_clean_exit`: clean exit produces no warnings
- All 168 unit tests pass