### PR TITLE
#217 fix: assign REAL and COMPLEX directly as numpy types, drop Manager indirection

### DIFF
--- a/quantarhei/__init__.py
+++ b/quantarhei/__init__.py
@@ -143,13 +143,12 @@ except _PackageNotFoundError:
 #
 # Fix used numerical types
 #
-# import numpy
+import numpy
+
 from .core.managers import Manager
 
-m = Manager()
-
-REAL: type = m.get_real_type()  # numpy.float64
-COMPLEX: type = m.get_complex_type()  # numpy.complex128
+REAL: type = numpy.float64
+COMPLEX: type = numpy.complex128
 
 LOG_URGENT = 1
 LOG_REPORT = 3

--- a/tests/unit/core/test_constants.py
+++ b/tests/unit/core/test_constants.py
@@ -1,0 +1,23 @@
+import unittest
+
+import numpy
+
+import quantarhei
+
+
+class TestTypeConstants(unittest.TestCase):
+    def test_REAL_is_float64(self):
+        self.assertIs(quantarhei.REAL, numpy.float64)
+
+    def test_COMPLEX_is_complex128(self):
+        self.assertIs(quantarhei.COMPLEX, numpy.complex128)
+
+    def test_REAL_is_not_resolved_via_Manager(self):
+        self.assertIsNot(type(quantarhei.REAL), type(lambda: None))
+        self.assertIs(quantarhei.REAL, numpy.float64)
+
+    def test_constants_usable_as_dtype(self):
+        a = numpy.zeros((2, 2), dtype=quantarhei.REAL)
+        b = numpy.zeros((2, 2), dtype=quantarhei.COMPLEX)
+        self.assertEqual(a.dtype, numpy.float64)
+        self.assertEqual(b.dtype, numpy.complex128)


### PR DESCRIPTION
## Summary

`REAL` and `COMPLEX` were assigned by calling `Manager().get_real_type()` / `get_complex_type()` at import time, implying the values were dynamic and tied to Manager state. In practice, both methods are hardwired to `numpy.float64` and `numpy.complex128` and cannot be reconfigured. The indirection was misleading with no benefit.

This PR assigns the constants directly and removes the now-unused module-level `m = Manager()` instantiation:

```python
# before
m = Manager()
REAL: type = m.get_real_type()    # numpy.float64
COMPLEX: type = m.get_complex_type()  # numpy.complex128

# after
REAL: type = numpy.float64
COMPLEX: type = numpy.complex128
```

## Test plan

- [ ] `test_REAL_is_float64` — `qr.REAL is numpy.float64`
- [ ] `test_COMPLEX_is_complex128` — `qr.COMPLEX is numpy.complex128`
- [ ] `test_constants_usable_as_dtype` — both work as `dtype=` arguments to `numpy.zeros`

Fixes #217