### PR TITLE
#323 fix: CircDichSpectrumCalculator drops rot_dip weighting on first exciton transition

### DIFF
--- a/quantarhei/spectroscopy/circular_dichroism.py
+++ b/quantarhei/spectroscopy/circular_dichroism.py
@@ -830,11 +830,6 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
         rot_dip = self._excitonic_rot_dip(SS, self.system, 0)
         data = rot_dip * numpy.real(self.one_transition_spectrum(tr))
 
-        #
-        # Calculates spectrum of a single transition
-        #
-        data = numpy.real(self.one_transition_spectrum(tr))
-
         for ii in range(2, HH.dim):
             if relaxation_tensor is not None:
                 tr["gg"] = gg[ii]


### PR DESCRIPTION
## Summary

Fixes #323.

`_calculate_aggregate` computed the rotational-strength-weighted spectrum for the first exciton transition and then immediately overwrote it with an unweighted spectrum. All subsequent transitions in the loop were correctly weighted. The result was that the first exciton transition always contributed with weight 1 regardless of geometry, making it impossible to get a zero CD signal for achiral aggregates.

## Change

`quantarhei/spectroscopy/circular_dichroism.py` — remove the three lines that overwrite `data` after the `rot_dip`-weighted assignment.

Before:
```python
rot_dip = self._excitonic_rot_dip(SS, self.system, 0)
data = rot_dip * numpy.real(self.one_transition_spectrum(tr))

#
# Calculates spectrum of a single transition
#
data = numpy.real(self.one_transition_spectrum(tr))   # ← bug: overwrites above
```

After:
```python
rot_dip = self._excitonic_rot_dip(SS, self.system, 0)
data = rot_dip * numpy.real(self.one_transition_spectrum(tr))
```

## Verification

Achiral parallel dimer (μ₁ = μ₂ = [1,0,0], cross product = 0, rot_dip = 0):
- Before fix: max|CD| ≈ 84 (spurious signal)
- After fix: max|CD| = 0.0 ✓

Chiral helical dimer (μ₁=[1,0,0], μ₂=[0,1,0], R₁₂=[0,0,5]Å):
- After fix: bisignate spectrum, max = +261, min = −255 ✓