### PR TITLE
#280 fix: remove duplicate set_delay_phase that shadowed real implementation

### DIFF
--- a/quantarhei/spectroscopy/labsetup.py
+++ b/quantarhei/spectroscopy/labsetup.py
@@ -1417,10 +1417,6 @@ class LabField:
         self.labsetup.phases[self.index] = val
         # FIXME: The pulse field has to be updated
 
-    def set_delay_phase(self, val: float) -> None:
-        """Returns the phase caused by the pulse delay"""
-        raise Exception("Setting delay phases independently is not allowed")
-
     def get_center(self) -> Any:
         """Returns the pulse center time"""
         return self.labsetup.pulse_centers[self.index]


### PR DESCRIPTION
## Summary

`LabField` had two definitions of `set_delay_phase`. The first (lines 1420–1422) raised `Exception("Setting delay phases independently is not allowed")`. The second (lines 1448–1454) contained the actual implementation that computes and stores the delay phase.

Python uses the last definition, so the real implementation was in effect — but the dead first definition was misleading and would have been the active one had the order been swapped. `set_center()` called `set_delay_phase()` in `__init__`, so this was already being exercised by the existing test suite without error.

Fix: remove the exception-raising duplicate entirely.

## Changes

- `quantarhei/spectroscopy/labsetup.py`: remove 4 dead lines

Closes #280