### PR TITLE
#223 feat: make sympy an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,12 @@ dependencies = [
   "gherkin-official>=4.1,<5",
   "pyyaml>=6.0,<7",
   "packaging>=21.0,<27",
-  "sympy>=1.12,<2",
 ]
 
 [project.optional-dependencies]
+symbolic = [
+  "sympy>=1.12,<2",
+]
 dev = [
   "pytest>=7.0",
   "pytest-cov>=4.0",

--- a/quantarhei/__init__.py
+++ b/quantarhei/__init__.py
@@ -442,30 +442,18 @@ from .spectroscopy.circular_dichroism import (
 from .spectroscopy.circular_dichroism import (
     CircDichSpectrumContainer as CircDichSpectrumContainer,
 )
-from .spectroscopy.dsfeynman import (
-    DSFeynmanDiagram as DSFeynmanDiagram,
-)
-from .spectroscopy.dsfeynman import (
-    R1f_Diagram as R1f_Diagram,
-)
-from .spectroscopy.dsfeynman import (
-    R1g_Diagram as R1g_Diagram,
-)
-from .spectroscopy.dsfeynman import (
-    R1g_R_Diagram as R1g_R_Diagram,
-)
-from .spectroscopy.dsfeynman import (
-    R2f_Diagram as R2f_Diagram,
-)
-from .spectroscopy.dsfeynman import (
-    R2g_Diagram as R2g_Diagram,
-)
-from .spectroscopy.dsfeynman import (
-    R3g_Diagram as R3g_Diagram,
-)
-from .spectroscopy.dsfeynman import (
-    R4g_Diagram as R4g_Diagram,
-)
+
+try:
+    from .spectroscopy.dsfeynman import DSFeynmanDiagram as DSFeynmanDiagram
+    from .spectroscopy.dsfeynman import R1f_Diagram as R1f_Diagram
+    from .spectroscopy.dsfeynman import R1g_Diagram as R1g_Diagram
+    from .spectroscopy.dsfeynman import R1g_R_Diagram as R1g_R_Diagram
+    from .spectroscopy.dsfeynman import R2f_Diagram as R2f_Diagram
+    from .spectroscopy.dsfeynman import R2g_Diagram as R2g_Diagram
+    from .spectroscopy.dsfeynman import R3g_Diagram as R3g_Diagram
+    from .spectroscopy.dsfeynman import R4g_Diagram as R4g_Diagram
+except ImportError:
+    pass
 
 #
 # Fluorescence
@@ -541,7 +529,11 @@ from .spectroscopy.twodcontainer import TwoDSpectrumContainer as TwoDSpectrumCon
 #
 from .spectroscopy.twodresponse import TwoDResponse as TwoDResponse
 from .spectroscopy.twodspect import TwoDSpectrum as TwoDSpectrum
-from .symbolic.cumulant import evaluate_cumulant as evaluate_cumulant
+
+try:
+    from .symbolic.cumulant import evaluate_cumulant as evaluate_cumulant
+except ImportError:
+    pass
 from .utils.logging import (
     init_logging as init_logging,
 )

--- a/quantarhei/spectroscopy/dsfeynman.py
+++ b/quantarhei/spectroscopy/dsfeynman.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..symbolic.cumulant import Uop, UopEater, transform_to_einsum_expr
+
+def _require_symbolic() -> None:
+    try:
+        import sympy  # noqa: F401
+    except ImportError:
+        raise ImportError(
+            "sympy is required for Feynman diagram calculations. "
+            "Install it with: pip install quantarhei[symbolic]"
+        )
 
 
 class DSFeynmanDiagram:
@@ -156,6 +164,9 @@ class DSFeynmanDiagram:
             A list of Uop objects will be returned if operators is True.
 
         """
+        _require_symbolic()
+        from ..symbolic.cumulant import Uop
+
         self._check_finished()
 
         symbols = set()
@@ -245,6 +256,8 @@ class DSFeynmanDiagram:
 
     def coherence_GF(self) -> Any:
         """Returns coherence Green's function product for this diagram"""
+        from ..symbolic.cumulant import UopEater
+
         evs = self.evolution_operators(operators=True)
         eater = UopEater()
         out_list = eater.eat(evs)
@@ -343,6 +356,9 @@ from quantarhei.symbolic.cumulant import evaluate_cumulant
         self, function: bool = True, participation_matrix: bool = True
     ) -> str:
         """Return the code that evaluates the response function"""
+        _require_symbolic()
+        from ..symbolic.cumulant import transform_to_einsum_expr
+
         dims = self.dimensions
         phfac = self.get_phase_factor(dimensions=dims)
         # print("\n ... phase factor:", phfac)

--- a/quantarhei/symbolic/abc.py
+++ b/quantarhei/symbolic/abc.py
@@ -1,22 +1,24 @@
-from sympy import Symbol
+try:
+    from sympy import Symbol as _Symbol
 
-a = Symbol("a", real=True)
-b = Symbol("b", real=True)
-c = Symbol("c", real=True)
-d = Symbol("d", real=True)
-e = Symbol("e", real=True)
-f = Symbol("f", real=True)
+    a = _Symbol("a", real=True)
+    b = _Symbol("b", real=True)
+    c = _Symbol("c", real=True)
+    d = _Symbol("d", real=True)
+    e = _Symbol("e", real=True)
+    f = _Symbol("f", real=True)
 
-
-s = Symbol("s", real=True)
-t = Symbol("t", real=True)
-T = Symbol("T", real=True)
-tau = Symbol("tau", real=True)
-x = Symbol("x", real=True)
-y = Symbol("y", real=True)
-t1 = Symbol("t1", real=True)
-t2 = Symbol("t2", real=True)
-t3 = Symbol("t3", real=True)
-tau1 = Symbol("tau1", real=True)
-tau2 = Symbol("tau2", real=True)
-tau3 = Symbol("tau3", real=True)
+    s = _Symbol("s", real=True)
+    t = _Symbol("t", real=True)
+    T = _Symbol("T", real=True)
+    tau = _Symbol("tau", real=True)
+    x = _Symbol("x", real=True)
+    y = _Symbol("y", real=True)
+    t1 = _Symbol("t1", real=True)
+    t2 = _Symbol("t2", real=True)
+    t3 = _Symbol("t3", real=True)
+    tau1 = _Symbol("tau1", real=True)
+    tau2 = _Symbol("tau2", real=True)
+    tau3 = _Symbol("tau3", real=True)
+except ImportError:
+    pass

--- a/quantarhei/symbolic/cumulant.py
+++ b/quantarhei/symbolic/cumulant.py
@@ -3,14 +3,41 @@ from __future__ import annotations
 from typing import Any
 
 import numpy
-import sympy as sp
-from sympy import Function, I, Mul, Pow, S, Wild, conjugate, sympify
-from sympy.physics.quantum import Dagger, Operator
-from sympy.physics.quantum.qexpr import QExpr
+
+try:
+    import sympy as sp
+    from sympy import Function, I, Mul, Pow, S, Wild, conjugate, sympify
+    from sympy.physics.quantum import Dagger, Operator
+    from sympy.physics.quantum.qexpr import QExpr
+
+    _SYMPY_AVAILABLE = True
+except ImportError:
+    sp = None  # type: ignore[assignment]
+    _SYMPY_AVAILABLE = False
+
+
+def _require_sympy() -> None:
+    if not _SYMPY_AVAILABLE:
+        raise ImportError(
+            "sympy is required for symbolic calculations. "
+            "Install it with: pip install quantarhei[symbolic]"
+        )
 
 
 class CumulantException(Exception):
     pass
+
+
+if not _SYMPY_AVAILABLE:
+    # Stub base classes so the module loads without sympy.
+    # Instantiating any of these will raise ImportError via _require_sympy().
+    class _SympyStub:  # type: ignore[no-redef]
+        def __init_subclass__(cls, **kwargs: Any) -> None:
+            pass
+
+    QExpr = _SympyStub  # type: ignore[assignment,misc]
+    Operator = _SympyStub  # type: ignore[assignment]
+    Function = _SympyStub  # type: ignore[assignment]
 
 
 """
@@ -354,6 +381,7 @@ def evaluate_cumulant(
     arrays: list[str] | None = None,
 ) -> Any:
     """ """
+    _require_sympy()
     if positive_times is None:
         positive_times = []
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ matplotlib
 terminaltables
 dill
 pyyaml
-sympy
-
+# sympy is an optional dependency; install with: pip install quantarhei[symbolic]


### PR DESCRIPTION
## Summary

- `sympy` was a hard runtime dependency despite being used only in `symbolic/` and `spectroscopy/dsfeynman.py`
- Moves `sympy` to `[project.optional-dependencies]` under the `symbolic` extra
- Users who need symbolic calculations install with `pip install quantarhei[symbolic]`
- Without sympy, all non-symbolic functionality works normally; symbolic methods raise `ImportError` with clear install instructions

## Changes

- **`quantarhei/symbolic/cumulant.py`**: guard module-level sympy imports in `try/except`; provide stub base classes so the module loads without sympy; `_require_sympy()` raises `ImportError` with install hint at entry points
- **`quantarhei/symbolic/abc.py`**: guard `Symbol` imports in `try/except`
- **`quantarhei/spectroscopy/dsfeynman.py`**: remove top-level symbolic import; `_require_symbolic()` + lazy local imports injected into the three methods that need them
- **`quantarhei/__init__.py`**: wrap `dsfeynman` and `evaluate_cumulant` imports in `try/except ImportError: pass`
- **`pyproject.toml`**: move `sympy>=1.12,<2` from `dependencies` to `[project.optional-dependencies] symbolic`
- **`requirements.txt`**: remove `sympy` line (replaced with explanatory comment)

## Test plan

- [ ] `python -c "import quantarhei"` works without sympy installed
- [ ] Attempting to call `evaluate_cumulant()` without sympy raises `ImportError` with `pip install quantarhei[symbolic]` message
- [ ] All 164 unit tests pass with sympy installed
- [ ] `mypy quantarhei/` reports no errors
- [ ] `ruff check quantarhei/` reports no errors

Closes #223