### PR TITLE
#324 fix: initialise Molecule._position to None to prevent AttributeError on first read

### DIFF
--- a/quantarhei/builders/molecules.py
+++ b/quantarhei/builders/molecules.py
@@ -132,6 +132,8 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         OpenSystem.__init__(self, elenergies)
         # self.manager = Manager()
 
+        self._position = None
+
         # monomer name
         if name is None:
             # FIXME: generate unique name


### PR DESCRIPTION
## Summary

Fixes #324.

`Molecule.position` is declared as `array_property("position", shape=(3,))`. The property getter does `getattr(self, "_position")`, but `_position` was never initialised in `__init__`. Reading `molecule.position` on a freshly constructed molecule raised:

```
AttributeError: 'Molecule' object has no attribute '_position'
```

This surfaced in `CircDichSpectrumCalculator._excitonic_rot_dip` (line 748) when any monomer in the aggregate had not had its position explicitly set.

## Change

`quantarhei/builders/molecules.py` — add `self._position = None` immediately after `OpenSystem.__init__()`.

## Verification

```python
import quantarhei as qr
m = qr.Molecule([0.0, 12000.0])
print(m.position)   # None  (was: AttributeError)

import numpy as np
m.position = np.array([1.0, 2.0, 3.0])
print(m.position)   # [1. 2. 3.]
```

All 16 existing doctests in `molecules.py` continue to pass (the module docstring already shows `position = None` in the printed representation).