### PR TITLE
#281 perf: replace O(dim⁴) loops in Liouvillian.__init__ with numpy.kron

### DIFF
--- a/quantarhei/qm/liouvillespace/liouvillian.py
+++ b/quantarhei/qm/liouvillespace/liouvillian.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..hilbertspace.operators import UnityOperator
+import numpy
+
 from .superoperator import SuperOperator
 
 
@@ -43,12 +44,6 @@ class Liouvillian(SuperOperator):
     def __init__(self, ham: Any) -> None:
         super().__init__(dim=ham.dim)
         dim = ham.dim
-        delta = UnityOperator(dim=dim)
-        for k_i in range(dim):
-            for k_j in range(dim):
-                for k_k in range(dim):
-                    for k_l in range(dim):
-                        self.data[k_i, k_j, k_k, k_l] = (
-                            ham.data[k_i, k_k] * delta.data[k_j, k_l]
-                            - delta.data[k_i, k_k] * ham.data[k_l, k_j]
-                        )
+        H = ham.data
+        I = numpy.eye(dim)
+        self.data = (numpy.kron(H, I) - numpy.kron(I, H.T)).reshape(dim, dim, dim, dim)

--- a/tests/unit/qm/liouvillespace/test_liouvillian.py
+++ b/tests/unit/qm/liouvillespace/test_liouvillian.py
@@ -1,0 +1,58 @@
+import unittest
+
+import numpy
+
+from quantarhei import Hamiltonian
+from quantarhei.qm.hilbertspace.operators import DensityMatrix
+from quantarhei.qm.liouvillespace.liouvillian import Liouvillian
+
+
+class TestLiouvillian(unittest.TestCase):
+    """Tests for the Liouvillian superoperator"""
+
+    def setUp(self):
+        self.H2 = Hamiltonian(data=[[0.0, 1.0], [1.0, 0.2]])
+        self.H3 = Hamiltonian(data=[[0.0, 1.0, 0.5], [1.0, 0.2, 0.3], [0.5, 0.3, 0.4]])
+
+    def test_liouvillian_matches_explicit_commutator_2x2(self):
+        """Liouvillian applied to rho equals [H, rho] for a 2x2 system"""
+        H = self.H2
+        rho = DensityMatrix(data=[[0.9, 0.05], [0.05, 0.1]])
+
+        Li = Liouvillian(H)
+        result = Li.apply(rho)
+
+        expected = numpy.dot(H.data, rho.data) - numpy.dot(rho.data, H.data)
+        numpy.testing.assert_allclose(result.data, expected, atol=1e-12)
+
+    def test_liouvillian_matches_explicit_commutator_3x3(self):
+        """Liouvillian applied to rho equals [H, rho] for a 3x3 system"""
+        H = self.H3
+        rho = DensityMatrix(
+            data=[[0.5, 0.1, 0.05], [0.1, 0.3, 0.02], [0.05, 0.02, 0.2]]
+        )
+
+        Li = Liouvillian(H)
+        result = Li.apply(rho)
+
+        expected = numpy.dot(H.data, rho.data) - numpy.dot(rho.data, H.data)
+        numpy.testing.assert_allclose(result.data, expected, atol=1e-12)
+
+    def test_liouvillian_tensor_shape(self):
+        """Liouvillian data must be (dim, dim, dim, dim)"""
+        for dim in (2, 3, 5):
+            data = numpy.diag(numpy.arange(dim, dtype=float))
+            H = Hamiltonian(data=data)
+            Li = Liouvillian(H)
+            self.assertEqual(Li.data.shape, (dim, dim, dim, dim))
+
+    def test_liouvillian_diagonal_hamiltonian_gives_zero_populations(self):
+        """[H, rho] leaves diagonal of rho unchanged when H is diagonal"""
+        H = Hamiltonian(data=numpy.diag([0.0, 1.0, 2.0]))
+        rho_data = numpy.diag([0.5, 0.3, 0.2]).astype(complex)
+        rho = DensityMatrix(data=rho_data)
+
+        Li = Liouvillian(H)
+        result = Li.apply(rho)
+
+        numpy.testing.assert_allclose(numpy.diag(result.data), 0.0, atol=1e-12)


### PR DESCRIPTION
## Summary

Fixes https://github.com/tmancal74/quantarhei/issues/281.

`Liouvillian.__init__` built the commutator superoperator `L[i,j,k,l]` using four nested Python loops — 6.25 million iterations for dim=50. The same computation is exact and reducible to two `numpy.kron` calls:

```python
# Before — O(dim⁴) Python loops
delta = UnityOperator(dim=dim)
for k_i in range(dim):
    for k_j in range(dim):
        for k_k in range(dim):
            for k_l in range(dim):
                self.data[k_i, k_j, k_k, k_l] = (
                    ham.data[k_i, k_k] * delta.data[k_j, k_l]
                    - delta.data[k_i, k_k] * ham.data[k_l, k_j]
                )

# After — vectorised O(dim²)
H = ham.data
I = numpy.eye(dim)
self.data = (numpy.kron(H, I) - numpy.kron(I, H.T)).reshape(dim, dim, dim, dim)
```

The equivalence follows from the Kronecker product identity:
`(kron(H, I))[i·d+j, k·d+l] = H[i,k]·δ[j,l]` and
`(kron(I, H.T))[i·d+j, k·d+l] = δ[i,k]·H[l,j]`

Also removes the now-unused `UnityOperator` import.

## Test plan

New `tests/unit/qm/liouvillespace/test_liouvillian.py`:
- `test_liouvillian_matches_explicit_commutator_2x2`: verifies `Li.apply(rho) == [H, rho]` for 2×2
- `test_liouvillian_matches_explicit_commutator_3x3`: same for 3×3
- `test_liouvillian_tensor_shape`: data shape is `(dim, dim, dim, dim)` for dim 2, 3, 5
- `test_liouvillian_diagonal_hamiltonian_gives_zero_populations`: diagonal `H` leaves populations invariant
- All 168 unit tests pass