### PR TITLE
#270 fix: lift safe deferred intra-layer imports to module level

### DIFF
--- a/quantarhei/__init__.py
+++ b/quantarhei/__init__.py
@@ -151,12 +151,13 @@ m = Manager()
 REAL: type = m.get_real_type()  # numpy.float64
 COMPLEX: type = m.get_complex_type()  # numpy.complex128
 
-LOG_URGENT = 1
-LOG_REPORT = 3
-LOG_INFO = 5
-LOG_DETAIL = 7
-LOG_QUICK = 9
-
+from .utils.logging import (
+    LOG_DETAIL,
+    LOG_INFO,
+    LOG_QUICK,
+    LOG_REPORT,
+    LOG_URGENT,
+)
 
 #
 # Non-linear response signals

--- a/quantarhei/builders/aggregate_excitonanalysis.py
+++ b/quantarhei/builders/aggregate_excitonanalysis.py
@@ -39,8 +39,7 @@ from typing import Any
 
 import numpy
 
-import quantarhei as qr
-
+from ..core.managers import energy_units
 from .aggregate_spectroscopy import AggregateSpectroscopy
 
 
@@ -243,7 +242,7 @@ class AggregateExcitonAnalysis(AggregateSpectroscopy):
         >>> print("{0:.4f}".format(agg.get_state_energy(2)))
         2.3231
 
-        >>> with qr.energy_units("1/cm"):
+        >>> with energy_units("1/cm"):
         ...     print("{0:.4f}".format(agg.get_state_energy(2)))
         12332.9320
 
@@ -335,7 +334,7 @@ class AggregateExcitonAnalysis(AggregateSpectroscopy):
                 stop_at = N01 + 1
 
             if (Nst >= start_at) and (Nst <= stop_at):
-                with qr.energy_units("1/cm"):
+                with energy_units("1/cm"):
                     tre = self.get_state_energy(Nst) - self.get_state_energy(0)
                 dip = self.get_transition_dipole(0, Nst)
 
@@ -352,7 +351,7 @@ class AggregateExcitonAnalysis(AggregateSpectroscopy):
                     print(txt, file=file)
                     print(line, file=file)
                     print("", file=file)
-                    with qr.energy_units("1/cm"):
+                    with energy_units("1/cm"):
                         print(f"Transition energy        : {tre:.8f} 1/cm", file=file)
                         print(f"Transition dipole moment : {dip:.8f} D", file=file)
                     self.report_on_expansion(file=file, state=Nst, N=Nrep)

--- a/quantarhei/builders/aggregate_spectroscopy.py
+++ b/quantarhei/builders/aggregate_spectroscopy.py
@@ -13,9 +13,8 @@ from typing import Any
 
 import numpy
 
-import quantarhei as qr
-
 from ..core.managers import eigenbasis_of
+from ..qm.liouvillespace.supopunity import SOpUnity
 from ..spectroscopy import diagramatics as diag
 from .aggregate_base import AggregateBase
 
@@ -45,7 +44,7 @@ class AggregateSpectroscopy(AggregateBase):
             dtol=dtol,
             ptol=ptol,
             lab=lab,
-            eUt=qr.qm.SOpUnity(dim=ham.dim),
+            eUt=SOpUnity(dim=ham.dim),
             verbose=verbose,
         )
         #

--- a/quantarhei/core/time.py
+++ b/quantarhei/core/time.py
@@ -201,15 +201,11 @@ Class Details
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy
 
+from .frequency import FrequencyAxis
 from .managers import energy_units
 from .valueaxis import ValueAxis
-
-if TYPE_CHECKING:
-    from .frequency import FrequencyAxis
 
 
 class TimeDependent:
@@ -272,8 +268,6 @@ class TimeAxis(ValueAxis):
 
     def get_FrequencyAxis(self) -> FrequencyAxis:
         """Returns corresponding FrequencyAxis object"""
-        from .frequency import FrequencyAxis
-
         if self.atype == "complete":
             frequencies = numpy.fft.fftshift(
                 (2.0 * numpy.pi) * numpy.fft.fftfreq(self.length, self.step)

--- a/quantarhei/models/spectral_densities/renger_2002.py
+++ b/quantarhei/models/spectral_densities/renger_2002.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from quantarhei import SpectralDensity, energy_units
-from quantarhei.models.spectdens import SpectralDensityDatabaseEntry
+from ...core.managers import energy_units
+from ...qm.corfunctions.spectraldensities import SpectralDensity
+from ..spectdens import SpectralDensityDatabaseEntry
 
 
 class renger_2002a(SpectralDensityDatabaseEntry):

--- a/quantarhei/models/spectral_densities/wendling_2000.py
+++ b/quantarhei/models/spectral_densities/wendling_2000.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from quantarhei import SpectralDensity, energy_units
-from quantarhei.models.spectdens import SpectralDensityDatabaseEntry
+from ...core.managers import energy_units
+from ...qm.corfunctions.spectraldensities import SpectralDensity
+from ..spectdens import SpectralDensityDatabaseEntry
 
 
 class wendling_2000a(SpectralDensityDatabaseEntry):

--- a/quantarhei/qm/liouvillespace/Mockevolutionsuperoperator.py
+++ b/quantarhei/qm/liouvillespace/Mockevolutionsuperoperator.py
@@ -194,8 +194,6 @@ import matplotlib.pyplot as plt
 import numpy
 from scipy.linalg import expm
 
-import quantarhei as qr
-
 from ... import COMPLEX
 from ...core.saveable import Saveable
 from ...core.time import TimeAxis, TimeDependent
@@ -278,11 +276,11 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
 
         if (self.time is not None) and (self.mode == "all"):
             self.data_pop = numpy.zeros(
-                (self.time.length, self.dim, self.dim), dtype=qr.COMPLEX
+                (self.time.length, self.dim, self.dim), dtype=COMPLEX
             )
 
             self.data_coh = numpy.zeros(
-                (self.time.length, self.dim, self.dim), dtype=qr.COMPLEX
+                (self.time.length, self.dim, self.dim), dtype=COMPLEX
             )
 
             #
@@ -295,9 +293,9 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
                     self.data_coh[0, i, j] = 1.0
 
         else:
-            self.data_pop = numpy.zeros((self.dim, self.dim), dtype=qr.COMPLEX)
+            self.data_pop = numpy.zeros((self.dim, self.dim), dtype=COMPLEX)
 
-            self.data_coh = numpy.zeros((self.dim, self.dim), dtype=qr.COMPLEX)
+            self.data_coh = numpy.zeros((self.dim, self.dim), dtype=COMPLEX)
             #
             # zero time value (unity superoperator)
             #
@@ -353,9 +351,9 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
         if (self.mode == "all") or save:
             # if we are supposed to save all time steps
             Nt = self.time.length
-            self.data_pop = numpy.zeros((Nt, self.dim, self.dim), dtype=qr.COMPLEX)
+            self.data_pop = numpy.zeros((Nt, self.dim, self.dim), dtype=COMPLEX)
 
-            self.data_coh = numpy.zeros((Nt, self.dim, self.dim), dtype=qr.COMPLEX)
+            self.data_coh = numpy.zeros((Nt, self.dim, self.dim), dtype=COMPLEX)
 
             #
             # zero time value (unity superoperator)
@@ -369,9 +367,9 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
         elif self.mode == "jit":
             # if we need to keep only the last state
             if self.dim != self.data.shape[0]:  # type: ignore[misc,index,attr-defined,assignment]
-                self.data_pop = numpy.zeros((self.dim, self.dim), dtype=qr.COMPLEX)
+                self.data_pop = numpy.zeros((self.dim, self.dim), dtype=COMPLEX)
 
-                self.data_coh = numpy.zeros((self.dim, self.dim), dtype=qr.COMPLEX)
+                self.data_coh = numpy.zeros((self.dim, self.dim), dtype=COMPLEX)
             #
             # zero time value (unity superoperator)
             #

--- a/quantarhei/qm/liouvillespace/redfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/redfieldtensor.py
@@ -14,8 +14,6 @@ from typing import Any
 import numpy
 import scipy
 
-import quantarhei as qr
-
 from ... import COMPLEX, REAL
 from ...core.managers import energy_units
 from ...core.parallel import (
@@ -24,6 +22,7 @@ from ...core.parallel import (
     distributed_configuration,
     start_parallel_region,
 )
+from ...utils.logging import log_detail, log_quick
 
 # from ...core.managers import BasisManaged
 from ...utils.types import BasisManagedComplexArray
@@ -275,7 +274,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
 
 
         """
-        qr.log_detail("Reference time-independent Redfield tensor calculation")
+        log_detail("Reference time-independent Redfield tensor calculation")
         # print("Reference Redfield implementation ...")
         #
         # dimension of the Hamiltonian (includes excitons
@@ -405,7 +404,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
 
         start_parallel_region()
         for ms in block_distributed_range(0, Nb):  # range(Nb):
-            qr.log_quick("Calculating bath component", ms, "of", Nb, end="\r")
+            log_quick("Calculating bath component", ms, "of", Nb, end="\r")
             # print(ms, "of", Nb)
             # for ns in range(Nb):
 
@@ -420,7 +419,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
             self._guts_Cmplx_Splines(ms, Lm, Km, Na, Om, length, rc1, tm)
 
         # perform reduction of Lm
-        qr.log_quick()
+        log_quick()
         distributed_configuration().allreduce(Lm, operation="sum")
         close_parallel_region()
 
@@ -455,7 +454,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
 
         self._post_implementation(Km, Lm, Ld)
 
-        qr.log_detail("... Redfield done")
+        log_detail("... Redfield done")
 
     def _post_implementation(
         self, Km: numpy.ndarray, Lm: numpy.ndarray, Ld: numpy.ndarray

--- a/quantarhei/qm/liouvillespace/superoperator.py
+++ b/quantarhei/qm/liouvillespace/superoperator.py
@@ -21,8 +21,7 @@ from typing import Any
 import numpy
 
 # quantarhei imports
-import quantarhei as qr
-
+from ... import COMPLEX, REAL
 from ...core.managers import BasisManaged
 from ...utils.types import BasisManagedComplexArray
 
@@ -83,7 +82,7 @@ class SuperOperator(BasisManaged):
 
     """
 
-    data = BasisManagedComplexArray("data")
+    data: numpy.ndarray = BasisManagedComplexArray("data")  # type: ignore[assignment]
     _data: numpy.ndarray
     name: str = ""
 
@@ -103,9 +102,9 @@ class SuperOperator(BasisManaged):
         self.dim = dim
         if dim is not None:
             if real:
-                self.data = numpy.zeros((dim, dim, dim, dim), dtype=qr.REAL)
+                self.data = numpy.zeros((dim, dim, dim, dim), dtype=REAL)
             else:
-                self.data = numpy.zeros((dim, dim, dim, dim), dtype=qr.COMPLEX)
+                self.data = numpy.zeros((dim, dim, dim, dim), dtype=COMPLEX)
         elif data is not None:
             self.data = data
             if len(data.shape) != 4:

--- a/quantarhei/qm/liouvillespace/supopunity.py
+++ b/quantarhei/qm/liouvillespace/supopunity.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import numpy
 
+from ... import REAL
 from .superoperator import SuperOperator
 
 
@@ -75,9 +76,7 @@ class SOpUnity(SuperOperator):
 
         # initialize the data
         if dim is not None:
-            import quantarhei as qr
-
-            self.data = numpy.zeros((dim, dim, dim, dim), qr.REAL)
+            self.data = numpy.zeros((dim, dim, dim, dim), REAL)
             for i in range(self.dim):
                 for j in range(self.dim):
                     self.data[i, j, i, j] = 1.0

--- a/quantarhei/qm/propagators/oqssvpropagator.py
+++ b/quantarhei/qm/propagators/oqssvpropagator.py
@@ -4,8 +4,8 @@ from typing import Any
 
 import numpy
 
-import quantarhei as qr
-from quantarhei.qm import TDRedfieldRateMatrix
+from ... import REAL
+from ...qm import TDRedfieldRateMatrix
 
 # from numba import njit
 from .oqssvevolution import OQSStateVectorEvolution
@@ -75,7 +75,7 @@ class OQSStateVectorPropagator:
 
             ppi = psii.data * psii.data
 
-            ppt = numpy.zeros((self.Nt, ham.dim), dtype=qr.REAL)
+            ppt = numpy.zeros((self.Nt, ham.dim), dtype=REAL)
             ppt[0, :] = ppi
 
             # RR0 = numpy.zeros((ham.dim, ham.dim, self.Nt))

--- a/quantarhei/qm/propagators/rdmpropagator.py
+++ b/quantarhei/qm/propagators/rdmpropagator.py
@@ -19,14 +19,13 @@ author: Tomas Mancal, Charles University
 import numpy
 import numpy.linalg
 
-import quantarhei as qr
-
-from ... import COMPLEX
+from ... import COMPLEX, REAL
 from ...core.managers import Manager, energy_units
 from ...core.matrixdata import MatrixData
 from ...core.saveable import Saveable
 from ...core.time import TimeAxis, TimeDependent
 from ...spectroscopy.labsetup import LabSetup
+from ...utils.logging import LOG_QUICK, log_detail, loglevels2bool, printlog
 from ..hilbertspace.hamiltonian import Hamiltonian
 from ..hilbertspace.operators import DensityMatrix, Operator, ReducedDensityMatrix
 from ..liouvillespace.redfieldtensor import RelaxationTensor
@@ -720,12 +719,12 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         #     HH = self.Hamiltonian.data
         HH = self._INIT_RWA()
 
-        qr.log_detail(
+        log_detail(
             "PROPAGATION (short exponential with relaxation in operator form): order ",
             L,
             verbose=self.verbose,
         )
-        qr.log_detail("Using complex numpy implementation")
+        log_detail("Using complex numpy implementation")
 
         Km = self.RelaxationTensor.Km  # real
         Lm = self.RelaxationTensor.Lm  # complex
@@ -737,8 +736,8 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         indx = 1
 
-        levs = [qr.LOG_QUICK]  # , 8]
-        verb = qr.loglevels2bool(levs)
+        levs = [LOG_QUICK]  # , 8]
+        verb = loglevels2bool(levs)
 
         # after each step we apply pure dephasing (if present)
         if self.has_PDeph:
@@ -752,7 +751,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
             # loop over time
             for ii in range(1, self.Nt):
-                qr.printlog(
+                printlog(
                     " time step ", ii, "of", self.Nt, verbose=verb[0], loglevel=levs[0]
                 )
 
@@ -797,7 +796,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         else:
             # loop over time
             for ii in range(1, self.Nt):
-                qr.printlog(
+                printlog(
                     " time step ", ii, "of", self.Nt, verbose=verb[0], loglevel=levs[0]
                 )
 
@@ -828,7 +827,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
                 pr.data[indx, :, :] = rho2
                 indx += 1
 
-        qr.log_detail("...DONE")
+        log_detail("...DONE")
 
         # if self.Hamiltonian.has_rwa:
         #    pr.is_in_rwa = True
@@ -1487,7 +1486,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
             # upper and lower triagle
             N = self.Hamiltonian.dim
-            Mu: numpy.ndarray = numpy.zeros((N, N), dtype=qr.REAL)
+            Mu: numpy.ndarray = numpy.zeros((N, N), dtype=REAL)
             for ii in range(N):
                 for jj in range(ii + 1, N):
                     Mu[ii, jj] = 1.0

--- a/quantarhei/spectroscopy/diagramatics.py
+++ b/quantarhei/spectroscopy/diagramatics.py
@@ -6,9 +6,7 @@ from typing import Any
 
 import numpy
 
-import quantarhei as qr
-
-# from ..core.units import cm2int
+from .. import REAL
 from ..core.managers import UnitsManaged
 from ..utils.types import Integer
 
@@ -292,9 +290,9 @@ class liouville_pathway(UnitsManaged):
 
         if interval > 0:
             if self.widths is None:
-                self.widths = numpy.zeros(4, qr.REAL)
+                self.widths = numpy.zeros(4, REAL)
                 self.widths[:] = -1.0
-                self.dephs = numpy.zeros(4, qr.REAL)
+                self.dephs = numpy.zeros(4, REAL)
                 self.dephs[:] = -1.0
             # transition width
             self.widths[interval] = width

--- a/quantarhei/spectroscopy/pathwayanalyzer.py
+++ b/quantarhei/spectroscopy/pathwayanalyzer.py
@@ -34,6 +34,7 @@ from ..core.parcel import load_parcel
 from ..core.time import TimeAxis
 from ..core.units import cm2int, convert
 from ..core.wrappers import deprecated
+from .twodcontainer import TwoDSpectrumContainer
 
 
 class LiouvillePathwayAnalyzer(UnitsManaged):
@@ -667,8 +668,6 @@ def get_TwoDSpectrumContainer_from_saved_pathways(
     tag_type: Any = REAL,
 ) -> Any:
     """Returns a container with 2D spectra calculated from saved pathways"""
-    from .twodcontainer import TwoDSpectrumContainer
-
     t2s = look_for_pathways(name=name, ext=ext, directory=directory)
 
     # order t2s

--- a/quantarhei/spectroscopy/pumpprobe.py
+++ b/quantarhei/spectroscopy/pumpprobe.py
@@ -7,8 +7,6 @@ import matplotlib.pyplot as plt
 import numpy
 import scipy
 
-from quantarhei import convert
-
 from .. import COMPLEX
 from ..builders.aggregates import Aggregate
 from ..builders.molecules import Molecule
@@ -16,6 +14,7 @@ from ..core.dfunction import DFunction
 from ..core.frequency import FrequencyAxis
 from ..core.managers import Manager, energy_units
 from ..core.time import TimeAxis
+from ..core.units import convert
 from ..utils import derived_type
 from .mocktwodcalculator import MockTwoDResponseCalculator as MockTwoDSpectrumCalculator
 from .twodcontainer import TwoDSpectrumContainer

--- a/quantarhei/spectroscopy/pumpprobe2.py
+++ b/quantarhei/spectroscopy/pumpprobe2.py
@@ -7,8 +7,6 @@ import matplotlib.pyplot as plt
 import numpy
 import scipy
 
-from quantarhei import convert
-
 from .. import COMPLEX
 from ..builders.aggregates import Aggregate
 from ..builders.molecules import Molecule
@@ -16,6 +14,7 @@ from ..core.dfunction import DFunction
 from ..core.frequency import FrequencyAxis
 from ..core.managers import Manager, energy_units
 from ..core.time import TimeAxis
+from ..core.units import convert
 from ..utils import derived_type
 from .mocktwodcalculator import MockTwoDResponseCalculator as MockTwoDSpectrumCalculator
 from .twodcontainer import TwoDSpectrumContainer

--- a/quantarhei/spectroscopy/twod22.py
+++ b/quantarhei/spectroscopy/twod22.py
@@ -17,8 +17,7 @@ from typing import IO, Any
 import matplotlib.pyplot as plt
 import numpy
 
-import quantarhei as qr
-
+from .. import COMPLEX
 from ..builders.aggregates import Aggregate
 from ..builders.molecules import Molecule
 from ..core.frequency import FrequencyAxis
@@ -1429,7 +1428,7 @@ class MockTwoDSpectrumCalculator(TwoDSpectrumCalculator):
         # print(shape, widthx, widthy)
 
         if pathway.pathway_type == "R":
-            reph2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=qr.COMPLEX)
+            reph2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)
 
             if shape == "Gaussian":
                 oo3 = self.oa3.data[:]
@@ -1459,7 +1458,7 @@ class MockTwoDSpectrumCalculator(TwoDSpectrumCalculator):
             return reph2D
 
         if pathway.pathway_type == "NR":
-            nonr2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=qr.COMPLEX)
+            nonr2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)
 
             if shape == "Gaussian":
                 oo3 = self.oa3.data[:]

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -5,12 +5,11 @@ from typing import Any, Literal
 
 import numpy
 
-import quantarhei as qr
-
 from .. import REAL, signal_NONR, signal_REPH
 from ..builders.aggregates import Aggregate
 from ..builders.molecules import Molecule
 from ..builders.opensystem import OpenSystem
+from ..core.managers import Manager, energy_units
 from ..core.time import TimeAxis
 from ..implementations.aceto.lab_settings import lab_settings
 from ..qm.propagators.poppropagator import PopulationPropagator
@@ -141,9 +140,9 @@ class TwoDResponseCalculator:
         self.pad = pad
         self.write_resp = write_resp
         self.keep_resp = keep_resp
-        self.rwa = qr.Manager().convert_energy_2_internal_u(rwa)
+        self.rwa = Manager().convert_energy_2_internal_u(rwa)
 
-        with qr.energy_units("int"):
+        with energy_units("int"):
             if self.write_resp:
                 try:
                     if isinstance(write_resp, str):
@@ -348,16 +347,16 @@ class TwoDResponseCalculator:
             self.resp_fcions = []
 
             # basic pathways
-            Nr1g = qr.NonLinearResponse(
+            Nr1g = NonLinearResponse(
                 self.lab, self.system, "R1g", self.t1axis, self.t2axis, self.t3axis
             )
-            Nr2g = qr.NonLinearResponse(
+            Nr2g = NonLinearResponse(
                 self.lab, self.system, "R2g", self.t1axis, self.t2axis, self.t3axis
             )
-            Nr3g = qr.NonLinearResponse(
+            Nr3g = NonLinearResponse(
                 self.lab, self.system, "R3g", self.t1axis, self.t2axis, self.t3axis
             )
-            Nr4g = qr.NonLinearResponse(
+            Nr4g = NonLinearResponse(
                 self.lab, self.system, "R4g", self.t1axis, self.t2axis, self.t3axis
             )
 
@@ -368,10 +367,10 @@ class TwoDResponseCalculator:
 
             if self.system.mult > 1:
                 # ESA (if mult > 1)
-                Nr1f = qr.NonLinearResponse(
+                Nr1f = NonLinearResponse(
                     self.lab, self.system, "R1f", self.t1axis, self.t2axis, self.t3axis
                 )
-                Nr2f = qr.NonLinearResponse(
+                Nr2f = NonLinearResponse(
                     self.lab, self.system, "R2f", self.t1axis, self.t2axis, self.t3axis
                 )
 
@@ -379,7 +378,7 @@ class TwoDResponseCalculator:
                 self.resp_fcions.append(Nr2f)
 
             # relaxation (if relax neq 0)
-            Nr1g_scM0g = qr.NonLinearResponse(
+            Nr1g_scM0g = NonLinearResponse(
                 self.lab,
                 self.system,
                 "R1g_scM0g",
@@ -387,7 +386,7 @@ class TwoDResponseCalculator:
                 self.t2axis,
                 self.t3axis,
             )
-            Nr2g_scM0g = qr.NonLinearResponse(
+            Nr2g_scM0g = NonLinearResponse(
                 self.lab,
                 self.system,
                 "R2g_scM0g",
@@ -406,7 +405,7 @@ class TwoDResponseCalculator:
                 self.resp_fcions.append(Nr2g_scM0g)
 
             if self.system.mult > 1:
-                Nr1f_scM0g = qr.NonLinearResponse(
+                Nr1f_scM0g = NonLinearResponse(
                     self.lab,
                     self.system,
                     "R1f_scM0g",
@@ -414,7 +413,7 @@ class TwoDResponseCalculator:
                     self.t2axis,
                     self.t3axis,
                 )
-                Nr2f_scM0g = qr.NonLinearResponse(
+                Nr2f_scM0g = NonLinearResponse(
                     self.lab,
                     self.system,
                     "R2f_scM0g",
@@ -422,7 +421,7 @@ class TwoDResponseCalculator:
                     self.t2axis,
                     self.t3axis,
                 )
-                Nr1f_scM0e = qr.NonLinearResponse(
+                Nr1f_scM0e = NonLinearResponse(
                     self.lab,
                     self.system,
                     "R1f_scM0e",
@@ -430,7 +429,7 @@ class TwoDResponseCalculator:
                     self.t2axis,
                     self.t3axis,
                 )
-                Nr2f_scM0e = qr.NonLinearResponse(
+                Nr2f_scM0e = NonLinearResponse(
                     self.lab,
                     self.system,
                     "R2f_scM0e",

--- a/quantarhei/utils/logging.py
+++ b/quantarhei/utils/logging.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import traceback
 from typing import Any
 
-import quantarhei as qr
+from quantarhei.core.managers import Manager
+
+LOG_URGENT = 1
+LOG_REPORT = 3
+LOG_INFO = 5
+LOG_DETAIL = 7
+LOG_QUICK = 9
 
 
 def init_logging() -> None:
@@ -14,7 +20,7 @@ def init_logging() -> None:
     We test if the logging is parallel or not
 
     """
-    manager = qr.Manager().log_conf
+    manager = Manager().log_conf
     try:
         from mpi4py import MPI
 
@@ -32,25 +38,25 @@ def init_logging() -> None:
 
 
 def log_urgent(*args: Any, **kwargs: Any) -> None:
-    printlog(*args, loglevel=qr.LOG_URGENT, **kwargs)
+    printlog(*args, loglevel=LOG_URGENT, **kwargs)
 
 
 def log_report(*args: Any, **kwargs: Any) -> None:
-    printlog(*args, loglevel=qr.LOG_REPORT, **kwargs)
+    printlog(*args, loglevel=LOG_REPORT, **kwargs)
 
 
 def log_info(*args: Any, **kwargs: Any) -> None:
-    printlog(*args, loglevel=qr.LOG_INFO, **kwargs)
+    printlog(*args, loglevel=LOG_INFO, **kwargs)
 
 
 def log_detail(*args: Any, **kwargs: Any) -> None:
-    printlog(*args, loglevel=qr.LOG_DETAIL, **kwargs)
+    printlog(*args, loglevel=LOG_DETAIL, **kwargs)
 
 
 def log_quick(*args: Any, verbose: bool = True, **kwargs: Any) -> None:
     if not verbose:
         return
-    printlog(*args, loglevel=qr.LOG_QUICK, **kwargs)
+    printlog(*args, loglevel=LOG_QUICK, **kwargs)
 
 
 def printlog(
@@ -113,7 +119,7 @@ def printlog(
     if (loglevel > 10) or (loglevel < 0):
         raise Exception("Loglevel must be between 0 and 10")
 
-    manager = qr.Manager().log_conf
+    manager = Manager().log_conf
     if not manager.initialized:
         init_logging()
 
@@ -176,7 +182,7 @@ def loglevels2bool(loglevs: list[int], verbose: bool = False) -> list[bool]:
     --------
     Standard usage:
 
-    >>> m = qr.Manager()
+    >>> m = Manager()
     >>> m.verbosity = 5
     >>> bools = loglevels2bool([0, 2, 5, 8, 10], verbose=True)
     >>> print(bools)
@@ -185,7 +191,7 @@ def loglevels2bool(loglevs: list[int], verbose: bool = False) -> list[bool]:
     Do not forget to set verbose to True. It is False by default
     to avoid lengthy evaluation when not required
 
-    >>> m = qr.Manager()
+    >>> m = Manager()
     >>> m.verbosity = 5
     >>> bools = loglevels2bool([0, 2, 5, 8, 10])
     >>> print(bools)
@@ -195,7 +201,7 @@ def loglevels2bool(loglevs: list[int], verbose: bool = False) -> list[bool]:
     verb = [False] * len(loglevs)
 
     if verbose:
-        m = qr.Manager().log_conf
+        m = Manager().log_conf
         k_v = 0
         for lev in loglevs:
             if m.verbosity > lev:
@@ -236,7 +242,7 @@ def tprint(var: str, messg: str | None = None, default: Any = None) -> None:
 
 def log_to_file(filename: str = "qrhei.log") -> None:
     """Set logging to file"""
-    manager = qr.Manager().log_conf
+    manager = Manager().log_conf
     # manager.log_on_screen = False
     manager.log_to_file = True
     manager.log_file_name = filename


### PR DESCRIPTION
## Summary

Lifts the deferred intra-package imports that are safe to move to module level — i.e. where no actual import cycle exists. Remaining deferred imports are left intentionally with an explanation.

**Lifted:**
- `core/time.py` → `core/frequency.py`: `FrequencyAxis` was behind `TYPE_CHECKING` guard; lifted to a real module-level import
- `spectroscopy/pathwayanalyzer.py` → `spectroscopy/twodcontainer.py`: `TwoDSpectrumContainer` was deferred inside `get_TwoDSpectrumContainer_from_saved_pathways`; lifted to module level

**Kept deferred (with reason):**
- `core/frequency.py` → `core/time.py`: mutual with `time.py → frequency.py`; lifting both causes `ImportError` on partial initialization. One direction is now at module level; the other stays deferred.
- `builders/opensystem.py`, `qm/lindbladform.py`, `qm/puredephasing.py`, `qm/systembathinteraction.py`: genuine `builders ↔ qm` cycle — resolving requires the layer separation work in #301

## Test plan

- [ ] All 177 unit tests pass
- [ ] `import quantarhei` succeeds
- [ ] mypy pre-commit hook passes

Fixes #270