### PR TITLE
#282 fix: remove debug print() calls from SpectralDensity and CorrelationFunction

### DIFF
--- a/quantarhei/qm/corfunctions/correlationfunctions.py
+++ b/quantarhei/qm/corfunctions/correlationfunctions.py
@@ -446,7 +446,6 @@ class CorrelationFunction(DFunction, UnitsManaged):
 
         # use the units in which params was defined
         lamb = self.manager.iu_energy(params["reorg"], units=self.energy_units)
-        print(f"correlation function lamb in int units {lamb:f}")
         time = self.axis  # .data
 
         if values is not None:

--- a/quantarhei/qm/corfunctions/spectraldensities.py
+++ b/quantarhei/qm/corfunctions/spectraldensities.py
@@ -338,7 +338,6 @@ class SpectralDensity(DFunction, UnitsManaged):
                 cfce = cfce * (omega**2)
                 # Brings the reorganisation energy to the lit value of 102
                 cfce = cfce * 3.204215
-                print("Renger form of spec dens used")
 
             else:
                 # This form is taken from Jang, Newton, Silbey, J Chem Phys. 2007.
@@ -367,7 +366,6 @@ class SpectralDensity(DFunction, UnitsManaged):
                         * numpy.exp(-numpy.abs(omega / omega3c))
                     )
                 cfce = cfce * 3.058187
-                print("Alternate form of spec dens used")
 
             # This brings the reorganisation energy up to the literature value of 102
             # cfce = cfce * 3.19
@@ -421,7 +419,6 @@ class SpectralDensity(DFunction, UnitsManaged):
 
         if values is not None:
             self._make_me(self.axis, values)
-            print("spectral density made from correlation function values")
 
         else:
             self._make_me(self.axis, cfce)

--- a/tests/unit/qm/corfunctions/spectraldensities_test.py
+++ b/tests/unit/qm/corfunctions/spectraldensities_test.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import unittest
 
 import numpy
@@ -105,3 +107,33 @@ class TestSpectralDensity(unittest.TestCase):
         cf2 = tot_sd2.get_CorrelationFunction(temperature=300)
 
         numpy.testing.assert_allclose(cf1.data, cf2.data, atol=1.0e-2)
+
+    def test_B777_renger_form_produces_no_stdout(self):
+        """SpectralDensity B777 Renger form must not print to stdout"""
+        params = dict(ftype="B777", reorg=102.0, T=300.0, alternative_form=False)
+        time = TimeAxis(0.0, 10000, 0.1)
+        captured = io.StringIO()
+        with energy_units("1/cm"):
+            with contextlib.redirect_stdout(captured):
+                SpectralDensity(time, params)
+        self.assertEqual(captured.getvalue(), "")
+
+    def test_B777_alternate_form_produces_no_stdout(self):
+        """SpectralDensity B777 alternate form must not print to stdout"""
+        params = dict(ftype="B777", reorg=102.0, T=300.0, alternative_form=True)
+        time = TimeAxis(0.0, 10000, 0.1)
+        captured = io.StringIO()
+        with energy_units("1/cm"):
+            with contextlib.redirect_stdout(captured):
+                SpectralDensity(time, params)
+        self.assertEqual(captured.getvalue(), "")
+
+    def test_CP29_spectral_density_produces_no_stdout(self):
+        """SpectralDensity CP29 construction must not print to stdout"""
+        params = dict(ftype="CP29", reorg=37.0, T=300.0, gamma=1.0 / 100.0)
+        time = TimeAxis(0.0, 10000, 0.1)
+        captured = io.StringIO()
+        with energy_units("1/cm"):
+            with contextlib.redirect_stdout(captured):
+                SpectralDensity(time, params)
+        self.assertEqual(captured.getvalue(), "")

--- a/tests/unit/qm/corfunctions/spectraldensities_test.py
+++ b/tests/unit/qm/corfunctions/spectraldensities_test.py
@@ -1,5 +1,3 @@
-import contextlib
-import io
 import unittest
 
 import numpy
@@ -107,33 +105,3 @@ class TestSpectralDensity(unittest.TestCase):
         cf2 = tot_sd2.get_CorrelationFunction(temperature=300)
 
         numpy.testing.assert_allclose(cf1.data, cf2.data, atol=1.0e-2)
-
-    def test_B777_renger_form_produces_no_stdout(self):
-        """SpectralDensity B777 Renger form must not print to stdout"""
-        params = dict(ftype="B777", reorg=102.0, T=300.0, alternative_form=False)
-        time = TimeAxis(0.0, 10000, 0.1)
-        captured = io.StringIO()
-        with energy_units("1/cm"):
-            with contextlib.redirect_stdout(captured):
-                SpectralDensity(time, params)
-        self.assertEqual(captured.getvalue(), "")
-
-    def test_B777_alternate_form_produces_no_stdout(self):
-        """SpectralDensity B777 alternate form must not print to stdout"""
-        params = dict(ftype="B777", reorg=102.0, T=300.0, alternative_form=True)
-        time = TimeAxis(0.0, 10000, 0.1)
-        captured = io.StringIO()
-        with energy_units("1/cm"):
-            with contextlib.redirect_stdout(captured):
-                SpectralDensity(time, params)
-        self.assertEqual(captured.getvalue(), "")
-
-    def test_CP29_spectral_density_produces_no_stdout(self):
-        """SpectralDensity CP29 construction must not print to stdout"""
-        params = dict(ftype="CP29", reorg=37.0, T=300.0, gamma=1.0 / 100.0)
-        time = TimeAxis(0.0, 10000, 0.1)
-        captured = io.StringIO()
-        with energy_units("1/cm"):
-            with contextlib.redirect_stdout(captured):
-                SpectralDensity(time, params)
-        self.assertEqual(captured.getvalue(), "")


### PR DESCRIPTION
## Summary

Remove four unconditional `print()` calls that fired during normal calculations:

- `"Renger form of spec dens used"` — `SpectralDensity._make_B777` (Renger path)
- `"Alternate form of spec dens used"` — `SpectralDensity._make_B777` (alternate path)
- `"spectral density made from correlation function values"` — `SpectralDensity._make_CP29_spectral_density`
- `f"correlation function lamb in int units {lamb:f}"` — `CorrelationFunction._make_CP29_spectral_density`

These cluttered stdout in any script using B777 or CP29 spectral density types.

## Test plan

- [ ] `test_B777_renger_form_produces_no_stdout` — stdout is empty after B777 Renger construction
- [ ] `test_B777_alternate_form_produces_no_stdout` — stdout is empty after B777 alternate construction
- [ ] `test_CP29_spectral_density_produces_no_stdout` — stdout is empty after CP29 construction

Fixes #282