### PR TITLE
#279 fix: CorrelationFunctionMatrix shallow copy bug in where sublists

### DIFF
--- a/quantarhei/qm/corfunctions/cfmatrix.py
+++ b/quantarhei/qm/corfunctions/cfmatrix.py
@@ -109,7 +109,7 @@ class CorrelationFunctionMatrix(Saveable):
         # FIXME: reorganization energies should be defined through _A2 and _A4
         # reorganization energies
         self.lambdas = numpy.zeros(nof + 1, dtype=REAL)
-        self.where = [[]] * (nof + 1)
+        self.where = [[] for _ in range(nof + 1)]
 
         # Actual storage of functions
         # here we store correlation functions

--- a/tests/unit/qm/corfunctions/cfmatrix_test.py
+++ b/tests/unit/qm/corfunctions/cfmatrix_test.py
@@ -130,3 +130,12 @@ class TestCFMatrix(unittest.TestCase):
 
         lam = cfm.get_reorganization_energy4(2, 2, 2, 2)
         self.assertTrue(qr.convert(lam, "int", "1/cm") != 80.0)
+
+    def test_where_sublists_are_independent(self):
+        """(CorrelationFunctionMatrix) Different sites must not share where sublists"""
+        cfm = cors.CorrelationFunctionMatrix(self.time, nob=3)
+        cfm.set_correlation_function(self.cf1, [(1, 1)])
+        cfm.set_correlation_function(self.cf2, [(2, 2)])
+        # cf1 is at index 1, cf2 is at index 2; their where lists must be disjoint
+        self.assertNotIn((2, 2), cfm.where[1])
+        self.assertNotIn((1, 1), cfm.where[2])


### PR DESCRIPTION
## Summary

`_initiate_storage()` used `[[]] * (nof + 1)` to initialise the `where` list. This creates `nof + 1` references to the **same** list object — assigning a different correlation function to any site would corrupt the `where` entries of all other sites silently.

Fix: use a list comprehension `[[] for _ in range(nof + 1)]` so each sublist is an independent object.

## Changes

- `quantarhei/qm/corfunctions/cfmatrix.py`: one-line fix in `_initiate_storage()`
- `tests/unit/qm/corfunctions/cfmatrix_test.py`: `test_where_sublists_are_independent` — assigns two different CFs to different sites and asserts their `where` entries are disjoint

## Why this matters

A heterogeneous aggregate (different bath parameters on different chromophores) would silently use the wrong correlation function for some sites. Any pinned integration test value involving a heterodimer or heterogeneous system would be unreliable while this bug was present.

Closes #279