### PR TITLE
#325 fix: secular Redfield propagator converges to Boltzmann steady state

### DIFF
--- a/quantarhei/qm/liouvillespace/relaxationtensor.py
+++ b/quantarhei/qm/liouvillespace/relaxationtensor.py
@@ -70,6 +70,8 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
                                     ):
                                         self.data[:, ii, jj, kk, ll] = 0
 
+            self.is_secular = True
+
         else:
             super().secularize()
 

--- a/quantarhei/qm/propagators/rdmpropagator.py
+++ b/quantarhei/qm/propagators/rdmpropagator.py
@@ -530,6 +530,14 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         else:
             HH = self.Hamiltonian.data
 
+        # Secular relaxation tensors zero off-diagonal Liouville elements so
+        # that population dynamics decouple from coherences.  The commutator
+        # step must therefore use only the diagonal part of H; off-diagonal
+        # couplings would otherwise drive persistent coherences that prevent
+        # convergence to the Boltzmann steady state.
+        if self.has_RTensor and getattr(self.RelaxationTensor, "is_secular", False):
+            HH = numpy.diag(numpy.diag(HH))
+
         if self.has_NonHerm:
             HH = HH + 1j * self.NonHerm
 

--- a/tests/unit/qm/propagators/test_redfield_boltzmann.py
+++ b/tests/unit/qm/propagators/test_redfield_boltzmann.py
@@ -1,0 +1,120 @@
+"""Regression tests for issue #325.
+
+The secular Redfield propagator used to converge to near-equipartition instead
+of the Boltzmann distribution because it used the non-diagonal site-basis
+Hamiltonian in the commutator step.
+
+Root cause (fixed)
+------------------
+``eigenbasis_of(H)`` tells *operator constructors* (RedfieldRelaxationTensor,
+etc.) to build their tensors in the eigenbasis but does NOT transform
+``H.data`` itself.  The propagator's ``_COM`` step used ``H.data`` directly,
+including the off-diagonal coupling J, which drove persistent coherences and
+prevented relaxation to the Boltzmann steady state.
+
+Fix
+---
+``ReducedDensityMatrixPropagator._INIT_RWA`` now detects a secularized
+relaxation tensor (``RelaxationTensor.is_secular``) and strips off-diagonal
+elements from H before the commutator loop.  The legacy ``secularize()`` path
+in ``RelaxationTensor`` was also fixed to set ``is_secular = True`` so the
+detection works.
+
+Additional note
+---------------
+Populations must be extracted from ``rhot.data`` *inside* the
+``eigenbasis_of(H)`` context.  Accessing ``rhot.data`` after the context exits
+triggers a basis back-transform that mixes populations and coherences, giving
+incorrect ratios in the site basis.
+"""
+
+import numpy
+import scipy.linalg as la
+
+import quantarhei as qr
+
+
+def _make_heterodimer_redfield(ta):
+    cpar = dict(
+        ftype="OverdampedBrownian",
+        reorg=20.0,
+        cortime=100.0,
+        T=300.0,
+        matsubara=20,
+    )
+    with qr.energy_units("1/cm"):
+        cfce = qr.CorrelationFunction(ta, cpar)
+        m1 = qr.Molecule([0.0, 12000.0])
+        m2 = qr.Molecule([0.0, 12300.0])
+    m1.set_transition_environment((0, 1), cfce)
+    m2.set_transition_environment((0, 1), cfce)
+    agg = qr.Aggregate(molecules=[m1, m2])
+    with qr.energy_units("1/cm"):
+        agg.set_resonance_coupling(0, 1, 100.0)
+    agg.build()
+    H = agg.get_Hamiltonian()
+    sbi = agg.get_SystemBathInteraction()
+    return H, sbi
+
+
+class TestRedfieldBoltzmann:
+    """#325 — secular Redfield steady-state population tests."""
+
+    def test_rate_matrix_satisfies_detailed_balance(self):
+        """Rate matrix satisfies detailed balance: k_up/k_down = exp(-dE/kT)."""
+        ta = qr.TimeAxis(0.0, 1001, 2.0)
+        H, sbi = _make_heterodimer_redfield(ta)
+
+        H.protect_basis()
+        with qr.eigenbasis_of(H):
+            RRT = qr.qm.RedfieldRelaxationTensor(H, sbi)
+            RRT.secularize()
+            k_down = numpy.real(RRT.data[1, 1, 2, 2])
+            k_up = numpy.real(RRT.data[2, 2, 1, 1])
+        H.unprotect_basis()
+
+        evals = sorted([qr.convert(e, "int", "1/cm") for e in la.eigvalsh(H.data)])
+        dE = abs(evals[2] - evals[1])
+        kB, T = 0.695, 300.0
+        expected = numpy.exp(-dE / (kB * T))
+
+        assert k_down > 0 and k_up > 0
+        assert abs(k_up / k_down - expected) / expected < 0.05
+
+    def test_propagator_converges_to_boltzmann(self):
+        """Secular Redfield propagation should relax to the Boltzmann distribution."""
+        ta = qr.TimeAxis(0.0, 6001, 2.0)
+        H, sbi = _make_heterodimer_redfield(ta)
+
+        H.protect_basis()
+        with qr.eigenbasis_of(H):
+            RRT = qr.qm.RedfieldRelaxationTensor(H, sbi)
+            RRT.secularize()
+            rho0 = qr.ReducedDensityMatrix(dim=H.dim)
+            rho0.data[2, 2] = 1.0
+            prop = qr.ReducedDensityMatrixPropagator(ta, H, RRT)
+            rhot = prop.propagate(rho0)
+
+            # Extract populations in the eigenbasis while still inside the context.
+            # Accessing rhot.data outside the context triggers a basis back-transform
+            # that mixes populations and coherences, giving incorrect ratios.
+            n = rhot.data.shape[0]
+            tail = max(1, n // 10)
+            p1 = float(
+                numpy.mean([numpy.real(rhot.data[k, 1, 1]) for k in range(n - tail, n)])
+            )
+            p2 = float(
+                numpy.mean([numpy.real(rhot.data[k, 2, 2]) for k in range(n - tail, n)])
+            )
+        H.unprotect_basis()
+
+        evals = sorted([qr.convert(e, "int", "1/cm") for e in la.eigvalsh(H.data)])
+        dE = abs(evals[2] - evals[1])
+        kB, T = 0.695, 300.0
+        expected = numpy.exp(-dE / (kB * T))
+
+        assert p1 > 0 and p2 > 0
+        ratio = p2 / p1
+        assert abs(ratio - expected) / expected < 0.05, (
+            f"p2/p1={ratio:.4f}, expected {expected:.4f} (dE={dE:.1f} cm⁻¹, T={T} K)"
+        )


### PR DESCRIPTION
Fixes #325.

## Summary

Two complementary fixes that together make the secular Redfield propagator converge to the correct Boltzmann steady-state populations:

**1. `RelaxationTensor.secularize()` sets `is_secular = True` (legacy path)**

The legacy `secularize()` override in `RelaxationTensor` zeroed non-secular Liouville elements but never set `self.is_secular = True`. The flag stayed `False` even after secularization, so downstream detection was blind to it.

**2. `ReducedDensityMatrixPropagator._INIT_RWA()` strips off-diagonal H for secular tensors**

When `is_secular` is `True`, the commutator step now uses `numpy.diag(numpy.diag(H))` instead of the full `H`. This prevents the off-diagonal coupling J from driving persistent coherences between exciton states — coherences that were preventing convergence to the Boltzmann distribution.

## Root cause (recap from #325)

`eigenbasis_of(H)` tells operator constructors to build tensors in the eigenbasis but does **not** transform `H.data`. The propagator's `_COM` step used the site-basis `H` (off-diagonal J = 100 cm⁻¹), which drove coherences even after secularization, preventing populations from relaxing to the Boltzmann steady state.

## Test

`tests/unit/qm/propagators/test_redfield_boltzmann.py` (new):
- `test_rate_matrix_satisfies_detailed_balance` — rate matrix k_up/k_down ≈ exp(-ΔE/kT) within 5%
- `test_propagator_converges_to_boltzmann` — propagated p₂/p₁ converges to exp(-ΔE/kT) within 5% after 12 ps

**Note for reviewers:** populations must be extracted inside the `eigenbasis_of(H)` context. Outside the context, accessing `rhot.data` triggers a basis back-transform that mixes populations and coherences in the site basis, giving incorrect ratios. The test documents this explicitly.