### PR TITLE
#219 fix: use numpy.finfo(float).tiny threshold in nm unit conversion

### DIFF
--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -596,16 +596,16 @@ class Manager(metaclass=Singleton):
 
         # special handling for nano meters
         if units == "nm":
-            # zero is interpretted as zero energy
+            # zero is interpreted as zero energy; use tiny threshold to guard
+            # against subnormals that would overflow 1/val to inf
+            tiny = numpy.finfo(float).tiny
             try:
+                nonzero = numpy.abs(val) > tiny  # type: ignore[operator]
                 ret = numpy.zeros(val.shape, dtype=val.dtype)  # type: ignore[union-attr]
-                ret[val != 0.0] = 1.0 / val[val != 0]  # type: ignore[index]
+                ret[nonzero] = 1.0 / val[nonzero]  # type: ignore[index]
                 return ret / cfact
-            except AttributeError:
-                return (1.0 / val) / cfact
-            # if val == 0.0:
-            #    return 0.0
-            # return (1.0/val)/cfact
+            except (AttributeError, TypeError):
+                return (0.0 if abs(val) <= tiny else 1.0 / val) / cfact  # type: ignore[arg-type]
         else:
             return val * cfact
 
@@ -625,13 +625,16 @@ class Manager(metaclass=Singleton):
 
         # special handling for nanometers
         if units == "nm":
-            # zero is interpretted as zero energy
+            # zero is interpreted as zero energy; use tiny threshold to guard
+            # against subnormals that would overflow 1/val to inf
+            tiny = numpy.finfo(float).tiny
             try:
+                nonzero = numpy.abs(val) > tiny  # type: ignore[operator]
                 ret = numpy.zeros(val.shape, dtype=val.dtype)  # type: ignore[union-attr]
-                ret[val != 0.0] = 1.0 / val[val != 0]  # type: ignore[index]
+                ret[nonzero] = 1.0 / val[nonzero]  # type: ignore[index]
                 return ret / cfact
-            except AttributeError:
-                return (1.0 / val) / cfact
+            except (AttributeError, TypeError):
+                return (0.0 if abs(val) <= tiny else 1.0 / val) / cfact  # type: ignore[arg-type]
         else:
             return val / cfact
 

--- a/tests/unit/core/test_Manager.py
+++ b/tests/unit/core/test_Manager.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy
+
 """
 *******************************************************************************
 
@@ -10,7 +12,7 @@ import unittest
 *******************************************************************************
 """
 
-from quantarhei import Manager
+from quantarhei import Manager, energy_units, set_current_units
 
 
 class TestManager(unittest.TestCase):
@@ -26,3 +28,44 @@ class TestManager(unittest.TestCase):
 
         if m is not n:
             raise Exception()
+
+
+class TestNmConversion(unittest.TestCase):
+    def setUp(self):
+        set_current_units()
+
+    def tearDown(self):
+        set_current_units()
+
+    def test_zero_energy_converts_to_zero_in_nm_units(self):
+        """convert_energy_2_current_u(0.0) must return 0.0 when units are nm"""
+        with energy_units("nm"):
+            m = Manager()
+            result = m.convert_energy_2_current_u(0.0)
+            self.assertEqual(result, 0.0)
+
+    def test_zero_array_converts_to_zero_array_in_nm_units(self):
+        """Zero array elements must stay zero in nm conversion, not become inf"""
+        with energy_units("nm"):
+            m = Manager()
+            val = numpy.array([0.0, 1.0, 0.0])
+            result = m.convert_energy_2_current_u(val)
+            self.assertTrue(numpy.isfinite(result).all())
+            self.assertEqual(result[0], 0.0)
+            self.assertEqual(result[2], 0.0)
+
+    def test_near_zero_subnormal_does_not_produce_inf_in_nm_units(self):
+        """A subnormal float near zero must not invert to inf in nm conversion"""
+        with energy_units("nm"):
+            m = Manager()
+            val = numpy.array([numpy.finfo(float).tiny])
+            result = m.convert_energy_2_current_u(val)
+            self.assertTrue(numpy.isfinite(result).all())
+
+    def test_internal_to_nm_roundtrip(self):
+        """convert_energy_2_internal_u(convert_energy_2_current_u(v)) == v for nonzero v"""
+        with energy_units("nm"):
+            m = Manager()
+            val = numpy.array([100.0, 500.0, 1000.0])
+            roundtrip = m.convert_energy_2_internal_u(m.convert_energy_2_current_u(val))
+            numpy.testing.assert_allclose(roundtrip, val, rtol=1e-10)

--- a/tests/unit/core/test_Manager.py
+++ b/tests/unit/core/test_Manager.py
@@ -1,9 +1,4 @@
-import unittest
-
-import numpy
-
-"""
-*******************************************************************************
+"""*******************************************************************************
 
 
     Tests of the quantarhei.Manager class
@@ -11,6 +6,10 @@ import numpy
 
 *******************************************************************************
 """
+
+import unittest
+
+import numpy
 
 from quantarhei import Manager, energy_units, set_current_units
 


### PR DESCRIPTION
## Summary

The nm unit conversion in `convert_energy_2_internal_u` and `convert_energy_2_current_u` used exact `val != 0.0` to guard against division by zero. This had two failure modes:

1. **Scalar `0.0`** fell through to the `except AttributeError` branch and raised `ZeroDivisionError` instead of returning `0.0`.
2. **Subnormal floats** (`abs(val) < ~2.2e-308`) passed the `!= 0.0` check but `1/val` overflowed to `inf`, silently producing wrong results.

Fix: replace `val != 0.0` with `abs(val) > numpy.finfo(float).tiny` in both the array and scalar paths.

## Test plan

- [ ] `test_zero_energy_converts_to_zero_in_nm_units` — scalar `0.0` returns `0.0`, no `ZeroDivisionError`
- [ ] `test_zero_array_converts_to_zero_array_in_nm_units` — zero elements in array stay `0.0`, no `inf`
- [ ] `test_near_zero_subnormal_does_not_produce_inf_in_nm_units` — subnormal input stays finite
- [ ] `test_internal_to_nm_roundtrip` — nonzero values round-trip correctly

Fixes #219