### PR TITLE
#283 fix: correct assert_version() operator logic and remove unreachable branch

### DIFF
--- a/quantarhei/__init__.py
+++ b/quantarhei/__init__.py
@@ -627,11 +627,11 @@ def assert_version(check: str, vno: str) -> None:
             ext()
 
     elif check == ">":
-        if not (version.parse(Manager().version) == version.parse(vno)):
+        if not (version.parse(Manager().version) > version.parse(vno)):
             ext()
 
-    elif check == "<=":
-        if not (version.parse(Manager().version) >= version.parse(vno)):
+    elif check == "<":
+        if not (version.parse(Manager().version) < version.parse(vno)):
             ext()
 
     else:

--- a/tests/unit/core/test_Manager.py
+++ b/tests/unit/core/test_Manager.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 """
 *******************************************************************************
@@ -10,6 +11,7 @@ import unittest
 *******************************************************************************
 """
 
+import quantarhei
 from quantarhei import Manager
 
 
@@ -26,3 +28,25 @@ class TestManager(unittest.TestCase):
 
         if m is not n:
             raise Exception()
+
+    def test_assert_version_gt_passes_when_current_is_greater(self):
+        """assert_version('>') must not exit when current version is strictly greater"""
+        with patch.object(Manager, "version", new="1.0.0"):
+            try:
+                quantarhei.assert_version(">", "0.9.0")
+            except SystemExit:
+                self.fail(
+                    "assert_version('>') called exit() even though current > required"
+                )
+
+    def test_assert_version_gt_exits_when_current_is_equal(self):
+        """assert_version('>') must exit when current version equals required"""
+        with patch.object(Manager, "version", new="1.0.0"):
+            with self.assertRaises(SystemExit):
+                quantarhei.assert_version(">", "1.0.0")
+
+    def test_assert_version_gt_exits_when_current_is_less(self):
+        """assert_version('>') must exit when current version is less than required"""
+        with patch.object(Manager, "version", new="0.9.0"):
+            with self.assertRaises(SystemExit):
+                quantarhei.assert_version(">", "1.0.0")


### PR DESCRIPTION
## Summary

Fix two bugs in `assert_version()` in `quantarhei/__init__.py`:

- The `">"` branch used `==` instead of `>`, so `assert_version(">", "0.9.0")` would incorrectly exit even when the current version was `1.0.0` or higher.
- A duplicate `elif check == "<="` block made the second branch unreachable (dead code). Replaced with a correct `"<"` branch.

## Test plan

- [ ] `test_assert_version_gt_passes_when_current_is_greater` — `assert_version(">", "0.9.0")` does not exit when current is `1.0.0`
- [ ] `test_assert_version_gt_exits_when_current_is_equal` — exits when current equals required
- [ ] `test_assert_version_gt_exits_when_current_is_less` — exits when current is less than required

Fixes #283