### PR TITLE
#216 feat: add __eq__ with numpy.allclose tolerance to MatrixData

### DIFF
--- a/quantarhei/core/matrixdata.py
+++ b/quantarhei/core/matrixdata.py
@@ -51,6 +51,13 @@ class MatrixData:
 
     __hash__ = None  # type: ignore[assignment]
 
+    def allclose(self, other: object, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        if self.data.shape != other.data.shape:
+            return False
+        return bool(numpy.allclose(self.data, other.data, rtol=rtol, atol=atol))
+
     def set_name(self, name: str) -> None:
         """Sets the object name
 

--- a/quantarhei/core/matrixdata.py
+++ b/quantarhei/core/matrixdata.py
@@ -42,6 +42,15 @@ class MatrixData:
             else:
                 self.data = data
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        if self.data.shape != other.data.shape:
+            return False
+        return bool(numpy.allclose(self.data, other.data))
+
+    __hash__ = None  # type: ignore[assignment]
+
     def set_name(self, name: str) -> None:
         """Sets the object name
 

--- a/tests/unit/qm/hilbertspace/test_operators.py
+++ b/tests/unit/qm/hilbertspace/test_operators.py
@@ -169,3 +169,35 @@ class TestMatrixDataEq(unittest.TestCase):
         op = Operator(data=numpy.eye(2))
         with self.assertRaises(TypeError):
             hash(op)
+
+    def test_allclose_with_default_tolerance(self):
+        """allclose() with defaults matches numpy.allclose defaults."""
+        data = numpy.array([[1.0, 2.0], [3.0, 4.0]])
+        op1 = Operator(data=data)
+        op2 = Operator(data=data + 1e-9)
+        self.assertTrue(op1.allclose(op2))
+
+    def test_allclose_with_tight_atol_rejects_small_difference(self):
+        """allclose(atol=0) rejects differences that == passes."""
+        data = numpy.array([[1.0, 2.0], [3.0, 4.0]])
+        op1 = Operator(data=data)
+        op2 = Operator(data=data + 1e-9)
+        self.assertFalse(op1.allclose(op2, atol=0.0, rtol=0.0))
+
+    def test_allclose_with_loose_atol_accepts_large_difference(self):
+        """allclose(atol=1.0) accepts differences that == rejects."""
+        op1 = Operator(data=numpy.array([[1.0, 0.0], [0.0, 1.0]]))
+        op2 = Operator(data=numpy.array([[1.5, 0.0], [0.0, 1.5]]))
+        self.assertFalse(op1 == op2)
+        self.assertTrue(op1.allclose(op2, atol=1.0))
+
+    def test_allclose_different_shapes_returns_false(self):
+        """allclose() returns False for operators with different shapes."""
+        op1 = Operator(data=numpy.eye(2))
+        op2 = Operator(data=numpy.eye(3))
+        self.assertFalse(op1.allclose(op2))
+
+    def test_allclose_with_non_operator_returns_not_implemented(self):
+        """allclose() with a non-Operator returns NotImplemented."""
+        op = Operator(data=numpy.eye(2))
+        self.assertIs(op.allclose(42), NotImplemented)

--- a/tests/unit/qm/hilbertspace/test_operators.py
+++ b/tests/unit/qm/hilbertspace/test_operators.py
@@ -128,3 +128,44 @@ class TestOperatorAdd(unittest.TestCase):
         self.assertTrue(numpy.allclose(op1.data, d1))
         self.assertTrue(numpy.allclose(op2.data, d2))
         self.assertTrue(numpy.allclose(result.data, 6.0 * numpy.eye(2)))
+
+
+class TestMatrixDataEq(unittest.TestCase):
+    """Tests for __eq__ on MatrixData and its subclasses (Operator, etc.)."""
+
+    def test_equal_operators_compare_equal(self):
+        """Two Operators with identical data must compare equal."""
+        op1 = Operator(data=numpy.array([[1.0, 2.0], [3.0, 4.0]]))
+        op2 = Operator(data=numpy.array([[1.0, 2.0], [3.0, 4.0]]))
+        self.assertEqual(op1, op2)
+
+    def test_different_operators_compare_unequal(self):
+        """Two Operators with different data must compare unequal."""
+        op1 = Operator(data=numpy.array([[1.0, 0.0], [0.0, 1.0]]))
+        op2 = Operator(data=numpy.array([[2.0, 0.0], [0.0, 2.0]]))
+        self.assertNotEqual(op1, op2)
+
+    def test_numerically_close_operators_compare_equal(self):
+        """Operators that differ by floating-point noise must compare equal."""
+        data = numpy.array([[1.0, 2.0], [3.0, 4.0]])
+        op1 = Operator(data=data)
+        op2 = Operator(data=data + 1e-12)
+        self.assertEqual(op1, op2)
+
+    def test_different_shape_operators_compare_unequal(self):
+        """Operators with different shapes must compare unequal."""
+        op1 = Operator(data=numpy.eye(2))
+        op2 = Operator(data=numpy.eye(3))
+        self.assertNotEqual(op1, op2)
+
+    def test_eq_with_non_operator_returns_not_implemented(self):
+        """Comparing an Operator to a non-Operator must not raise."""
+        op = Operator(data=numpy.eye(2))
+        result = op.__eq__(42)
+        self.assertIs(result, NotImplemented)
+
+    def test_operator_is_unhashable(self):
+        """Operator must be unhashable (mutable objects with __eq__ should not be hashable)."""
+        op = Operator(data=numpy.eye(2))
+        with self.assertRaises(TypeError):
+            hash(op)


### PR DESCRIPTION
## Summary

Add `__eq__` and `allclose(other, rtol, atol)` to `MatrixData` so all domain objects (`Operator`, `Hamiltonian`, `DensityMatrix`, `SuperOperator`, etc.) support equality comparison and tolerance-controlled closeness checks without reaching into `.data` manually.

Two objects are equal when they are of the same class, have the same data shape, and pass `numpy.allclose` with default tolerances. `__hash__` is set to `None` so instances are unhashable — correct for mutable array-backed objects.

`allclose(other, rtol=1e-5, atol=1e-8)` mirrors `numpy.allclose` but operates on `MatrixData` objects directly, letting callers specify tolerances when the default `==` tolerance is too strict or too loose.

Before:
```python
assert numpy.allclose(H1.data, H2.data) and H1.data.shape == H2.data.shape
# no way to adjust tolerance
```

After:
```python
assert H1 == H2                      # default tolerances
assert H1.allclose(H2, atol=1e-3)   # custom tolerance
```

## Test plan

- [ ] `test_equal_operators_compare_equal` — identical data compares equal
- [ ] `test_different_operators_compare_unequal` — different data compares unequal
- [ ] `test_numerically_close_operators_compare_equal` — data differing by floating-point noise compares equal
- [ ] `test_different_shape_operators_compare_unequal` — different shapes compare unequal
- [ ] `test_eq_with_non_operator_returns_not_implemented` — comparing to a non-Operator does not raise
- [ ] `test_operator_is_unhashable` — `hash(op)` raises `TypeError`
- [ ] `test_allclose_with_default_tolerance` — `allclose()` matches numpy defaults
- [ ] `test_allclose_with_tight_atol_rejects_small_difference` — `allclose(atol=0, rtol=0)` rejects what `==` accepts
- [ ] `test_allclose_with_loose_atol_accepts_large_difference` — `allclose(atol=1.0)` accepts what `==` rejects
- [ ] `test_allclose_different_shapes_returns_false` — different shapes return False
- [ ] `test_allclose_with_non_operator_returns_not_implemented` — non-Operator returns NotImplemented

Fixes #216