### PR TITLE
#282 #283 fix: remove debug prints from SpectralDensity and fix assert_version unreachable branch

### DIFF
--- a/quantarhei/__init__.py
+++ b/quantarhei/__init__.py
@@ -627,11 +627,11 @@ def assert_version(check: str, vno: str) -> None:
             ext()
 
     elif check == ">":
-        if not (version.parse(Manager().version) == version.parse(vno)):
+        if not (version.parse(Manager().version) > version.parse(vno)):
             ext()
 
-    elif check == "<=":
-        if not (version.parse(Manager().version) >= version.parse(vno)):
+    elif check == "<":
+        if not (version.parse(Manager().version) < version.parse(vno)):
             ext()
 
     else:

--- a/quantarhei/qm/corfunctions/correlationfunctions.py
+++ b/quantarhei/qm/corfunctions/correlationfunctions.py
@@ -446,7 +446,6 @@ class CorrelationFunction(DFunction, UnitsManaged):
 
         # use the units in which params was defined
         lamb = self.manager.iu_energy(params["reorg"], units=self.energy_units)
-        print(f"correlation function lamb in int units {lamb:f}")
         time = self.axis  # .data
 
         if values is not None:

--- a/quantarhei/qm/corfunctions/spectraldensities.py
+++ b/quantarhei/qm/corfunctions/spectraldensities.py
@@ -338,7 +338,6 @@ class SpectralDensity(DFunction, UnitsManaged):
                 cfce = cfce * (omega**2)
                 # Brings the reorganisation energy to the lit value of 102
                 cfce = cfce * 3.204215
-                print("Renger form of spec dens used")
 
             else:
                 # This form is taken from Jang, Newton, Silbey, J Chem Phys. 2007.
@@ -367,7 +366,6 @@ class SpectralDensity(DFunction, UnitsManaged):
                         * numpy.exp(-numpy.abs(omega / omega3c))
                     )
                 cfce = cfce * 3.058187
-                print("Alternate form of spec dens used")
 
             # This brings the reorganisation energy up to the literature value of 102
             # cfce = cfce * 3.19
@@ -421,7 +419,6 @@ class SpectralDensity(DFunction, UnitsManaged):
 
         if values is not None:
             self._make_me(self.axis, values)
-            print("spectral density made from correlation function values")
 
         else:
             self._make_me(self.axis, cfce)

--- a/tests/unit/core/test_Manager.py
+++ b/tests/unit/core/test_Manager.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 """
 *******************************************************************************
@@ -10,6 +11,7 @@ import unittest
 *******************************************************************************
 """
 
+import quantarhei
 from quantarhei import Manager
 
 
@@ -26,3 +28,25 @@ class TestManager(unittest.TestCase):
 
         if m is not n:
             raise Exception()
+
+    def test_assert_version_gt_passes_when_current_is_greater(self):
+        """assert_version('>') must not exit when current version is strictly greater"""
+        with patch.object(Manager, "version", new="1.0.0"):
+            try:
+                quantarhei.assert_version(">", "0.9.0")
+            except SystemExit:
+                self.fail(
+                    "assert_version('>') called exit() even though current > required"
+                )
+
+    def test_assert_version_gt_exits_when_current_is_equal(self):
+        """assert_version('>') must exit when current version equals required"""
+        with patch.object(Manager, "version", new="1.0.0"):
+            with self.assertRaises(SystemExit):
+                quantarhei.assert_version(">", "1.0.0")
+
+    def test_assert_version_gt_exits_when_current_is_less(self):
+        """assert_version('>') must exit when current version is less than required"""
+        with patch.object(Manager, "version", new="0.9.0"):
+            with self.assertRaises(SystemExit):
+                quantarhei.assert_version(">", "1.0.0")

--- a/tests/unit/qm/corfunctions/spectraldensities_test.py
+++ b/tests/unit/qm/corfunctions/spectraldensities_test.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import unittest
 
 import numpy
@@ -105,3 +107,33 @@ class TestSpectralDensity(unittest.TestCase):
         cf2 = tot_sd2.get_CorrelationFunction(temperature=300)
 
         numpy.testing.assert_allclose(cf1.data, cf2.data, atol=1.0e-2)
+
+    def test_B777_renger_form_produces_no_stdout(self):
+        """SpectralDensity B777 Renger form must not print to stdout"""
+        params = dict(ftype="B777", reorg=102.0, T=300.0, alternative_form=False)
+        time = TimeAxis(0.0, 10000, 0.1)
+        captured = io.StringIO()
+        with energy_units("1/cm"):
+            with contextlib.redirect_stdout(captured):
+                SpectralDensity(time, params)
+        self.assertEqual(captured.getvalue(), "")
+
+    def test_B777_alternate_form_produces_no_stdout(self):
+        """SpectralDensity B777 alternate form must not print to stdout"""
+        params = dict(ftype="B777", reorg=102.0, T=300.0, alternative_form=True)
+        time = TimeAxis(0.0, 10000, 0.1)
+        captured = io.StringIO()
+        with energy_units("1/cm"):
+            with contextlib.redirect_stdout(captured):
+                SpectralDensity(time, params)
+        self.assertEqual(captured.getvalue(), "")
+
+    def test_CP29_spectral_density_produces_no_stdout(self):
+        """SpectralDensity CP29 construction must not print to stdout"""
+        params = dict(ftype="CP29", reorg=37.0, T=300.0, gamma=1.0 / 100.0)
+        time = TimeAxis(0.0, 10000, 0.1)
+        captured = io.StringIO()
+        with energy_units("1/cm"):
+            with contextlib.redirect_stdout(captured):
+                SpectralDensity(time, params)
+        self.assertEqual(captured.getvalue(), "")


### PR DESCRIPTION
## Summary

- **#282** — Remove three unconditional `print()` calls that fired during normal calculations: `"Renger form of spec dens used"` and `"Alternate form of spec dens used"` in `SpectralDensity._make_B777`, and `"spectral density made from correlation function values"` in `SpectralDensity._make_CP29_spectral_density`. Also removes a debug print in `CorrelationFunction._make_CP29_spectral_density` that logged the internal reorganization energy on every construction.
- **#283** — Fix `assert_version()` in `quantarhei/__init__.py`: the `">"` branch incorrectly used `==` (so `assert_version(">", "0.9.0")` would exit even when current version is `1.0.0`), and a duplicate `elif check == "<="` block shadowed an unreachable second branch. Replaced with correct `>` and `<` operators.

## Test plan

- [ ] `test_B777_renger_form_produces_no_stdout` — captures stdout during B777 Renger construction, asserts empty
- [ ] `test_B777_alternate_form_produces_no_stdout` — same for alternate form
- [ ] `test_CP29_spectral_density_produces_no_stdout` — same for CP29 construction
- [ ] `test_assert_version_gt_passes_when_current_is_greater` — `assert_version(">", "0.9.0")` must not exit when current is `1.0.0`
- [ ] `test_assert_version_gt_exits_when_current_is_equal` — must exit when equal
- [ ] `test_assert_version_gt_exits_when_current_is_less` — must exit when less