### PR TITLE
#221 fix: add threading.Lock to Singleton metaclass

### DIFF
--- a/quantarhei/core/singleton.py
+++ b/quantarhei/core/singleton.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from typing import Any
 
 
@@ -17,8 +18,10 @@ class Singleton(type):
     """
 
     _instances: dict[type, Singleton] = {}
+    _lock: threading.Lock = threading.Lock()
 
     def __call__(cls, *args: Any, **kwargs: Any) -> Any:
-        if cls not in cls._instances:
-            cls._instances[cls] = super().__call__(*args, **kwargs)
+        with cls._lock:
+            if cls not in cls._instances:
+                cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]

--- a/tests/unit/core/test_singleton.py
+++ b/tests/unit/core/test_singleton.py
@@ -1,0 +1,57 @@
+import threading
+import unittest
+
+from quantarhei.core.singleton import Singleton
+
+
+class _TestSingleton(metaclass=Singleton):
+    def __init__(self):
+        self.value = 0
+
+
+class TestSingletonThreadSafety(unittest.TestCase):
+    def setUp(self):
+        Singleton._instances.pop(_TestSingleton, None)
+
+    def test_concurrent_instantiation_returns_same_instance(self):
+        instances = []
+        barrier = threading.Barrier(10)
+
+        def create():
+            barrier.wait()
+            instances.append(_TestSingleton())
+
+        threads = [threading.Thread(target=create) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(set(id(i) for i in instances)), 1)
+
+    def test_constructor_runs_exactly_once_under_concurrency(self):
+        call_count = []
+        barrier = threading.Barrier(10)
+
+        original_init = _TestSingleton.__init__
+
+        def counting_init(self):
+            call_count.append(1)
+            original_init(self)
+
+        _TestSingleton.__init__ = counting_init
+        try:
+
+            def create():
+                barrier.wait()
+                _TestSingleton()
+
+            threads = [threading.Thread(target=create) for _ in range(10)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            self.assertEqual(len(call_count), 1)
+        finally:
+            _TestSingleton.__init__ = original_init


### PR DESCRIPTION
## Summary

Add a `threading.Lock` to `Singleton` to prevent a race condition on first instantiation. Without the lock, two threads can both pass the `if cls not in _instances` check before either writes the result, running `__init__` twice and silently discarding one instance.

The lock only contends on the very first instantiation of each class — subsequent calls return from `_instances` immediately after acquiring the (uncontested) lock.

```python
# before
def __call__(cls, *args, **kwargs):
    if cls not in cls._instances:
        cls._instances[cls] = super().__call__(*args, **kwargs)
    return cls._instances[cls]

# after
def __call__(cls, *args, **kwargs):
    with cls._lock:
        if cls not in cls._instances:
            cls._instances[cls] = super().__call__(*args, **kwargs)
    return cls._instances[cls]
```

## Test plan

- [ ] `test_concurrent_instantiation_returns_same_instance` — 10 threads racing produce identical instance ids
- [ ] `test_constructor_runs_exactly_once_under_concurrency` — `__init__` is called exactly once across 10 racing threads

Fixes #221