### PR TITLE
#197 docs: add NumPy docstring style guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,42 @@ uv run mypy quantarhei/
 
 Configuration lives in `[tool.mypy]` in `pyproject.toml`. The entire package is annotated and `mypy quantarhei/` should exit with `Success: no issues found`.
 
+## Docstring style
+
+All new and updated docstrings should follow **NumPy style**. This is the convention used by NumPy, SciPy, and the rest of the scientific Python ecosystem. It renders correctly with the `numpydoc` Sphinx extension already enabled in `docs/sphinx/conf.py`.
+
+```python
+def some_method(self, val, units="1/cm"):
+    """Convert a value to internal units.
+
+    Parameters
+    ----------
+    val : float or numpy.ndarray
+        Value to convert.
+    units : str, optional
+        Unit string. Default is ``"1/cm"``.
+
+    Returns
+    -------
+    float or numpy.ndarray
+        Value in internal units.
+
+    Raises
+    ------
+    UnitsError
+        If ``units`` is not a recognized unit string.
+    """
+```
+
+Key conventions:
+- One-line summary on the opening `"""` line
+- If a description follows, separate it from the summary with a blank line
+- Section names (`Parameters`, `Returns`, `Raises`, `Notes`, `Examples`) are underlined with dashes of the same length
+- Parameter types go after a colon; mark optional parameters with `, optional`
+- Use double backticks for inline code inside docstrings
+
+Full reference: [NumPy docstring guide](https://numpydoc.readthedocs.io/en/latest/format.html)
+
 ## Submitting changes
 
 1. Fork the repository and create a feature branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ ignore = [
     # A statement like `x.attr` with no assignment or call — probably dead code
     # or a typo. Needs human review to confirm it is safe to delete.
     "B018",
+
 ]
 
 [tool.mypy]

--- a/quantarhei/__init__.py
+++ b/quantarhei/__init__.py
@@ -578,7 +578,13 @@ from .wizard.input.input import Input as Input
 
 
 def exit(msg: str | None = None) -> None:
-    """Exit to the level above the script with SystemExit exception"""
+    """Exit to the level above the script by raising :exc:`SystemExit`.
+
+    Parameters
+    ----------
+    msg : str or None, optional
+        Optional message to log before exiting. Default is ``None``.
+    """
     import sys
 
     if msg is not None:
@@ -587,14 +593,27 @@ def exit(msg: str | None = None) -> None:
 
 
 def stop(msg: str | None = None) -> None:
-    """Stop execution and leave to level above"""
+    """Stop execution and exit to the level above.
+
+    Parameters
+    ----------
+    msg : str or None, optional
+        Ignored; present for API compatibility. Default is ``None``.
+    """
     exit("Execution stopped")
 
 
 def show_plot(block: bool = True) -> None:
-    """Shows current plot
+    """Show the current matplotlib plot.
 
-    This function is used to avoid explicit import of matplotlib
+    Convenience wrapper around ``matplotlib.pyplot.show`` that avoids an
+    explicit import of ``matplotlib``.
+
+    Parameters
+    ----------
+    block : bool, optional
+        If ``True``, block until the plot window is closed. Default is
+        ``True``.
     """
     import matplotlib.pyplot as plt
 
@@ -602,9 +621,15 @@ def show_plot(block: bool = True) -> None:
 
 
 def savefig(fname: str) -> None:
-    """Saves current plot to a file
+    """Save the current matplotlib plot to a file.
 
-    This function is used to avoid explicit import of matplotlib
+    Convenience wrapper around ``matplotlib.pyplot.savefig`` that avoids an
+    explicit import of ``matplotlib``.
+
+    Parameters
+    ----------
+    fname : str
+        Output file path (format inferred from the extension).
     """
     import matplotlib.pyplot as plt
 
@@ -612,7 +637,20 @@ def savefig(fname: str) -> None:
 
 
 def assert_version(check: str, vno: str) -> None:
-    """Throws an exception if the condition is not satisfied"""
+    """Assert that the installed Quantarhei version satisfies a version constraint.
+
+    Parameters
+    ----------
+    check : str
+        Comparison operator string: ``">="``, ``"=="``, or ``"<="``.
+    vno : str
+        Version string to compare against (e.g. ``"0.0.63"``).
+
+    Raises
+    ------
+    SystemExit
+        If the version constraint is not satisfied.
+    """
     from packaging import version
 
     def ext() -> None:

--- a/quantarhei/builders/aggregates.py
+++ b/quantarhei/builders/aggregates.py
@@ -38,10 +38,18 @@ from .aggregate_pdeph import AggregatePureDephasing
 
 
 class Aggregate(AggregatePureDephasing):
-    """This clas wraps up the definition of the Aggregate class. It is the end
-    of a long series of mutually inheriting classes starting with
-    AggregateBase.
+    """Tightly organized molecular aggregate such as a photosynthetic antenna.
 
+    Combines a collection of :class:`~quantarhei.builders.molecules.Molecule`
+    objects into a coupled system and provides a unified interface for
+    building Hamiltonians, computing spectra, and simulating dynamics.
+    This class is the final layer in a hierarchy of inheriting classes that
+    starts with ``AggregateBase``.
+
+    Notes
+    -----
+    Call :meth:`build` after adding all molecules and setting all parameters
+    before using any calculation methods.
     """
 
     pass

--- a/quantarhei/builders/disorder.py
+++ b/quantarhei/builders/disorder.py
@@ -6,6 +6,34 @@ import numpy
 
 
 class Disorder:
+    """Diagonal energetic disorder model for excitonic Hamiltonians.
+
+    Draws random site-energy offsets from a specified distribution and
+    applies them to the diagonal elements of a Hamiltonian on each
+    disorder realisation.
+
+    Parameters
+    ----------
+    data : numpy.ndarray
+        Reference Hamiltonian data array whose diagonal entries are used as
+        the unperturbed site energies.
+    distribution : str, optional
+        Statistical distribution for the disorder. Currently only
+        ``"Gaussian"`` is supported. Default is ``"Gaussian"``.
+    dtype : str, optional
+        Type of disorder. Currently only ``"diagonal"`` (site-energy
+        disorder) is supported. Default is ``"diagonal"``.
+    seed : int or None, optional
+        Seed for the NumPy random-number generator. Default is ``None``
+        (random seed).
+
+    Raises
+    ------
+    Exception
+        If ``data`` is ``None``, or if an unknown distribution or disorder
+        type is requested.
+    """
+
     def __init__(
         self,
         data: numpy.ndarray | None = None,

--- a/quantarhei/builders/molecules.py
+++ b/quantarhei/builders/molecules.py
@@ -91,19 +91,19 @@ from .opensystem import OpenSystem
 
 
 class Molecule(UnitsManaged, Saveable, OpenSystem):
-    """Multi-level molecule (monomer)
+    """Multi-level molecule (monomer).
 
+    Represents a single chromophore with multiple electronic states, optional
+    vibrational modes, and system-bath coupling. It is the basic building
+    block for constructing molecular aggregates.
 
     Parameters
     ----------
-    name : str
-        Monomer descriptor; a string identifying the monomer
-
-    elenergies : list of real numbers
-        List of electronic energies, one per state. It includes ground state
-        energy. It wise to chose the ground state energy as zero.
-
-
+    elenergies : list of float, optional
+        Electronic state energies in the current energy units, starting
+        with the ground state (typically ``0.0``). Default is ``[0.0, 1.0]``.
+    name : str, optional
+        Human-readable label for the molecule. Default is ``''``.
     """
 
     # position of the monomer

--- a/quantarhei/builders/opensystem.py
+++ b/quantarhei/builders/opensystem.py
@@ -16,14 +16,18 @@ from ..utils import array_property
 
 
 class OpenSystem:
-    """The class representing a general open quantum system
+    """General open quantum system.
 
-    It provides routines to store and extract the most interesting
-    characteristics of an open qwuantum system, such as the Hamiltonian,
-    SystemBathInteraction object, relaxation tensor and the reduced density
-    matrix evolution.
+    Provides routines to store and retrieve the key characteristics of an
+    open quantum system, such as the Hamiltonian, ``SystemBathInteraction``
+    object, relaxation tensor, and reduced density matrix evolution.
 
-
+    Parameters
+    ----------
+    elen : list
+        Nested list (or flat list) of electronic state energies. Each
+        sub-list defines one excitation band; a flat entry defines a
+        single-state band.
     """
 
     # energies of electronic states
@@ -189,19 +193,21 @@ class OpenSystem:
         raise Exception("Aggregate object not built")
 
     def set_transition_environment(self, transition: tuple, egcf: object) -> None:
-        """Sets a correlation function for a transition on this monomer
+        """Set a correlation function for a transition.
 
         Parameters
         ----------
         transition : tuple
-            A tuple describing a transition in the molecule, e.g. (0,1) is
-            a transition from the ground state to the first excited state.
-
+            Pair of state indices describing the transition, e.g. ``(0, 1)``
+            for the ground-to-first-excited-state transition.
         egcf : CorrelationFunction
-            CorrelationFunction object
+            Correlation function assigned to the transition.
 
-        (Should go to Open System)
-
+        Raises
+        ------
+        Exception
+            If the system is mapped onto a ``CorrelationFunctionMatrix`` or
+            if a correlation function is already set for this transition.
         """
         if self._is_mapped_on_egcf_matrix:
             raise Exception("This system is mapped on a CorrelationFunctionMatrix")
@@ -216,18 +222,19 @@ class OpenSystem:
             raise Exception("Correlation function already speficied for this monomer")
 
     def unset_transition_environment(self, transition: tuple) -> None:
-        """Unsets correlation function from a transition on this monomer
+        """Remove the correlation function assigned to a transition.
 
-        This is needed if the environment is to be replaced
+        This is needed when the environment needs to be replaced.
 
         Parameters
         ----------
         transition : tuple
-            A tuple describing a transition in the molecule, e.g. (0,1) is
-            a transition from the ground state to the first excited state.
+            Pair of state indices describing the transition, e.g. ``(0, 1)``.
 
-        (Should go to OpenSystem)
-
+        Raises
+        ------
+        Exception
+            If the system is mapped onto a ``CorrelationFunctionMatrix``.
         """
         if self._is_mapped_on_egcf_matrix:
             raise Exception("This monomer is mapped on a CorrelationFunctionMatrix")
@@ -240,16 +247,22 @@ class OpenSystem:
         self._has_system_bath_coupling = False
 
     def get_transition_environment(self, transition: tuple) -> object:
-        """Returns energy gap correlation function of a monomer
+        """Return the correlation function assigned to a transition.
 
         Parameters
         ----------
         transition : tuple
-            A tuple describing a transition in the molecule, e.g. (0,1) is
-            a transition from the ground state to the first excited state.
+            Pair of state indices describing the transition, e.g. ``(0, 1)``.
 
-        (Should go to OpenSystem)
+        Returns
+        -------
+        CorrelationFunction
+            The correlation function for the specified transition.
 
+        Raises
+        ------
+        Exception
+            If no environment is set for the transition.
         """
         if self._has_egcf[self.triangle.locate(transition[0], transition[1])]:
             return self.egcf[self.triangle.locate(transition[0], transition[1])]
@@ -266,28 +279,23 @@ class OpenSystem:
     def set_egcf_mapping(
         self, transition: tuple, correlation_matrix: object, position: int
     ) -> None:
-        """Sets a correlation function mapping for a selected transition.
-
-        The monomer can either have a correlation function assigned to it,
-        or it can be a part of a correlation matrix. Here the mapping to the
-        correlation matrix is specified.
+        """Map a transition to a position in a ``CorrelationFunctionMatrix``.
 
         Parameters
         ----------
         transition : tuple
-            A tuple describing a transition in the molecule, e.g. (0,1) is
-            a transition from the ground state to the first excited state.
-
+            Pair of state indices describing the transition, e.g. ``(0, 1)``.
         correlation_matrix : CorrelationFunctionMatrix
-            An instance of CorrelationFunctionMatrix
-
+            Matrix of correlation functions to map onto.
         position : int
-            Position in the CorrelationFunctionMatrix corresponding
-            to the monomer.
+            Position (row/column index) in ``correlation_matrix`` that
+            corresponds to this system.
 
-
-        (Should go to OpenSystems)
-
+        Raises
+        ------
+        Exception
+            If a direct correlation function is already assigned to this
+            transition.
         """
         if not (self._has_egcf[self.triangle.locate(transition[0], transition[1])]):
             if not (self._is_mapped_on_egcf_matrix):

--- a/quantarhei/builders/pdb.py
+++ b/quantarhei/builders/pdb.py
@@ -15,7 +15,14 @@ _chainId_max = 22
 
 
 class PDBFile:
-    """Represents a PDB file with a protein-pigment complex structure"""
+    """Represents a PDB file containing a protein-pigment complex structure.
+
+    Parameters
+    ----------
+    fname : str or None, optional
+        Path to the PDB file to load. If ``None``, an empty object is created
+        and the file can be loaded later with :meth:`load_file`.
+    """
 
     def __init__(self, fname: str | None = None) -> None:
 
@@ -42,7 +49,18 @@ class PDBFile:
         self._unique_lines = dict()
 
     def load_file(self, fname: str) -> int:
-        """Loads a PDB file"""
+        """Load a PDB file and return the number of lines read.
+
+        Parameters
+        ----------
+        fname : str
+            Path to the PDB file.
+
+        Returns
+        -------
+        int
+            Number of lines read from the file.
+        """
         with open(fname) as file:
             k = 0
             for line in file:
@@ -51,7 +69,19 @@ class PDBFile:
         return k
 
     def get_Molecules(self, model: Any = None) -> list:
-        """Returns all molecules corresponding to a given model"""
+        """Return all molecules matching a given model definition.
+
+        Parameters
+        ----------
+        model : object or None, optional
+            Model object whose ``pdbname`` attribute identifies the residue
+            name to match. If ``None``, returns all stored molecules.
+
+        Returns
+        -------
+        list
+            List of :class:`~quantarhei.Molecule` objects.
+        """
         if model is None:
             return self.molecules
 

--- a/quantarhei/builders/sysmodes.py
+++ b/quantarhei/builders/sysmodes.py
@@ -12,11 +12,20 @@ from .submodes import SubMode
 
 
 class HarmonicMode(SubMode, OpenSystem):
-    """Renaming the SubMode to be used as a standalone Harmonic oscillator mode
+    """Standalone harmonic oscillator mode.
 
+    A thin wrapper around ``SubMode`` that can be used independently as a
+    quantum harmonic oscillator. The potential-energy-surface shift is
+    currently always zero.
 
-    PES shift is always 0 (will be implemented later)
-
+    Parameters
+    ----------
+    omega : float, optional
+        Oscillator frequency in internal units. Default is ``1.0``.
+    shift : float, optional
+        PES shift (currently unused). Default is ``0.0``.
+    nmax : int, optional
+        Maximum number of Fock states to include. Default is ``2``.
     """
 
     def __init__(self, omega: float = 1.0, shift: float = 0.0, nmax: int = 2) -> None:

--- a/quantarhei/builders/sysmodes.py
+++ b/quantarhei/builders/sysmodes.py
@@ -183,7 +183,24 @@ class HarmonicMode(SubMode, OpenSystem):
 
 
 class AnharmonicMode(HarmonicMode):
-    """ """
+    """Anharmonic (Morse-like) oscillator mode.
+
+    An extension of :class:`HarmonicMode` in which the energy levels are
+    corrected for anharmonicity. The ``omega`` parameter specifies the
+    fundamental frequency (energy gap between levels 0 and 1); the
+    underlying harmonic frequency ``om0`` is derived from ``omega`` and the
+    anharmonicity ``xi`` via ``om0 = omega / (1 - 2*xi)``.
+
+    Parameters
+    ----------
+    omega : float, optional
+        Fundamental oscillator frequency (level 1 minus level 0 energy) in
+        internal units. Default is ``1.0``.
+    shift : float, optional
+        Potential-energy-surface shift (currently unused). Default is ``0.0``.
+    nmax : int, optional
+        Maximum number of Fock states to include. Default is ``2``.
+    """
 
     def __init__(self, omega: float = 1.0, shift: float = 0.0, nmax: int = 2) -> None:
         """In this case, omega is the difference between levels 1 and 0"""

--- a/quantarhei/core/dfunction.py
+++ b/quantarhei/core/dfunction.py
@@ -345,20 +345,29 @@ class DFunction(Saveable, DataSaveable):
             raise Exception("Incompatible axis")
 
     def at(self, x: Any, approx: str = "default") -> Any:
-        """Returns the function value at the argument `x`
+        """Return the function value at argument ``x``.
 
-        Returns the value of the function at a given value of argument `x`. The
-        default interpolation is linear, until the spline interpolation is
-        initialized by calling the method with approx = "spline". From then
-        on, the default is spline.
+        The default interpolation is ``'linear'`` until spline interpolation
+        is first requested via ``approx='spline'``, after which ``'spline'``
+        becomes the default.
 
         Parameters
         ----------
-        x : number
-            Function argument
+        x : float
+            Function argument.
+        approx : str, optional
+            Interpolation type: ``'default'``, ``'linear'``, or ``'spline'``.
+            Default is ``'default'``.
 
-        approx : string {"default","linear","spline"}
-            Type of interpolation
+        Returns
+        -------
+        float or complex
+            Interpolated function value at ``x``.
+
+        Raises
+        ------
+        Exception
+            If ``approx`` is not one of the allowed interpolation types.
 
 
         Examples
@@ -542,10 +551,28 @@ class DFunction(Saveable, DataSaveable):
     #
 
     def get_Fourier_transform(self, window: DFunction | None = None) -> DFunction:
-        """Returns Fourier transform of the DFunction
+        """Return the Fourier transform of the DFunction.
 
+        Parameters
+        ----------
+        window : DFunction, optional
+            Window function to multiply the data before transforming.
+            Must share the same axis. If ``None``, a rectangular window
+            of ones is used.
 
+        Returns
+        -------
+        DFunction
+            Fourier-transformed function defined on the dual
+            :class:`FrequencyAxis`.
 
+        Raises
+        ------
+        Exception
+            If the axis type is not ``'complete'`` or ``'upper-half'``.
+
+        Examples
+        --------
         >>> t = TimeAxis(0.0, 200, 1.0)
 
         The default type of TimeAxis is "upper-half"

--- a/quantarhei/core/frequency.py
+++ b/quantarhei/core/frequency.py
@@ -134,22 +134,30 @@ if TYPE_CHECKING:
 
 
 class FrequencyAxis(ValueAxis, EnergyUnitsManaged):
-    """Class representing frequency axis of calculations
+    """Frequency grid dual to a :class:`TimeAxis` via the FFT.
+
+    Stores frequency values whose units are managed by the global
+    :class:`Manager`. Typically obtained by calling
+    :meth:`TimeAxis.get_FrequencyAxis` rather than constructed directly.
 
     Parameters
     ----------
     start : float
-        start of the FrequencyAxis
-
+        First frequency value (internal units, i.e. rad/fs).
     length : int
-        number of steps
-
+        Number of frequency points.
     step : float
-        time step
+        Spacing between consecutive frequency values (rad/fs).
+    atype : str, optional
+        Axis type: ``'complete'`` (default) or ``'upper-half'``.
+    time_start : float, optional
+        Time-domain start value of the corresponding :class:`TimeAxis`.
+        Default is ``0.0``.
 
-    atype : string {"complete","upper-half"}
-        Axis type
-
+    Raises
+    ------
+    Exception
+        If ``atype`` is not ``'complete'`` or ``'upper-half'``.
     """
 
     data = UnitsManagedRealArray("data")

--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -84,7 +84,25 @@ from .units import (
 
 
 class Manager(metaclass=Singleton):
-    """Main package Manager"""
+    """Main package Manager.
+
+    Handles units management, basis conversion, and selection of optimized
+    implementations for the entire Quantarhei package. Only one instance
+    exists at any time (Singleton pattern).
+
+    Attributes
+    ----------
+    version : str
+        The installed package version number.
+    allowed_utypes : list of str
+        Unit types that can be managed (``'energy'``, ``'frequency'``, etc.).
+    units : dict
+        Available unit strings for each unit type.
+    units_repre : dict
+        Short string abbreviations for each unit string.
+    units_repre_latex : dict
+        LaTeX representations for each unit string.
+    """
 
     try:
         version = _pkg_version("quantarhei")
@@ -526,7 +544,22 @@ class Manager(metaclass=Singleton):
             raise Exception("Unknown unit type")
 
     def set_current_units(self, utype: str, units: str) -> None:
-        """Sets current units"""
+        """Set the current units for a given unit type.
+
+        Parameters
+        ----------
+        utype : str
+            Unit type (e.g. ``'energy'``, ``'length'``).
+        units : str
+            Unit string to set as current (must be a recognized value
+            for the given ``utype``).
+
+        Raises
+        ------
+        Exception
+            If ``utype`` is not in ``allowed_utypes`` or ``units`` is not
+            recognized for ``utype``.
+        """
         self._saved_units[utype] = self.get_current_units(utype)
 
         if utype in self.allowed_utypes:
@@ -911,7 +944,22 @@ class units_context_manager:
 
 
 class energy_units(units_context_manager):
-    """Context manager for units of energy"""
+    """Context manager for units of energy.
+
+    Sets the active energy units for the duration of the ``with`` block and
+    restores the previous units on exit.
+
+    Parameters
+    ----------
+    units : str
+        Energy unit string (e.g. ``'1/cm'``, ``'eV'``, ``'int'``).
+
+    Examples
+    --------
+    >>> import quantarhei as qr
+    >>> with qr.energy_units("1/cm"):
+    ...     H = qr.Hamiltonian(data=[[0.0, 100.0], [100.0, 12000.0]])
+    """
 
     def __init__(self, units: str) -> None:
         super().__init__(utype="energy")
@@ -945,17 +993,31 @@ class energy_units(units_context_manager):
 
 
 class frequency_units(energy_units):
-    """Context manager for units of frequency
+    """Context manager for units of frequency.
 
-    It behaves exactly the same as ``energy_units`` context manager.
+    Behaves identically to :class:`energy_units` since frequency and energy
+    share the same internal representation in Quantarhei.
 
+    Parameters
+    ----------
+    units : str
+        Frequency unit string (e.g. ``'1/cm'``, ``'THz'``, ``'int'``).
     """
 
     pass
 
 
 class length_units(units_context_manager):
-    """Context manager for length units"""
+    """Context manager for length units.
+
+    Sets the active length units for the duration of the ``with`` block and
+    restores the previous units on exit.
+
+    Parameters
+    ----------
+    units : str
+        Length unit string (e.g. ``'A'``, ``'nm'``, ``'Bohr'``).
+    """
 
     def __init__(self, units: str) -> None:
         super().__init__(utype="length")
@@ -995,7 +1057,16 @@ class basis_context_manager:
 
 
 class eigenbasis_of(basis_context_manager):
-    """Context manager for basis change"""
+    """Context manager for working in the eigenbasis of an operator.
+
+    Diagonalizes the given operator on entry, making subsequent calculations
+    in the eigenbasis, and transforms all registered objects back on exit.
+
+    Parameters
+    ----------
+    operator : SelfAdjointOperator
+        The operator whose eigenbasis is used inside the context block.
+    """
 
     def __init__(self, operator: Any) -> None:
         super().__init__()
@@ -1074,7 +1145,20 @@ class eigenbasis_of(basis_context_manager):
 
 
 def set_current_units(units: dict[str, str] | None = None) -> None:
-    """Sets units globaly without the need for a context manager"""
+    """Set units globally without a context manager.
+
+    Parameters
+    ----------
+    units : dict of str, optional
+        Mapping from unit type (e.g. ``'energy'``) to unit string
+        (e.g. ``'1/cm'``). If ``None``, all unit types are reset to
+        their internal defaults.
+
+    Raises
+    ------
+    Exception
+        If any key in ``units`` is not a recognized unit type.
+    """
     manager = Manager()
     if units is not None:
         # set units using a supplied dictionary

--- a/quantarhei/core/parallel.py
+++ b/quantarhei/core/parallel.py
@@ -328,8 +328,22 @@ def block_distributed_list(dlist: list[Any], return_index: bool = False) -> list
 
 
 def block_distributed_array(array: numpy.ndarray, return_index: bool = False) -> Any:
-    """ """
+    """Distribute blocks of an array across parallel workers.
 
+    Parameters
+    ----------
+    array : numpy.ndarray
+        Array to distribute. Each worker receives a contiguous block of rows.
+    return_index : bool, optional
+        If ``True``, return a ``(block, start_index)`` tuple instead of just
+        the block. Default is ``False``.
+
+    Returns
+    -------
+    numpy.ndarray or tuple
+        The local block assigned to this worker, or ``(block, start_index)``
+        when ``return_index`` is ``True``.
+    """
     from .managers import Manager
 
     # we share the work only in parallel_level == 1

--- a/quantarhei/core/parallel.py
+++ b/quantarhei/core/parallel.py
@@ -197,11 +197,12 @@ class DistributedConfiguration:
 
 
 def start_parallel_region() -> None:
-    """Starts a parallel region
+    """Start a parallel region.
 
-    This is a clean solution without having to explicitely invoke Manager
-    and DistributedConfiguration class
-
+    Convenience wrapper around
+    :meth:`DistributedConfiguration.start_parallel_region` that avoids
+    explicit use of :class:`~quantarhei.core.managers.Manager` and
+    :class:`DistributedConfiguration`.
     """
     from .managers import Manager
 
@@ -213,11 +214,12 @@ def start_parallel_region() -> None:
 
 
 def close_parallel_region() -> None:
-    """Closes a parallel region
+    """Close a parallel region.
 
-    This is a clean solution without having to explicitely invoke Manager
-    and DistributedConfiguration class
-
+    Convenience wrapper around
+    :meth:`DistributedConfiguration.finish_parallel_region` that avoids
+    explicit use of :class:`~quantarhei.core.managers.Manager` and
+    :class:`DistributedConfiguration`.
     """
     from .managers import Manager
 
@@ -229,7 +231,14 @@ def close_parallel_region() -> None:
 
 
 def distributed_configuration() -> DistributedConfiguration:
-    """Returns the DistributedConfiguration object from the Manager"""
+    """Return the active :class:`DistributedConfiguration` from the Manager.
+
+    Returns
+    -------
+    DistributedConfiguration
+        The shared distributed configuration object managed by
+        :class:`~quantarhei.core.managers.Manager`.
+    """
     from .managers import Manager
 
     return Manager().get_DistributedConfiguration()
@@ -635,7 +644,29 @@ def _get_next_from_MPI(config: DistributedConfiguration, source: int) -> int | N
 
 
 def asynchronous_range(start: int, stop: int) -> Generator[int, None, None]:
-    """Range distributing numbers asynchronously among processes"""
+    """Yield integers from ``start`` to ``stop``, distributed across processes.
+
+    In a parallel MPI environment the integers are distributed asynchronously
+    so that each MPI process receives the next available value as soon as it
+    is ready. In serial mode this is equivalent to :func:`range`.
+
+    Parameters
+    ----------
+    start : int
+        First integer to yield.
+    stop : int
+        Upper bound (exclusive) of the range.
+
+    Yields
+    ------
+    int
+        The next available integer from the range.
+
+    Raises
+    ------
+    Exception
+        If called outside a declared parallel region.
+    """
     from .managers import Manager
 
     config = Manager().get_DistributedConfiguration()

--- a/quantarhei/core/parcel.py
+++ b/quantarhei/core/parcel.py
@@ -10,6 +10,13 @@ from .managers import Manager
 
 
 class Parcel:
+    """Container that serialises a single Python object to a ``.qrp`` file.
+
+    Content is set via :meth:`set_content` and persisted via :meth:`save`.
+    Use the module-level :func:`~quantarhei.save_parcel` and
+    :func:`~quantarhei.load_parcel` helpers for the common save/load workflow.
+    """
+
     def set_content(self, obj: Any) -> None:
         """Set the content of the parcel"""
         self.content = obj

--- a/quantarhei/core/saveable.py
+++ b/quantarhei/core/saveable.py
@@ -21,31 +21,30 @@ from .parcel import Parcel, load_parcel
 
 
 class Saveable:
-    """Defines a class of objects that can save and load themselves"""
+    """Base class for objects that can save and load themselves to/from files.
+
+    Subclasses gain the ability to persist their state to a ``.qrp`` file
+    (a pickled :class:`Parcel`) and restore it later, supporting both named
+    files and file-like objects.
+    """
 
     hashes: dict = {}
 
     def save(
         self, filename: str | IO[bytes], comment: str | None = None, test: bool = False
     ) -> None:
-        """Saves the object with all its content into a file
-
+        """Save the object and all its content to a file.
 
         Parameters
         ----------
-        filename : str or File
-            Name of the file or a file object to which the content of
-            the object will be saved
-
-        comment : str
-            A comment which will be saved together with the content of
-            the object
-
-        test : bool
-            If test is True, and file descriptor is submitted, we save into
-            the file and move to its start for subsequent reading
-
-
+        filename : str or file-like
+            Path to the output file or an open binary file object.
+        comment : str, optional
+            A comment stored alongside the object content.
+        test : bool, optional
+            If ``True`` and a file object is given, seek back to the
+            start after writing so the file is ready for immediate reading.
+            Default is ``False``.
         """
         p = Parcel()
         p.set_content(self)
@@ -58,14 +57,21 @@ class Saveable:
                 filename.seek(0)
 
     def load(self, filename: str | IO[bytes], test: bool = False) -> Any:
-        """Loads an object from a file and returns it
+        """Load an object from a file and return it.
 
         Parameters
         ----------
-        filename : str or File
-            Filename of the file or file descriptor of the file from which
-            and object should be loaded.
+        filename : str or file-like
+            Path to the file or an open binary file object from which
+            the object should be loaded.
+        test : bool, optional
+            If ``True`` and a file object is given, seek to the start
+            before reading. Default is ``False``.
 
+        Returns
+        -------
+        object
+            The object stored in the file.
         """
         if test:
             if not isinstance(filename, str):

--- a/quantarhei/core/time.py
+++ b/quantarhei/core/time.py
@@ -218,24 +218,32 @@ class TimeDependent:
 
 
 class TimeAxis(ValueAxis):
-    """Class representing time in time dependent calculations.
+    """Linear time grid for time-dependent calculations.
 
+    Closely related to :class:`FrequencyAxis`: the FFT of a function defined
+    on a ``TimeAxis`` lives on the corresponding ``FrequencyAxis``. The
+    default type ``'upper-half'`` exploits conjugation symmetry of bath
+    correlation functions; ``'complete'`` gives a straightforward full-range
+    grid.
 
     Parameters
     ----------
     start : float
-        start of the TimeAxis
-
+        First value of the time axis (in internal units, i.e. fs).
     length : int
-        number of steps
-
+        Number of time points.
     step : float
-        time step
+        Spacing between consecutive time points (fs).
+    atype : str, optional
+        Axis type. Must be ``'upper-half'`` (default) or ``'complete'``.
+    frequency_start : float, optional
+        Offset applied to the first frequency of the corresponding
+        :class:`FrequencyAxis`. Default is ``0.0``.
 
-    atype : string {"complete","upper-half"}
-        Axis type
-
-
+    Raises
+    ------
+    Exception
+        If ``atype`` is not ``'upper-half'`` or ``'complete'``.
     """
 
     def __init__(

--- a/quantarhei/core/units.py
+++ b/quantarhei/core/units.py
@@ -103,7 +103,23 @@ eps0_int = 1.0e19 / (4.0 * const.pi * J2int)
 def convert(
     val: float | numpy.ndarray, in_units: str, to: str | None = None
 ) -> float | numpy.ndarray:
-    """Converts value in certain units into other units"""
+    """Convert a value from one set of units to another.
+
+    Parameters
+    ----------
+    val : float or numpy.ndarray
+        Value(s) to convert.
+    in_units : str
+        Unit string describing the units of ``val``
+        (e.g. ``'1/cm'``, ``'eV'``).
+    to : str, optional
+        Target unit string. If ``None``, the current global units are used.
+
+    Returns
+    -------
+    float or numpy.ndarray
+        Converted value(s) in the target units.
+    """
     from .managers import Manager, energy_units
 
     m = Manager()
@@ -122,7 +138,21 @@ def convert(
 def in_current_units(
     val: float | numpy.ndarray, in_units: str
 ) -> float | numpy.ndarray:
-    """Converts value in certain units into the current units"""
+    """Convert a value from given units into the current global units.
+
+    Parameters
+    ----------
+    val : float or numpy.ndarray
+        Value(s) to convert.
+    in_units : str
+        Unit string describing the units of ``val``
+        (e.g. ``'1/cm'``, ``'eV'``).
+
+    Returns
+    -------
+    float or numpy.ndarray
+        Converted value(s) in the currently active energy units.
+    """
     from .managers import Manager, energy_units
 
     m = Manager()

--- a/quantarhei/core/valueaxis.py
+++ b/quantarhei/core/valueaxis.py
@@ -104,21 +104,25 @@ from .saveable import Saveable
 
 
 class ValueAxis(Saveable):
-    """Linear array of values which are used as variables of numerical functions
-    and parameter dependent matrices
+    """Linear array of values used as the argument axis of numerical functions.
 
     Parameters
     ----------
     start : float
-        Beginning of the axis
-
-    lenght : int
-        Number of points in the DFunction
-
+        First value of the axis.
+    length : int
+        Number of points on the axis.
     step : float
-        Step size on the axis
+        Spacing between consecutive axis values.
 
-
+    Attributes
+    ----------
+    data : numpy.ndarray
+        Array of axis values, length ``length``.
+    min : float
+        Minimum (first) value on the axis.
+    max : float
+        Maximum (last) value on the axis.
     """
 
     step = Float("step")
@@ -150,16 +154,24 @@ class ValueAxis(Saveable):
         return self.data[self.length - 1]
 
     def locate(self, val: float) -> tuple[int, float]:
-        """Returns the index of the lower neigbor of the ``val``
-
-        Returns the index of the lower neigbor of the value x and the
-        remaining distance to the value of ``val``
+        """Return the index of the lower neighbor of ``val`` and the distance.
 
         Parameters
         ----------
         val : float
-            A value within the min and max values of the axis
+            A value within the ``[min, max]`` range of the axis.
 
+        Returns
+        -------
+        int
+            Index of the largest axis point that is ``<= val``.
+        float
+            Distance from that axis point to ``val``.
+
+        Raises
+        ------
+        Exception
+            If ``val`` is outside the axis bounds.
         """
         # nearest smaller neighbor index
         nsni = int(numpy.floor((val - self.start) / self.step))
@@ -172,17 +184,26 @@ class ValueAxis(Saveable):
         raise Exception("Value out of bounds")
 
     def nearest(self, val: float) -> int:
-        """Returns the index of the nearest neighbor to ``val``
+        """Return the index of the nearest axis point to ``val``.
 
-        Returns the index of the nearest neighbor of ``val``. If ``val``
-        is out of the upper bounds within the ``self.step`` from the upper
-        limit, the lower neighbor index is returned.
+        If ``val`` is within one step above the upper bound, the index of
+        the last point is returned.
 
         Parameters
         ----------
         val : float
-            A value within the min and max values of the axis
+            A value within (or just above) the ``[min, max]`` range of the
+            axis.
 
+        Returns
+        -------
+        int
+            Index of the axis point closest to ``val``.
+
+        Raises
+        ------
+        Exception
+            If ``val`` is outside the axis bounds.
         """
         # nearest smaller neighbor index
         nsni = int(numpy.floor((val - self.start) / self.step))

--- a/quantarhei/qm/corfunctions/correlationfunctions.py
+++ b/quantarhei/qm/corfunctions/correlationfunctions.py
@@ -59,22 +59,24 @@ from ...core.wrappers import enforce_energy_units_context
 
 
 class CorrelationFunction(DFunction, UnitsManaged):
-    """Provides typical Bath correlation function types.
+    """Bath (energy-gap) correlation function.
 
+    Provides several standard spectral-density models as analytical or
+    numerically evaluated correlation functions. The type is selected via
+    the ``'ftype'`` key of ``params``.
 
     Parameters
     ----------
     axis : TimeAxis
-        TimeAxis object specifying the time interval on which the
-        correlation function is defined.
-
-    params : dictionary
-        A dictionary of the correlation function parameters
-
-    values : optional
-        Correlation function can be set by specifying values at all times
-
-
+        Time grid on which the correlation function is evaluated.
+    params : dict or list of dict
+        Parameter dictionary (or list of dictionaries for a composite
+        correlation function). Must contain at least ``'ftype'``, ``'reorg'``,
+        and ``'T'`` (temperature in Kelvin).
+    values : numpy.ndarray, optional
+        Pre-computed complex values of the correlation function at the
+        time points of ``axis``. When supplied, the analytical evaluation
+        is skipped.
     """
 
     allowed_types = (
@@ -717,28 +719,26 @@ class LineshapeFunction(DFunction, UnitsManaged):
     def __init__(
         self, axis: Any = None, params: Any = None, values: Any = None, lfactor: int = 1
     ) -> None:
-        """Currently we do not use 'values'
+        """Initialize the lineshape function by integrating a correlation function.
 
         Parameters
         ----------
-        axis : TYPE, optional
-            DESCRIPTION. The default is None.
-        params : TYPE, optional
-            DESCRIPTION. The default is None.
-        values : TYPE, optional
-            DESCRIPTION. The default is None.
-        lfactor : TYPE, optional
-            DESCRIPTION. The default is 1.
+        axis : TimeAxis
+            Time grid on which the correlation function is defined.
+        params : dict
+            Parameter dictionary for the underlying
+            :class:`CorrelationFunction`.
+        values : numpy.ndarray, optional
+            Pre-computed correlation function values; passed through to
+            :class:`CorrelationFunction`.
+        lfactor : int, optional
+            Length multiplication factor applied to the time axis before
+            integration. Default is ``1``.
 
         Raises
         ------
         Exception
-            DESCRIPTION.
-
-        Returns
-        -------
-        None.
-
+            If ``params`` is ``None``.
         """
         self.lfactor = lfactor
         self.axis = axis

--- a/quantarhei/qm/corfunctions/correlationfunctions.py
+++ b/quantarhei/qm/corfunctions/correlationfunctions.py
@@ -713,33 +713,35 @@ class CorrelationFunction(DFunction, UnitsManaged):
 
 
 class LineshapeFunction(DFunction, UnitsManaged):
-    """ """
+    """Lineshape function obtained by double integration of a correlation function.
+
+    Computes ``g(t) = int_0^t dt' int_0^{t'} dt'' C(t'')`` numerically,
+    where ``C`` is a :class:`CorrelationFunction` built from ``params``.
+
+    Parameters
+    ----------
+    axis : TimeAxis
+        Time grid on which the correlation function is defined.
+    params : dict
+        Parameter dictionary for the underlying :class:`CorrelationFunction`.
+        Must contain at least ``"ftype"``, ``"reorg"``, and ``"T"``.
+    values : numpy.ndarray, optional
+        Pre-computed correlation function values; passed through to
+        :class:`CorrelationFunction`. Default is ``None``.
+    lfactor : int, optional
+        Length multiplication factor applied to the time axis before
+        integration. Default is ``1``.
+
+    Raises
+    ------
+    Exception
+        If ``params`` is ``None``.
+    """
 
     @enforce_energy_units_context
     def __init__(
         self, axis: Any = None, params: Any = None, values: Any = None, lfactor: int = 1
     ) -> None:
-        """Initialize the lineshape function by integrating a correlation function.
-
-        Parameters
-        ----------
-        axis : TimeAxis
-            Time grid on which the correlation function is defined.
-        params : dict
-            Parameter dictionary for the underlying
-            :class:`CorrelationFunction`.
-        values : numpy.ndarray, optional
-            Pre-computed correlation function values; passed through to
-            :class:`CorrelationFunction`.
-        lfactor : int, optional
-            Length multiplication factor applied to the time axis before
-            integration. Default is ``1``.
-
-        Raises
-        ------
-        Exception
-            If ``params`` is ``None``.
-        """
         self.lfactor = lfactor
         self.axis = axis
         self.params = params

--- a/quantarhei/qm/corfunctions/functionstorage.py
+++ b/quantarhei/qm/corfunctions/functionstorage.py
@@ -657,7 +657,27 @@ class FunctionStorage:
 
 
 class FastFunctionStorage(FunctionStorage):
-    """Function storage with no overhead retrieval"""
+    """Function storage with minimal-overhead array retrieval.
+
+    A subclass of :class:`FunctionStorage` optimised for fast random access
+    via direct array slicing.  Supports integer or full-slice ``:``) as the
+    first index.
+
+    Parameters
+    ----------
+    N : int, optional
+        Number of functions to store. Default is ``1``.
+    timeaxis : TimeAxis or list of TimeAxis
+        One or more time axes on which functions are discretised.
+    dtype : numpy.dtype, optional
+        Data type of the stored arrays. Default is ``numpy.complex64``.
+    show_config : bool, optional
+        If ``True``, print the storage configuration at construction time.
+        Default is ``False``.
+    config : dict or None, optional
+        Custom storage configuration dictionary. If ``None``, the default
+        three-time (t1, t2, t3) configuration is used.
+    """
 
     def __getitem__(self, index: Any) -> Any:
         i, j = index

--- a/quantarhei/qm/corfunctions/spectraldensities.py
+++ b/quantarhei/qm/corfunctions/spectraldensities.py
@@ -23,46 +23,25 @@ from .correlationfunctions import CorrelationFunction, FTCorrelationFunction
 
 
 class SpectralDensity(DFunction, UnitsManaged):
-    """This class represents the so-called spectral density
+    """Spectral density of a system-bath coupling.
+
+    Stores the bath spectral density :math:`J(\\omega)` as a discrete
+    function on a frequency grid. Can be constructed from the same parameter
+    dictionaries as :class:`CorrelationFunction`.
 
     Parameters
     ----------
-    axis : TimeAxis, FrequencyAxis
-        ValueAxis object specifying the frequency range directly or through
-        Fourier transform frequencies corresponding to a TimeAxis
-
-    params : dictionary
-        Parameters of the spectral density
-
-
-    Methods
-    -------
-....is_analytical()
-        Returns `True` if the spectral density is calculated from an analytical
-        formula, `False` otherwise.
-
-    copy()
-        Makes a copy of the SpectralDensity object
-
-    get_temperature()
-        Returns temperature assigned to the spectral density or raises an
-        exception if it was not set
-
-    get_reorganization_energy()
-        Returns the reorganization energy parameters of
-        the spectral density
-
-    measure_reorganization_energy()
-        Calculates reorganization energy from the shape of the spectral
-        density
-
-    get_CorrelationFunction()
-        Returns numerically calculated correlation function, based on the
-        spectral density
-
-    get_FTCorrelationFunction()
-        Returns a numerically calculated Fourier transform of the correlation
-        function
+    axis : TimeAxis or FrequencyAxis
+        Frequency grid on which the spectral density is defined, either
+        directly as a :class:`FrequencyAxis` or derived from a
+        :class:`TimeAxis` via FFT.
+    params : dict or list of dict
+        Parameter dictionary (or list of dictionaries for composite spectral
+        densities). Each dictionary must contain at least ``'ftype'`` and
+        ``'reorg'``.
+    values : numpy.ndarray, optional
+        If provided, use these pre-computed values instead of evaluating the
+        analytical form.
 
 
     Examples

--- a/quantarhei/qm/hilbertspace/hamiltonian.py
+++ b/quantarhei/qm/hilbertspace/hamiltonian.py
@@ -11,7 +11,24 @@ from .operators import Operator, SelfAdjointOperator
 
 
 class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
-    """Hamiltonian operator"""
+    """Hamiltonian operator of a quantum system.
+
+    Represents the system Hamiltonian as a real symmetric matrix whose
+    elements are stored in the currently active energy units and managed
+    by the global :class:`Manager`.
+
+    Parameters
+    ----------
+    dim : int, optional
+        Dimension of the Hilbert space. Required if ``data`` is not given.
+    data : array_like, optional
+        Square matrix of Hamiltonian elements. Must be real and symmetric.
+
+    Raises
+    ------
+    Exception
+        If ``data`` is not self-adjoint (symmetric for a real matrix).
+    """
 
     _has_remainder_coupling = False
     JR: numpy.ndarray
@@ -38,7 +55,22 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
         self.Nblocks = 1
 
     def set_rwa(self, rwa_indices: Any, rwa_energy: float | None = None) -> None:
-        """sets indice of RWA blocks of the Hamiltonian
+        """Set the block indices for the Rotating Wave Approximation (RWA).
+
+        Parameters
+        ----------
+        rwa_indices : array_like of int
+            Sorted list of block-start indices. The first element must be
+            ``0``. For example ``[0, N]`` defines a ground-state block
+            ``[0, N)`` and an excited-state block ``[N, dim)``.
+        rwa_energy : float, optional
+            If provided, average block energies are set to multiples of
+            this value rather than computed from the diagonal of the data.
+
+        Raises
+        ------
+        Exception
+            If the first element of ``rwa_indices`` is not ``0``.
 
 
         Examples

--- a/quantarhei/qm/hilbertspace/operators.py
+++ b/quantarhei/qm/hilbertspace/operators.py
@@ -14,14 +14,24 @@ from .statevector import StateVector
 
 
 class Operator(MatrixData, BasisManaged, Saveable):
-    """Class representing quantum mechanical operators
+    """Quantum mechanical operator on a finite-dimensional Hilbert space.
 
+    Stores the matrix representation of the operator and participates in
+    basis management so that the stored data is automatically transformed
+    when the active basis changes via :class:`eigenbasis_of`.
 
-    The class Operator represents an operator on quantum mechanical Hilbert
-    space. Together with StateVector they provide the basic functionality
-    for quantum mechanical calculations in Hilbert space.
-
-
+    Parameters
+    ----------
+    dim : int, optional
+        Dimension of the Hilbert space. Must be supplied if ``data`` is
+        not given.
+    data : array_like, optional
+        Square matrix providing the operator elements.
+    real : bool, optional
+        If ``True`` and ``data`` is not provided, allocate a real-valued
+        matrix. Default is ``False`` (complex).
+    name : str, optional
+        Human-readable label for the operator. Default is ``''``.
     """
 
     _data: numpy.ndarray
@@ -135,13 +145,25 @@ class Operator(MatrixData, BasisManaged, Saveable):
 
 
 class SelfAdjointOperator(Operator):
-    """Class representing a self adjoint operator
+    """Quantum mechanical operator that is required to be self-adjoint.
 
-    The class SelfAdjointOperator extends the Operator class by automatically
-    checking the data for the self adjoint property. Physically measurable
-    quantities are represented by self adjoint operators in quantum mechanics.
+    Extends :class:`Operator` by verifying on construction that the supplied
+    data satisfies ``A == A†``. Physically observable quantities in quantum
+    mechanics are represented by self-adjoint operators.
 
+    Parameters
+    ----------
+    dim : int, optional
+        Dimension of the Hilbert space.
+    data : array_like, optional
+        Self-adjoint square matrix of operator elements.
+    name : str, optional
+        Human-readable label. Default is ``''``.
 
+    Raises
+    ------
+    Exception
+        If ``data`` is not self-adjoint.
     """
 
     def __init__(
@@ -200,11 +222,21 @@ class BasisReferenceOperator(SelfAdjointOperator):
 
 
 class ProjectionOperator(Operator):
-    """Projection operator projecting from state m to state n.
-    Braket definition:
+    """Projection operator |n⟩⟨m| from state ``from_state`` to ``to_state``.
 
-    |n\rangle \\langle m|
+    Parameters
+    ----------
+    to_state : int, optional
+        Row index (ket index ``n``). Default is ``-1``.
+    from_state : int, optional
+        Column index (bra index ``m``). Default is ``-1``.
+    dim : int, optional
+        Dimension of the Hilbert space. Must be ``> 0``.
 
+    Raises
+    ------
+    Exception
+        If ``dim`` is not positive.
     """
 
     def __init__(self, to_state: int = -1, from_state: int = -1, dim: int = 0) -> None:
@@ -235,13 +267,19 @@ class ProjectionOperator(Operator):
 
 
 class DensityMatrix(SelfAdjointOperator, Saveable):
-    """Class representing a density matrix
+    """Density matrix of a quantum system.
 
+    Extends :class:`SelfAdjointOperator` with convenience methods for
+    population extraction, normalization, and delta-pulse excitation.
 
-    Density matrix is a good example of self adjoint operator. It extends
-    the class SelfAdjointOperator without adding much functionality.
-
-
+    Parameters
+    ----------
+    dim : int, optional
+        Dimension of the Hilbert space.
+    data : array_like, optional
+        Self-adjoint square matrix of density-matrix elements.
+    name : str, optional
+        Human-readable label. Default is ``''``.
     """
 
     def normalize2(self, norm: float = 1.0) -> None:
@@ -293,11 +331,20 @@ class DensityMatrix(SelfAdjointOperator, Saveable):
 
 
 class ReducedDensityMatrix(DensityMatrix):
-    """Class representing a reduced density matrix
+    """Reduced density matrix of an open quantum system.
 
-    This class is basically just a nickname for the Density Matrix
+    A specialization of :class:`DensityMatrix` used throughout Quantarhei
+    to represent the state of a subsystem after tracing out environmental
+    degrees of freedom.
 
-
+    Parameters
+    ----------
+    dim : int, optional
+        Dimension of the system Hilbert space.
+    data : array_like, optional
+        Self-adjoint square matrix of reduced density-matrix elements.
+    name : str, optional
+        Human-readable label. Default is ``''``.
     """
 
     def __str__(self) -> str:

--- a/quantarhei/qm/liouvillespace/heom.py
+++ b/quantarhei/qm/liouvillespace/heom.py
@@ -437,8 +437,18 @@ class KTHierarchy:
 
 
 class KTHierarchyPropagator:
-    """Propagator of the Kubo-Tanimura hierarchy
+    """Propagator for the Kubo-Tanimura (HEOM) hierarchy.
 
+    Parameters
+    ----------
+    timeaxis : TimeAxis
+        Time axis defining the propagation grid.
+    hierarchy : KTHierarchy
+        Pre-built hierarchy object holding all bath parameters and ADO
+        indices.
+
+    Examples
+    --------
     >>> import numpy
     >>> import quantarhei as qr
     >>> with qr.energy_units("1/cm"):
@@ -657,7 +667,19 @@ class KTHierarchyPropagator:
 
 
 class QuTip_KTHierarchyPropagator(KTHierarchyPropagator):
-    """If QuTip is installed, this class provides the solution of the HEOM"""
+    """HEOM propagator backed by the QuTiP library.
+
+    Uses the QuTiP HEOM solver when it is available. Falls back to an error
+    if QuTiP is not installed.
+
+    Parameters
+    ----------
+    timeaxis : TimeAxis
+        Time axis defining the propagation grid.
+    hierarchy : KTHierarchy
+        Pre-built hierarchy object holding all bath parameters and ADO
+        indices.
+    """
 
     def __init__(self, timeaxis: Any, hierarchy: Any) -> None:
 

--- a/quantarhei/qm/propagators/oqssvevolution.py
+++ b/quantarhei/qm/propagators/oqssvevolution.py
@@ -9,6 +9,22 @@ from ..propagators.dmevolution import ReducedDensityMatrixEvolution
 
 
 class OQSStateVectorEvolution:
+    """Time evolution of a state vector under an open quantum system (OQS).
+
+    Stores the state vector at each time step produced by an
+    :class:`OQSStateVectorPropagator` and provides utilities to convert
+    the result to a reduced density matrix evolution.
+
+    Parameters
+    ----------
+    timeaxis : TimeAxis or None, optional
+        Time grid for the propagation. Default is ``None``.
+    psii : StateVector or None, optional
+        Initial state vector. If provided, its dimension is used to
+        allocate the storage array and it is set as the initial condition.
+        Default is ``None``.
+    """
+
     def __init__(self, timeaxis: Any = None, psii: Any = None) -> None:
 
         if timeaxis is not None:

--- a/quantarhei/qm/propagators/oqssvpropagator.py
+++ b/quantarhei/qm/propagators/oqssvpropagator.py
@@ -12,6 +12,27 @@ from .oqssvevolution import OQSStateVectorEvolution
 
 
 class OQSStateVectorPropagator:
+    """Propagator for state vectors under an open quantum system rate matrix.
+
+    Uses a short-expansion method to integrate the equation of motion
+    for the state-vector amplitudes driven by a (possibly time-dependent)
+    rate matrix ``KK``.
+
+    Parameters
+    ----------
+    timeaxis : TimeAxis or None, optional
+        Time grid specifying the output time points. Default is ``None``.
+    current_matrix : numpy.ndarray or None, optional
+        Rate matrix (shape ``(Nt, N, N)`` for time-dependent, or ``(N, N)``
+        for static) driving the evolution. Default is ``None``.
+    agg : Aggregate or None, optional
+        Molecular aggregate used when computing secular dynamics via
+        ``get_secular_dynamics``. Default is ``None``.
+    theory_type : str, optional
+        Relaxation theory to use in secular-dynamics mode. Currently
+        ``"Redfield"`` is supported. Default is ``"Redfield"``.
+    """
+
     def __init__(
         self,
         timeaxis: Any = None,

--- a/quantarhei/qm/propagators/rdmpropagator.py
+++ b/quantarhei/qm/propagators/rdmpropagator.py
@@ -41,11 +41,36 @@ def debug(msg: str) -> None:
 
 
 class ReducedDensityMatrixPropagator(MatrixData, Saveable):
-    """Reduced Density Matrix Propagator calculates the evolution of the
-    reduced density matrix based on the Hamiltonian and optionally
-    a relaxation tensor. Relaxation tensor may be constant or time
-    dependent.
+    """Propagator for the reduced density matrix.
 
+    Calculates the time evolution of a :class:`ReducedDensityMatrix` under
+    a given :class:`Hamiltonian` and an optional relaxation tensor (constant
+    or time-dependent).
+
+    Parameters
+    ----------
+    timeaxis : TimeAxis
+        Time grid on which the evolution is stored.
+    Ham : Hamiltonian
+        System Hamiltonian.
+    RTensor : RelaxationTensor, optional
+        Relaxation (Redfield/Lindblad) tensor. If ``None``, purely unitary
+        propagation is performed.
+    Iterm : array_like, optional
+        Inhomogeneous term; requires ``RTensor`` to be set.
+    Efield : numpy.ndarray or LabSetup, optional
+        External driving field.
+    Trdip : Operator, optional
+        Transition dipole moment operator; required when ``Efield`` is set.
+    PDeph : object, optional
+        Pure-dephasing operator; also enables relaxation mode.
+    NonHerm : object, optional
+        Non-Hermitian correction to the Hamiltonian.
+
+    Raises
+    ------
+    Exception
+        If ``timeaxis`` is not a :class:`TimeAxis` or ``Ham`` is missing.
     """
 
     Efield: Any
@@ -63,24 +88,12 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         PDeph: Any = None,
         NonHerm: Any = None,
     ) -> None:
-        """Creates a Reduced Density Matrix propagator which can propagate
-        a given initial density matrix with the given Hamiltonian and
-        relaxation tensor.Time axis of the propagation is specied by
-        the second argument.
-
-        RWA : tuple
-            A tuple of block starting indices. It is assumed that if RWA is
-            to be used, that there is at least a ground state and a single
-            block of excited state starting from the Nth energy level. In this
-            case the tuple reads (0, N). The tuple always starts with 0. In
-            case there are two excited blocks, it reads (0, N1, N2) where
-            N2 > N1 > 0.
-
+        """Initialize the propagator.
 
         Examples
         --------
-        The constructor accepts only numpy.ndarray object, so the
-        following code will fail, because it submits normal Python arrays.
+        The constructor requires a :class:`TimeAxis` object.  Passing plain
+        Python lists will raise an exception:
 
         >>> pr = ReducedDensityMatrixPropagator([[0.0, 0.0],
         ...                                     [0.0, 1.0]],[0,1,2,3,4,5])
@@ -88,7 +101,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
             ...
         Exception: TimeAxis expected here.
 
-        The correct way to construct the propagator is the following:
+        The correct construction requires proper types:
 
         >>> h = numpy.array([[0.0, 0.0],[0.0,1.0]])
         >>> HH = Hamiltonian(data=h)
@@ -206,14 +219,20 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
             )
 
     def setDtRefinement(self, Nref: int) -> None:
-        """The TimeAxis object specifies at what times the propagation
-        should be stored. We can tell the propagator to use finer
-        time step for the calculation by setting the refinement. The
-        refinement is an integer by which the TimeAxis time step should
-        be devided to get the finer time step. In the code below, we
-        have dt = 10 in the TimeAxis, but we want to calculate with
-        dt = 1
+        """Set a finer internal time step by subdividing the stored time step.
 
+        The :class:`TimeAxis` controls the times at which results are stored.
+        This method subdivides the stored time step by ``Nref`` for a more
+        accurate numerical integration.
+
+        Parameters
+        ----------
+        Nref : int
+            Number of internal sub-steps per :class:`TimeAxis` step.
+            A value of ``1`` means no refinement.
+
+        Examples
+        --------
         >>> HH = Hamiltonian(data=numpy.array([[0.0, 0.0],[0.0,1.0]]))
         >>> times = TimeAxis(0,1000,10.0)
         >>> pr = ReducedDensityMatrixPropagator(times, HH)
@@ -226,11 +245,40 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
     def propagate(
         self, rhoi: Any, method: str = "short-exp", mdata: Any = None, Nref: int = 1
     ) -> Any:
-        """>>> T0   = 0
+        """Propagate the density matrix forward in time.
+
+        Parameters
+        ----------
+        rhoi : ReducedDensityMatrix or DensityMatrix
+            Initial density matrix at the start of the time axis.
+        method : str, optional
+            Propagation algorithm. Currently only ``'short-exp'`` (default)
+            and variants ``'short-exp-2'``, ``'short-exp-4'``,
+            ``'short-exp-6'`` are supported.
+        mdata : object, optional
+            Additional method-specific data (reserved for future use).
+        Nref : int, optional
+            Time-step refinement factor; equivalent to calling
+            :meth:`setDtRefinement` before propagating. Default is ``1``.
+
+        Returns
+        -------
+        ReducedDensityMatrixEvolution
+            Object containing the density matrix at each point of the
+            :class:`TimeAxis`.
+
+        Raises
+        ------
+        Exception
+            If ``rhoi`` is not a :class:`ReducedDensityMatrix` or
+            :class:`DensityMatrix`, or if an unknown method is requested.
+
+        Examples
+        --------
+        >>> T0   = 0
         >>> Tmax = 100
         >>> dt   = 1
         >>> Nref = 30
-
 
         >>> initial_dm = [[1.0, 0.0, 0.0],
         ...               [0.0, 0.0, 0.0],

--- a/quantarhei/qm/propagators/svpropagator.py
+++ b/quantarhei/qm/propagators/svpropagator.py
@@ -13,6 +13,21 @@ from .statevectorevolution import StateVectorEvolution
 
 
 class StateVectorPropagator:
+    """Propagator for pure state vectors under a Hamiltonian.
+
+    Integrates the time-dependent Schrodinger equation using a short
+    Taylor-expansion of the time-evolution operator. Supports static,
+    time-dependent, and non-linear Hamiltonians.
+
+    Parameters
+    ----------
+    timeaxis : TimeAxis
+        Time grid specifying the output time points.
+    ham : Hamiltonian
+        Hamiltonian operator driving the evolution. May include a
+        rotating-wave approximation (RWA) frame.
+    """
+
     def __init__(self, timeaxis: Any, ham: Any) -> None:
         self.timeaxis = timeaxis
         self.ham = ham

--- a/quantarhei/spectroscopy/abs2.py
+++ b/quantarhei/spectroscopy/abs2.py
@@ -7,6 +7,13 @@ class AbsSpectrum(AbsSpectrumBase):
     """Class representing absorption spectrum.
 
     Inherits all functionality from ``AbsSpectrumBase``.
+
+    Parameters
+    ----------
+    axis : FrequencyAxis
+        Frequency axis for the spectrum.
+    data : numpy.ndarray
+        Spectral data array.
     """
 
     pass

--- a/quantarhei/spectroscopy/abs2.py
+++ b/quantarhei/spectroscopy/abs2.py
@@ -1,16 +1,12 @@
-"""Class representing absorption spectrum
-
-
-
-Class Details
--------------
-
-"""
+"""Class representing absorption spectrum."""
 
 from .absbase import AbsSpectrumBase
 
 
 class AbsSpectrum(AbsSpectrumBase):
-    """Class representing absorption spectrum"""
+    """Class representing absorption spectrum.
+
+    Inherits all functionality from ``AbsSpectrumBase``.
+    """
 
     pass

--- a/quantarhei/spectroscopy/abscontainer.py
+++ b/quantarhei/spectroscopy/abscontainer.py
@@ -6,6 +6,8 @@ from ..core.saveable import Saveable
 
 
 class AbsSpectrumContainer(Saveable):
+    """Container for a set of absorption spectra sharing a common frequency axis."""
+
     def __init__(self, axis: Any = None) -> None:
 
         self.axis = axis
@@ -16,10 +18,22 @@ class AbsSpectrumContainer(Saveable):
         self.axis = axis
 
     def set_spectrum(self, spect: Any, tag: Any = None) -> None:
-        """Stores absorption spectrum
+        """Store an absorption spectrum, checking axis compatibility.
 
-        Checks compatibility of its frequency axis
+        Parameters
+        ----------
+        spect : AbsSpectrum
+            Spectrum object to store. Its frequency axis must match the
+            container's axis (or becomes the axis if none is set yet).
+        tag : str or None, optional
+            Key under which to store the spectrum. If ``None``, the current
+            count value is used as the string key.
 
+        Raises
+        ------
+        Exception
+            If the spectrum's frequency axis is incompatible with the
+            container's existing axis.
         """
         frq = spect.axis
 
@@ -37,10 +51,23 @@ class AbsSpectrumContainer(Saveable):
             raise Exception("Incompatible time axis (equal axis required)")
 
     def get_spectrum(self, tag: Any) -> Any:
-        """Returns spectrum corresponing to time t2
+        """Return the spectrum identified by tag.
 
-        Checks if the time t2 is present in the t2axis
+        Parameters
+        ----------
+        tag : str or int
+            Key identifying the stored spectrum. Integer tags are converted
+            to strings.
 
+        Returns
+        -------
+        AbsSpectrum
+            The stored spectrum corresponding to ``tag``.
+
+        Raises
+        ------
+        Exception
+            If no spectrum is stored under ``tag``.
         """
         if not isinstance(tag, str):
             tag = str(tag)
@@ -50,6 +77,12 @@ class AbsSpectrumContainer(Saveable):
         raise Exception("Unknown spectrum")
 
     def get_spectra(self) -> list[Any]:
-        """Returns a list or tuple of the calculated spectra"""
+        """Return all stored spectra sorted by their string tags.
+
+        Returns
+        -------
+        list
+            List of stored spectra in tag-sorted order.
+        """
         ven = [value for (key, value) in sorted(self.spectra.items())]
         return ven

--- a/quantarhei/spectroscopy/abscontainer.py
+++ b/quantarhei/spectroscopy/abscontainer.py
@@ -6,7 +6,14 @@ from ..core.saveable import Saveable
 
 
 class AbsSpectrumContainer(Saveable):
-    """Container for a set of absorption spectra sharing a common frequency axis."""
+    """Container for a set of absorption spectra sharing a common frequency axis.
+
+    Parameters
+    ----------
+    axis : FrequencyAxis, optional
+        Shared frequency axis for all stored spectra. Can be set later via
+        ``set_axis``.
+    """
 
     def __init__(self, axis: Any = None) -> None:
 

--- a/quantarhei/spectroscopy/circular_dichroism.py
+++ b/quantarhei/spectroscopy/circular_dichroism.py
@@ -29,7 +29,7 @@ from ..utils import derived_type
 
 
 class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
-    """Provides basic container for circular dichroism spectrum"""
+    """Provides basic container for circular dichroism spectrum."""
 
     def __init__(self, axis: Any = None, data: Any = None) -> None:
         super().__init__()
@@ -37,24 +37,22 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
         self.data = data
 
     def set_axis(self, axis: Any) -> None:
-        """Sets axis atribute
+        """Set the frequency axis of the spectrum.
 
         Parameters
         ----------
-        axis : FrequencyAxis object
-            Frequency axis object. This object has managed energy units
-
+        axis : FrequencyAxis
+            Frequency axis object with managed energy units.
         """
         self.axis = axis
 
     def set_data(self, data: Any) -> None:
-        """Sets data atribute
+        """Set the spectral data array.
 
         Parameters
         ----------
-        data : array like object (numpy array)
-            Sets the data of the circular dichroism spectrum
-
+        data : numpy.ndarray
+            Array of circular dichroism spectral values.
         """
         self.data = data
 
@@ -118,16 +116,18 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
         self.data -= val
 
     def add_to_data(self, spect: Any) -> None:
-        """Performs addition on the data.
-
-        Expects a compatible object holding circular dichroism spectrum
-        and adds its data to the present circular dichroism spectrum.
+        """Add data from a compatible spectrum to this spectrum.
 
         Parameters
         ----------
-        spect : spectrum containing object
-            This object should have a compatible axis and some data
+        spect : CircDichSpectrumBase
+            Spectrum whose data will be added. Must have a compatible
+            frequency axis.
 
+        Raises
+        ------
+        Exception
+            If the spectrum's axis is incompatible with this object's axis.
         """
         if self.axis is None:
             self.axis = spect.axis.copy()
@@ -150,15 +150,23 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
         replace: bool = False,
         **kwargs: Any,
     ) -> None:
-        """Load the spectrum from a file
+        """Load the spectrum from a file.
 
-        Uses the load method of the DFunction class to load the circular dichroism
-        spectrum from a file. It sets the axis type to 'frequency', otherwise
-        no changes to the inherited method are applied.
+        Delegates to ``DFunction.load_data`` with the axis type forced to
+        ``'frequency'``.
 
         Parameters
         ----------
-
+        name : str
+            Path to the file to load.
+        with_axis : optional
+            Ignored; provided for API compatibility.
+        ext : str or None, optional
+            File extension hint passed to the parent method.
+        replace : bool, optional
+            If ``True``, replace existing data. Default is ``False``.
+        **kwargs
+            Additional keyword arguments forwarded to the parent method.
         """
         super().load_data(name, ext=ext, axis="frequency", replace=replace)
 
@@ -381,7 +389,7 @@ def _n_gaussians(x: Any, N: int, *params: float) -> Any:
 
 
 class CircDichSpectrum(CircDichSpectrumBase):
-    """Class representing circular dichroism spectrum"""
+    """Class representing a circular dichroism spectrum."""
 
     pass
 
@@ -437,6 +445,8 @@ class CircDichSpectrum(CircDichSpectrumBase):
 
 
 class CircDichSpectrumContainer(Saveable):
+    """Container for a set of circular dichroism spectra sharing a common frequency axis."""
+
     def __init__(self, axis: Any = None) -> None:
 
         self.axis = axis
@@ -447,10 +457,22 @@ class CircDichSpectrumContainer(Saveable):
         self.axis = axis
 
     def set_spectrum(self, spect: Any, tag: Any = None) -> None:
-        """Stores circular dichroism spectrum
+        """Store a circular dichroism spectrum, checking axis compatibility.
 
-        Checks compatibility of its frequency axis
+        Parameters
+        ----------
+        spect : CircDichSpectrum
+            Spectrum to store. Its frequency axis must match the container's
+            axis (or becomes the axis if none is set yet).
+        tag : str or None, optional
+            Key under which to store the spectrum. If ``None``, the current
+            count value is used as the string key.
 
+        Raises
+        ------
+        Exception
+            If the spectrum's frequency axis is incompatible with the
+            container's existing axis.
         """
         frq = spect.axis
 
@@ -468,10 +490,23 @@ class CircDichSpectrumContainer(Saveable):
             raise Exception("Incompatible time axis (equal axis required)")
 
     def get_spectrum(self, tag: Any) -> Any:
-        """Returns spectrum corresponing to time t2
+        """Return the spectrum identified by tag.
 
-        Checks if the time t2 is present in the t2axis
+        Parameters
+        ----------
+        tag : str or int
+            Key identifying the stored spectrum. Integer tags are converted
+            to strings.
 
+        Returns
+        -------
+        CircDichSpectrum
+            The stored spectrum corresponding to ``tag``.
+
+        Raises
+        ------
+        Exception
+            If no spectrum is stored under ``tag``.
         """
         if not isinstance(tag, str):
             tag = str(tag)
@@ -481,7 +516,13 @@ class CircDichSpectrumContainer(Saveable):
         raise Exception("Unknown spectrum")
 
     def get_spectra(self) -> list[Any]:
-        """Returns a list or tuple of the calculated spectra"""
+        """Return all stored spectra sorted by their string tags.
+
+        Returns
+        -------
+        list
+            List of stored spectra in tag-sorted order.
+        """
         ven = [value for (key, value) in sorted(self.spectra.items())]
         return ven
 

--- a/quantarhei/spectroscopy/circular_dichroism.py
+++ b/quantarhei/spectroscopy/circular_dichroism.py
@@ -389,7 +389,15 @@ def _n_gaussians(x: Any, N: int, *params: float) -> Any:
 
 
 class CircDichSpectrum(CircDichSpectrumBase):
-    """Class representing a circular dichroism spectrum."""
+    """Class representing a circular dichroism spectrum.
+
+    Parameters
+    ----------
+    axis : FrequencyAxis
+        Frequency axis for the spectrum.
+    data : numpy.ndarray
+        Spectral data array.
+    """
 
     pass
 
@@ -445,7 +453,14 @@ class CircDichSpectrum(CircDichSpectrumBase):
 
 
 class CircDichSpectrumContainer(Saveable):
-    """Container for a set of circular dichroism spectra sharing a common frequency axis."""
+    """Container for a set of circular dichroism spectra sharing a common frequency axis.
+
+    Parameters
+    ----------
+    axis : FrequencyAxis or None, optional
+        Shared frequency axis for all stored spectra. Default is ``None``;
+        the axis is set automatically when the first spectrum is added.
+    """
 
     def __init__(self, axis: Any = None) -> None:
 

--- a/quantarhei/spectroscopy/dsfeynman.py
+++ b/quantarhei/spectroscopy/dsfeynman.py
@@ -14,7 +14,19 @@ def _require_symbolic() -> None:
 
 
 class DSFeynmanDiagram:
-    """Double-sided Feynman diagrams"""
+    """Double-sided Feynman diagram for non-linear spectroscopy.
+
+    Parameters
+    ----------
+    ptype : str, optional
+        Diagram type string, e.g. ``"R1g"``, ``"R2g"``. Default is
+        ``"non-defined"``.
+
+    Raises
+    ------
+    Exception
+        If ``ptype`` is not a recognised diagram type.
+    """
 
     def __init__(self, ptype: str = "non-defined") -> None:
 
@@ -547,20 +559,18 @@ def _format_code(N: int, code_string: str) -> str:
 
 
 class R1g_Diagram(DSFeynmanDiagram):
-    """R1g diagram
-
-    Diagram of R1g type
+    """R1g-type double-sided Feynman diagram (ground-state bleach, rephasing).
 
 
-          | g      g |
-      <---|----------|
-          | a      g |
-          |----------|--->
-          | a      b |
-          |----------|<---
-          | a      g |
-      --->|----------|
-          | g      g |
+        | g      g |
+    <---|----------|
+        | a      g |
+        |----------|--->
+        | a      b |
+        |----------|<---
+        | a      g |
+    --->|----------|
+        | g      g |
 
     """
 
@@ -577,22 +587,20 @@ class R1g_Diagram(DSFeynmanDiagram):
 
 
 class R1g_R_Diagram(DSFeynmanDiagram):
-    """R1g diagram
-
-    Diagram of R1g type
+    """R1g-type double-sided Feynman diagram with a relaxation step.
 
 
-          | g      g |
-      <---|----------|
-          | b      g |
-          |----------|--->
-          | b      b |
-          |..........|
-          | a      a |
-          |----------|<---
-          | a      g |
-      --->|----------|
-          | g      g |
+        | g      g |
+    <---|----------|
+        | b      g |
+        |----------|--->
+        | b      b |
+        |..........|
+        | a      a |
+        |----------|<---
+        | a      g |
+    --->|----------|
+        | g      g |
 
     """
 
@@ -610,20 +618,18 @@ class R1g_R_Diagram(DSFeynmanDiagram):
 
 
 class R2g_Diagram(DSFeynmanDiagram):
-    """R2g diagram
-
-    Diagram of R2g type
+    """R2g-type double-sided Feynman diagram (stimulated emission, rephasing).
 
 
-          | g      g |
-      <---|----------|
-          | b      g |
-          |----------|--->
-          | b      a |
-      --->|----------|
-          | g      a |
-          |----------|<---
-          | g      g |
+        | g      g |
+    <---|----------|
+        | b      g |
+        |----------|--->
+        | b      a |
+    --->|----------|
+        | g      a |
+        |----------|<---
+        | g      g |
 
     """
 
@@ -640,20 +646,18 @@ class R2g_Diagram(DSFeynmanDiagram):
 
 
 class R3g_Diagram(DSFeynmanDiagram):
-    """R3g diagram
-
-    Diagram of R3g type
+    """R3g-type double-sided Feynman diagram (stimulated emission, non-rephasing).
 
 
-          | g      g |
-      <---|----------|
-          | b      g |
-      --->|----------|
-          | g      g |
-          |----------|--->
-          | g      a |
-          |----------|<---
-          | g      g |
+        | g      g |
+    <---|----------|
+        | b      g |
+    --->|----------|
+        | g      g |
+        |----------|--->
+        | g      a |
+        |----------|<---
+        | g      g |
 
     """
 
@@ -670,20 +674,18 @@ class R3g_Diagram(DSFeynmanDiagram):
 
 
 class R4g_Diagram(DSFeynmanDiagram):
-    """R4g diagram
-
-    Diagram of R4g type
+    """R4g-type double-sided Feynman diagram (ground-state bleach, non-rephasing).
 
 
-          | g      g |
-      <---|----------|
-          | b      g |
-      --->|----------|
-          | g      g |
-      <---|----------|
-          | a      g |
-      --->|----------|
-          | g      g |
+        | g      g |
+    <---|----------|
+        | b      g |
+    --->|----------|
+        | g      g |
+    <---|----------|
+        | a      g |
+    --->|----------|
+        | g      g |
 
     """
 
@@ -700,20 +702,18 @@ class R4g_Diagram(DSFeynmanDiagram):
 
 
 class R1f_Diagram(DSFeynmanDiagram):
-    """R1f diagram
-
-    Diagram of R1f type
+    """R1f-type double-sided Feynman diagram (excited-state absorption, rephasing).
 
 
-          | b      b |
-      <---|----------|
-          | f      b |
-      --->|----------|
-          | a      b |
-          |----------|<---
-          | a      g |
-      --->|----------|
-          | g      g |
+        | b      b |
+    <---|----------|
+        | f      b |
+    --->|----------|
+        | a      b |
+        |----------|<---
+        | a      g |
+    --->|----------|
+        | g      g |
 
     """
 
@@ -730,19 +730,17 @@ class R1f_Diagram(DSFeynmanDiagram):
 
 
 class R2f_Diagram(DSFeynmanDiagram):
-    """R2f diagram
+    """R2f-type double-sided Feynman diagram (excited-state absorption, non-rephasing).
 
-    Diagram of R2f type
-
-          | a      a |
-      <---|----------|
-          | f      a |
-      --->|----------|
-          | b      a |
-      --->|----------|
-          | g      a |
-          |----------|<---
-          | g      g |
+        | a      a |
+    <---|----------|
+        | f      a |
+    --->|----------|
+        | b      a |
+    --->|----------|
+        | g      a |
+        |----------|<---
+        | g      g |
 
     """
 

--- a/quantarhei/spectroscopy/dsfeynman.py
+++ b/quantarhei/spectroscopy/dsfeynman.py
@@ -572,6 +572,11 @@ class R1g_Diagram(DSFeynmanDiagram):
     --->|----------|
         | g      g |
 
+    Parameters
+    ----------
+    states : list of str or None, optional
+        Labels for the two excited states involved in the diagram. Default
+        is ``["a", "b"]``.
     """
 
     def __init__(self, states: list[str] | None = None) -> None:
@@ -589,6 +594,11 @@ class R1g_Diagram(DSFeynmanDiagram):
 class R1g_R_Diagram(DSFeynmanDiagram):
     """R1g-type double-sided Feynman diagram with a relaxation step.
 
+    Parameters
+    ----------
+    states : list of str or None, optional
+        Labels for the two excited states involved in the diagram. Default
+        is ``["a", "b"]``.
 
         | g      g |
     <---|----------|
@@ -631,6 +641,11 @@ class R2g_Diagram(DSFeynmanDiagram):
         |----------|<---
         | g      g |
 
+    Parameters
+    ----------
+    states : list of str or None, optional
+        Labels for the two excited states involved in the diagram. Default
+        is ``["a", "b"]``.
     """
 
     def __init__(self, states: list[str] | None = None) -> None:
@@ -659,6 +674,11 @@ class R3g_Diagram(DSFeynmanDiagram):
         |----------|<---
         | g      g |
 
+    Parameters
+    ----------
+    states : list of str or None, optional
+        Labels for the two excited states involved in the diagram. Default
+        is ``["a", "b"]``.
     """
 
     def __init__(self, states: list[str] | None = None) -> None:
@@ -687,6 +707,11 @@ class R4g_Diagram(DSFeynmanDiagram):
     --->|----------|
         | g      g |
 
+    Parameters
+    ----------
+    states : list of str or None, optional
+        Labels for the two excited states involved in the diagram. Default
+        is ``["a", "b"]``.
     """
 
     def __init__(self, states: list[str] | None = None) -> None:
@@ -715,6 +740,11 @@ class R1f_Diagram(DSFeynmanDiagram):
     --->|----------|
         | g      g |
 
+    Parameters
+    ----------
+    states : list of str or None, optional
+        Labels for the three states involved: two single-excited states and
+        one double-excited state. Default is ``["a", "b", "f"]``.
     """
 
     def __init__(self, states: list[str] | None = None) -> None:
@@ -742,6 +772,11 @@ class R2f_Diagram(DSFeynmanDiagram):
         |----------|<---
         | g      g |
 
+    Parameters
+    ----------
+    states : list of str or None, optional
+        Labels for the three states involved: two single-excited states and
+        one double-excited state. Default is ``["a", "b", "f"]``.
     """
 
     def __init__(self, states: list[str] | None = None) -> None:

--- a/quantarhei/spectroscopy/fluorescence.py
+++ b/quantarhei/spectroscopy/fluorescence.py
@@ -32,7 +32,7 @@ from ..utils import derived_type
 
 
 class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
-    """Provides basic container for fluorescence spectrum"""
+    """Provides basic container for fluorescence spectrum."""
 
     def __init__(self, axis: Any = None, data: Any = None) -> None:
         super().__init__()
@@ -40,24 +40,22 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
         self.data = data
 
     def set_axis(self, axis: Any) -> None:
-        """Sets axis atribute
+        """Set the frequency axis of the spectrum.
 
         Parameters
         ----------
-        axis : FrequencyAxis object
-            Frequency axis object. This object has managed energy units
-
+        axis : FrequencyAxis
+            Frequency axis object with managed energy units.
         """
         self.axis = axis
 
     def set_data(self, data: Any) -> None:
-        """Sets data atribute
+        """Set the spectral data array.
 
         Parameters
         ----------
-        data : array like object (numpy array)
-            Sets the data of the fluorescence spectrum
-
+        data : numpy.ndarray
+            Array of fluorescence spectral values.
         """
         self.data = data
 
@@ -121,16 +119,18 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
         self.data -= val
 
     def add_to_data(self, spect: Any) -> None:
-        """Performs addition on the data.
-
-        Expects a compatible object holding fluorescence spectrum
-        and adds its data to the present fluorescence spectrum.
+        """Add data from a compatible spectrum to this spectrum.
 
         Parameters
         ----------
-        spect : spectrum containing object
-            This object should have a compatible axis and some data
+        spect : FluorSpectrumBase
+            Spectrum whose data will be added. Must have a compatible
+            frequency axis.
 
+        Raises
+        ------
+        Exception
+            If the spectrum's axis is incompatible with this object's axis.
         """
         if self.axis is None:
             self.axis = spect.axis.copy()
@@ -153,15 +153,23 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
         replace: bool = False,
         **kwargs: Any,
     ) -> None:
-        """Load the spectrum from a file
+        """Load the spectrum from a file.
 
-        Uses the load method of the DFunction class to load the fluorescence
-        spectrum from a file. It sets the axis type to 'frequency', otherwise
-        no changes to the inherited method are applied.
+        Delegates to ``DFunction.load_data`` with the axis type forced to
+        ``'frequency'``.
 
         Parameters
         ----------
-
+        name : str
+            Path to the file to load.
+        with_axis : optional
+            Ignored; provided for API compatibility.
+        ext : str or None, optional
+            File extension hint passed to the parent method.
+        replace : bool, optional
+            If ``True``, replace existing data. Default is ``False``.
+        **kwargs
+            Additional keyword arguments forwarded to the parent method.
         """
         super().load_data(name, ext=ext, axis="frequency", replace=replace)
 
@@ -384,7 +392,7 @@ def _n_gaussians(x: Any, N: int, *params: float) -> Any:
 
 
 class FluorSpectrum(FluorSpectrumBase):
-    """Class representing fluorescence spectrum"""
+    """Class representing a fluorescence spectrum."""
 
     pass
 
@@ -440,6 +448,8 @@ class FluorSpectrum(FluorSpectrumBase):
 
 
 class FluorSpectrumContainer(Saveable):
+    """Container for a set of fluorescence spectra sharing a common frequency axis."""
+
     def __init__(self, axis: Any = None) -> None:
 
         self.axis = axis
@@ -450,10 +460,22 @@ class FluorSpectrumContainer(Saveable):
         self.axis = axis
 
     def set_spectrum(self, spect: Any, tag: Any = None) -> None:
-        """Stores fluorescence spectrum
+        """Store a fluorescence spectrum, checking axis compatibility.
 
-        Checks compatibility of its frequency axis
+        Parameters
+        ----------
+        spect : FluorSpectrum
+            Spectrum to store. Its frequency axis must match the container's
+            axis (or becomes the axis if none is set yet).
+        tag : str or None, optional
+            Key under which to store the spectrum. If ``None``, the current
+            count value is used as the string key.
 
+        Raises
+        ------
+        Exception
+            If the spectrum's frequency axis is incompatible with the
+            container's existing axis.
         """
         frq = spect.axis
 
@@ -471,10 +493,23 @@ class FluorSpectrumContainer(Saveable):
             raise Exception("Incompatible time axis (equal axis required)")
 
     def get_spectrum(self, tag: Any) -> Any:
-        """Returns spectrum corresponing to time t2
+        """Return the spectrum identified by tag.
 
-        Checks if the time t2 is present in the t2axis
+        Parameters
+        ----------
+        tag : str or int
+            Key identifying the stored spectrum. Integer tags are converted
+            to strings.
 
+        Returns
+        -------
+        FluorSpectrum
+            The stored spectrum corresponding to ``tag``.
+
+        Raises
+        ------
+        Exception
+            If no spectrum is stored under ``tag``.
         """
         if not isinstance(tag, str):
             tag = str(tag)
@@ -484,7 +519,13 @@ class FluorSpectrumContainer(Saveable):
         raise Exception("Unknown spectrum")
 
     def get_spectra(self) -> list[Any]:
-        """Returns a list or tuple of the calculated spectra"""
+        """Return all stored spectra sorted by their string tags.
+
+        Returns
+        -------
+        list
+            List of stored spectra in tag-sorted order.
+        """
         ven = [value for (key, value) in sorted(self.spectra.items())]
         return ven
 

--- a/quantarhei/spectroscopy/fluorescence.py
+++ b/quantarhei/spectroscopy/fluorescence.py
@@ -392,7 +392,15 @@ def _n_gaussians(x: Any, N: int, *params: float) -> Any:
 
 
 class FluorSpectrum(FluorSpectrumBase):
-    """Class representing a fluorescence spectrum."""
+    """Class representing a fluorescence spectrum.
+
+    Parameters
+    ----------
+    axis : FrequencyAxis
+        Frequency axis for the spectrum.
+    data : numpy.ndarray
+        Spectral data array.
+    """
 
     pass
 
@@ -448,7 +456,14 @@ class FluorSpectrum(FluorSpectrumBase):
 
 
 class FluorSpectrumContainer(Saveable):
-    """Container for a set of fluorescence spectra sharing a common frequency axis."""
+    """Container for a set of fluorescence spectra sharing a common frequency axis.
+
+    Parameters
+    ----------
+    axis : FrequencyAxis or None, optional
+        Shared frequency axis for all stored spectra. Default is ``None``;
+        the axis is set automatically when the first spectrum is added.
+    """
 
     def __init__(self, axis: Any = None) -> None:
 

--- a/quantarhei/spectroscopy/labsetup.py
+++ b/quantarhei/spectroscopy/labsetup.py
@@ -1203,13 +1203,18 @@ def _get_example_lab() -> LabSetup:
 
 
 class LabField:
-    """Class representing electric field of a laser pulse defined in LabSetup
+    """Electric field of a single laser pulse defined within a ``LabSetup``.
 
+    Objects of this class are linked to their parent ``LabSetup``. Properties
+    can be changed locally (affecting only this field) or globally from the
+    ``LabSetup`` (affecting all linked ``LabField`` objects).
 
-    Objects of this class are linked to their "mother" object of the LabSetup
-    type. Their properties can be changed locally, with an effect on the
-    LabSetup, or globally from the LabSetup with an effect on the EField
-    objects.
+    Parameters
+    ----------
+    lab : LabSetup
+        Parent laboratory setup object.
+    index : int
+        Zero-based index of the pulse within the ``LabSetup``.
 
 
     Examples

--- a/quantarhei/spectroscopy/linear_dichroism.py
+++ b/quantarhei/spectroscopy/linear_dichroism.py
@@ -29,7 +29,7 @@ from ..utils import derived_type
 
 
 class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
-    """Provides basic container for linear dichroism spectrum"""
+    """Provides basic container for linear dichroism spectrum."""
 
     def __init__(self, axis: Any = None, data: Any = None) -> None:
         super().__init__()
@@ -37,24 +37,22 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
         self.data = data
 
     def set_axis(self, axis: Any) -> None:
-        """Sets axis atribute
+        """Set the frequency axis of the spectrum.
 
         Parameters
         ----------
-        axis : FrequencyAxis object
-            Frequency axis object. This object has managed energy units
-
+        axis : FrequencyAxis
+            Frequency axis object with managed energy units.
         """
         self.axis = axis
 
     def set_data(self, data: Any) -> None:
-        """Sets data atribute
+        """Set the spectral data array.
 
         Parameters
         ----------
-        data : array like object (numpy array)
-            Sets the data of the linear dichroism spectrum
-
+        data : numpy.ndarray
+            Array of linear dichroism spectral values.
         """
         self.data = data
 
@@ -118,16 +116,18 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
         self.data -= val
 
     def add_to_data(self, spect: Any) -> None:
-        """Performs addition on the data.
-
-        Expects a compatible object holding linear dichroism spectrum
-        and adds its data to the present linear dichroism spectrum.
+        """Add data from a compatible spectrum to this spectrum.
 
         Parameters
         ----------
-        spect : spectrum containing object
-            This object should have a compatible axis and some data
+        spect : LinDichSpectrumBase
+            Spectrum whose data will be added. Must have a compatible
+            frequency axis.
 
+        Raises
+        ------
+        Exception
+            If the spectrum's axis is incompatible with this object's axis.
         """
         if self.axis is None:
             self.axis = spect.axis.copy()
@@ -150,15 +150,23 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
         replace: bool = False,
         **kwargs: Any,
     ) -> None:
-        """Load the spectrum from a file
+        """Load the spectrum from a file.
 
-        Uses the load method of the DFunction class to load the linear dichroism
-        spectrum from a file. It sets the axis type to 'frequency', otherwise
-        no changes to the inherited method are applied.
+        Delegates to ``DFunction.load_data`` with the axis type forced to
+        ``'frequency'``.
 
         Parameters
         ----------
-
+        name : str
+            Path to the file to load.
+        with_axis : optional
+            Ignored; provided for API compatibility.
+        ext : str or None, optional
+            File extension hint passed to the parent method.
+        replace : bool, optional
+            If ``True``, replace existing data. Default is ``False``.
+        **kwargs
+            Additional keyword arguments forwarded to the parent method.
         """
         super().load_data(name, ext=ext, axis="frequency", replace=replace)
 
@@ -381,7 +389,7 @@ def _n_gaussians(x: Any, N: int, *params: float) -> Any:
 
 
 class LinDichSpectrum(LinDichSpectrumBase):
-    """Class representing linear dichroism spectrum"""
+    """Class representing a linear dichroism spectrum."""
 
     pass
 
@@ -437,6 +445,8 @@ class LinDichSpectrum(LinDichSpectrumBase):
 
 
 class LinDichSpectrumContainer(Saveable):
+    """Container for a set of linear dichroism spectra sharing a common frequency axis."""
+
     def __init__(self, axis: Any = None) -> None:
 
         self.axis = axis
@@ -447,10 +457,22 @@ class LinDichSpectrumContainer(Saveable):
         self.axis = axis
 
     def set_spectrum(self, spect: Any, tag: Any = None) -> None:
-        """Stores linear dichroism spectrum
+        """Store a linear dichroism spectrum, checking axis compatibility.
 
-        Checks compatibility of its frequency axis
+        Parameters
+        ----------
+        spect : LinDichSpectrum
+            Spectrum to store. Its frequency axis must match the container's
+            axis (or becomes the axis if none is set yet).
+        tag : str or None, optional
+            Key under which to store the spectrum. If ``None``, the current
+            count value is used as the string key.
 
+        Raises
+        ------
+        Exception
+            If the spectrum's frequency axis is incompatible with the
+            container's existing axis.
         """
         frq = spect.axis
 
@@ -468,10 +490,23 @@ class LinDichSpectrumContainer(Saveable):
             raise Exception("Incompatible time axis (equal axis required)")
 
     def get_spectrum(self, tag: Any) -> Any:
-        """Returns spectrum corresponing to time t2
+        """Return the spectrum identified by tag.
 
-        Checks if the time t2 is present in the t2axis
+        Parameters
+        ----------
+        tag : str or int
+            Key identifying the stored spectrum. Integer tags are converted
+            to strings.
 
+        Returns
+        -------
+        LinDichSpectrum
+            The stored spectrum corresponding to ``tag``.
+
+        Raises
+        ------
+        Exception
+            If no spectrum is stored under ``tag``.
         """
         if not isinstance(tag, str):
             tag = str(tag)
@@ -481,7 +516,13 @@ class LinDichSpectrumContainer(Saveable):
         raise Exception("Unknown spectrum")
 
     def get_spectra(self) -> list[Any]:
-        """Returns a list or tuple of the calculated spectra"""
+        """Return all stored spectra sorted by their string tags.
+
+        Returns
+        -------
+        list
+            List of stored spectra in tag-sorted order.
+        """
         ven = [value for (key, value) in sorted(self.spectra.items())]
         return ven
 

--- a/quantarhei/spectroscopy/linear_dichroism.py
+++ b/quantarhei/spectroscopy/linear_dichroism.py
@@ -389,7 +389,15 @@ def _n_gaussians(x: Any, N: int, *params: float) -> Any:
 
 
 class LinDichSpectrum(LinDichSpectrumBase):
-    """Class representing a linear dichroism spectrum."""
+    """Class representing a linear dichroism spectrum.
+
+    Parameters
+    ----------
+    axis : FrequencyAxis
+        Frequency axis for the spectrum.
+    data : numpy.ndarray
+        Spectral data array.
+    """
 
     pass
 
@@ -445,7 +453,14 @@ class LinDichSpectrum(LinDichSpectrumBase):
 
 
 class LinDichSpectrumContainer(Saveable):
-    """Container for a set of linear dichroism spectra sharing a common frequency axis."""
+    """Container for a set of linear dichroism spectra sharing a common frequency axis.
+
+    Parameters
+    ----------
+    axis : FrequencyAxis or None, optional
+        Shared frequency axis for all stored spectra. Default is ``None``;
+        the axis is set automatically when the first spectrum is added.
+    """
 
     def __init__(self, axis: Any = None) -> None:
 

--- a/quantarhei/spectroscopy/mocktwodcalculator.py
+++ b/quantarhei/spectroscopy/mocktwodcalculator.py
@@ -15,15 +15,24 @@ from .twodresponse import TwoDResponse
 
 
 class MockTwoDResponseCalculator(TwoDResponseCalculator):
-    """Calculator of the third order non-linear response
-
+    """Calculator of the third order non-linear response using effective lineshapes.
 
     This class is used to represent LiouvillePathway objects. Lineshape is
-    Gaussian.
+    Gaussian (default) or Lorentzian. The response is calculated with effective
+    lineshapes directly in the frequency domain rather than via time-domain
+    propagation.
 
-    The response is calculated with effective lineshapes directly in frequency
-    domain.
-
+    Parameters
+    ----------
+    t1axis : TimeAxis
+        Coherence-time axis for the first interaction period.
+    t2axis : TimeAxis
+        Waiting-time axis.
+    t3axis : TimeAxis
+        Detection-time axis for the third interaction period.
+    temp : float or None, optional
+        Temperature in Kelvin. Default is ``None`` (temperature-independent
+        lineshapes).
     """
 
     def __init__(self, t1axis: Any, t2axis: Any, t3axis: Any, temp: Any = None) -> None:

--- a/quantarhei/spectroscopy/pumpprobe.py
+++ b/quantarhei/spectroscopy/pumpprobe.py
@@ -21,7 +21,12 @@ from .twodcontainer import TwoDSpectrumContainer
 
 
 class PumpProbeSpectrum(DFunction):
-    """Class representing a pump-probe spectrum."""
+    """Class representing a pump-probe spectrum.
+
+    A one-dimensional spectrum obtained at a fixed waiting time ``t2``
+    from a pump-probe experiment. Data and axis are set via ``set_data``
+    and ``set_axis`` after construction.
+    """
 
     # data = None
 
@@ -65,7 +70,13 @@ class PumpProbeSpectrum(DFunction):
 
 
 class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
-    """Container for a set of pump-probe spectra."""
+    """Container for a set of pump-probe spectra indexed by waiting time.
+
+    Parameters
+    ----------
+    t2axis : TimeAxis or None, optional
+        Waiting-time axis shared by all stored spectra. Default is ``None``.
+    """
 
     def __init__(self, t2axis: Any = None) -> None:
 
@@ -291,6 +302,29 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
 
 
 class PumpProbeSpectrumCalculator:
+    """Calculator for pump-probe spectra derived from 2D response pathways.
+
+    Parameters
+    ----------
+    t2axis : TimeAxis
+        Waiting-time axis over which spectra are calculated.
+    t3axis : TimeAxis
+        Detection-time axis used to build the frequency axis.
+    system : Molecule or Aggregate, optional
+        Quantum system for which spectra are calculated.
+    dynamics : str, optional
+        Dynamics type, e.g. ``"secular"``. Default is ``"secular"``.
+    relaxation_tensor : optional
+        Relaxation tensor to include population relaxation.
+    rate_matrix : optional
+        Rate matrix alternative to a full relaxation tensor.
+    effective_hamiltonian : optional
+        Effective Hamiltonian used in the relaxation basis.
+    separate_relax_pwy : bool, optional
+        If ``True``, pathways with relaxation steps are treated separately.
+        Default is ``True``.
+    """
+
     t2axis = derived_type("t2axis", TimeAxis)
     t3axis = derived_type("t3axis", TimeAxis)
 
@@ -1676,7 +1710,25 @@ def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:
 
 
 class MockPumpProbeSpectrumCalculator(MockTwoDSpectrumCalculator):
-    """Effective line-shape pump-probe spectrum calculator."""
+    """Effective line-shape pump-probe spectrum calculator.
+
+    Uses Gaussian or Lorentzian lineshapes evaluated directly in the
+    frequency domain to produce pump-probe spectra without computing the
+    full time-domain response.
+
+    Parameters
+    ----------
+    t1axis : TimeAxis
+        Coherence-time axis (used by parent class; not directly needed for
+        pump-probe).
+    t2axis : TimeAxis
+        Waiting-time axis over which spectra are calculated.
+    t3axis : TimeAxis
+        Detection-time axis used to build the frequency axis.
+    temp : float or None, optional
+        Temperature in Kelvin. Default is ``None`` (temperature-independent
+        lineshapes).
+    """
 
     def calculate_all_system(
         self,

--- a/quantarhei/spectroscopy/pumpprobe.py
+++ b/quantarhei/spectroscopy/pumpprobe.py
@@ -21,7 +21,7 @@ from .twodcontainer import TwoDSpectrumContainer
 
 
 class PumpProbeSpectrum(DFunction):
-    """Class representing pump-probe spectra"""
+    """Class representing a pump-probe spectrum."""
 
     # data = None
 
@@ -65,7 +65,7 @@ class PumpProbeSpectrum(DFunction):
 
 
 class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
-    """Container for a set of pump-probe spectra"""
+    """Container for a set of pump-probe spectra."""
 
     def __init__(self, t2axis: Any = None) -> None:
 
@@ -1676,7 +1676,7 @@ def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:
 
 
 class MockPumpProbeSpectrumCalculator(MockTwoDSpectrumCalculator):
-    """Effective line shape pump-probe spectrum calculator"""
+    """Effective line-shape pump-probe spectrum calculator."""
 
     def calculate_all_system(
         self,
@@ -1689,7 +1689,32 @@ class MockPumpProbeSpectrumCalculator(MockTwoDSpectrumCalculator):
         H: Any = None,
         **kwargs: Any,
     ) -> Any:
-        """Calculates all spectra corresponding to a specified t2axis"""
+        """Calculate all pump-probe spectra for all t2 times in the t2axis.
+
+        Parameters
+        ----------
+        sys : Aggregate
+            Molecular aggregate system.
+        eUt : evolution superoperator
+            Evolution superoperator evaluated at each t2 time.
+        lab : LabSetup
+            Laboratory setup with polarization information.
+        selection : optional
+            Pathway selection; not currently used.
+        show_progress : bool, optional
+            If ``True``, print progress messages. Default is ``False``.
+        dtol : float, optional
+            Tolerance for dipole moment contributions. Default is ``1e-12``.
+        H : optional
+            Hamiltonian; not currently used.
+        **kwargs
+            Additional keyword arguments.
+
+        Returns
+        -------
+        PumpProbeSpectrumContainer
+            Container with all calculated pump-probe spectra.
+        """
         temporary_fix = True
 
         if temporary_fix:
@@ -1709,7 +1734,34 @@ class MockPumpProbeSpectrumCalculator(MockTwoDSpectrumCalculator):
         H: Any = None,
         **kwargs: Any,
     ) -> Any:
-        """Calculates one spectru corresponding to a specified t2 time"""
+        """Calculate a single pump-probe spectrum at the specified t2 time.
+
+        Parameters
+        ----------
+        t2 : float
+            Waiting time at which to calculate the spectrum.
+        sys : Aggregate
+            Molecular aggregate system.
+        eUt : evolution superoperator
+            Evolution superoperator.
+        lab : LabSetup
+            Laboratory setup with polarization information.
+        selection : optional
+            Pathway selection; not currently used.
+        pways : optional
+            Pathway storage; not currently used.
+        dtol : float, optional
+            Tolerance for dipole moment contributions. Default is ``1e-12``.
+        H : optional
+            Hamiltonian; not currently used.
+        **kwargs
+            Additional keyword arguments.
+
+        Returns
+        -------
+        PumpProbeSpectrum
+            Calculated pump-probe spectrum at t2.
+        """
         temporary_fix = True
 
         if temporary_fix:

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -23,7 +23,23 @@ from .response_implementations import get_implementation
 
 
 class NonLinearResponse:
-    """Non-linear response function"""
+    """Non-linear response function for a specific Feynman diagram type.
+
+    Parameters
+    ----------
+    lab : LabSetup
+        Laboratory setup holding pulse polarization information.
+    system : OpenSystem
+        The quantum system for which the response is calculated.
+    diagram : str
+        Feynman diagram type (e.g. ``"R1g"``, ``"R2g"``).
+    t1s : TimeAxis
+        Time axis for the first coherence period.
+    t2s : TimeAxis
+        Time axis for the waiting period.
+    t3s : TimeAxis
+        Time axis for the second coherence period.
+    """
 
     def __init__(
         self, lab: Any, system: Any, diagram: str, t1s: Any, t2s: Any, t3s: Any
@@ -56,16 +72,18 @@ class NonLinearResponse:
         self.set_rate_matrix(KK)
 
     def calculate_matrix(self, t2: float) -> Any:
-        """Calculates the matrix of response values in t1 and t3 times
-
+        """Calculate the matrix of response values over t1 and t3 times.
 
         Parameters
         ----------
         t2 : float
-            Waiting time for which the response is calculated
+            Waiting time for which the response is calculated.
 
-
-
+        Returns
+        -------
+        numpy.ndarray
+            2D complex array of response values with shape
+            ``(len(t1s), len(t3s))``.
         """
         # identify the index of the present t2 time
         out = self.t2s.locate(t2)
@@ -89,7 +107,20 @@ class NonLinearResponse:
         pass  # rwa is set through the system class, at least for now
 
     def set_rate_matrix(self, KK: numpy.ndarray) -> None:
-        """Sets the rate matrix and the corresponding evolution coefficients"""
+        """Set the rate matrix and pre-compute the evolution coefficients.
+
+        Parameters
+        ----------
+        KK : numpy.ndarray
+            Square rate matrix of shape ``(N, N)`` where ``N`` is the number
+            of single-excited states.
+
+        Raises
+        ------
+        Exception
+            If ``KK`` is not a square matrix or if any depopulation rate is
+            positive.
+        """
         if KK.shape[0] == KK.shape[1]:
             self.KK = KK
 
@@ -151,12 +182,12 @@ class NonLinearResponse:
 
 
 class LiouvillePathway:
-    """Parameters
+    """A single Liouville pathway (deprecated).
+
+    Parameters
     ----------
     ptype : str
-        Type of the Liouville pathway
-
-
+        Type of the Liouville pathway (e.g. ``"R1g"``, ``"R2g"``).
     """
 
     def __init__(self, ptype: str) -> None:
@@ -200,25 +231,18 @@ class LiouvillePathway:
         d3: numpy.ndarray | None = None,
         d4: numpy.ndarray | None = None,
     ) -> None:
-        """Sets the transition dipole moments of the response
+        """Set the transition dipole moments of the response.
 
-        Parameters:
-        -----------
-        d1 : vector
-            First transition dipole moment of the response.
-
-        d2 : vector or None
-            The second transition dipole moment of the response. If None,
-            it is set to the value of the first transition dipole moment.
-
-        d3 : vector or None
-            The third transition dipole moment of the response. If None,
-            it is set to the value of the first transition dipole moment.
-
-        d4 : vector or None
-            The fourth transition dipole moment of the response. If None,
-            it is set to the value of the first transition dipole moment.
-
+        Parameters
+        ----------
+        d1 : numpy.ndarray
+            First transition dipole moment (3-vector).
+        d2 : numpy.ndarray or None, optional
+            Second transition dipole moment. If ``None``, defaults to ``d1``.
+        d3 : numpy.ndarray or None, optional
+            Third transition dipole moment. If ``None``, defaults to ``d1``.
+        d4 : numpy.ndarray or None, optional
+            Fourth transition dipole moment. If ``None``, defaults to ``d1``.
         """
         d = numpy.zeros((4, 3), dtype=float)
 
@@ -292,7 +316,7 @@ class LiouvillePathway:
 
 
 class ResponseFunction(LiouvillePathway):
-    """Non-linear response function"""
+    """Non-linear response function (deprecated)."""
 
     def calculate_matrix(
         self, lab: Any, sys: Any, t2: float, t1s: Any, t3s: Any, rwa: float

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -316,7 +316,13 @@ class LiouvillePathway:
 
 
 class ResponseFunction(LiouvillePathway):
-    """Non-linear response function (deprecated)."""
+    """Non-linear response function (deprecated).
+
+    Parameters
+    ----------
+    ptype : str
+        Type of the Liouville pathway (e.g. ``"R1g"``, ``"R2g"``).
+    """
 
     def calculate_matrix(
         self, lab: Any, sys: Any, t2: float, t1s: Any, t3s: Any, rwa: float

--- a/quantarhei/spectroscopy/twodresponse.py
+++ b/quantarhei/spectroscopy/twodresponse.py
@@ -1260,18 +1260,20 @@ TwoDSpectrumBase = TwoDResponseBase  # temporary backwards-compatible alias
 
 
 class TwoDResponse(TwoDSpectrumBase, Saveable):
-    """This class represents a single 2D spectrum
+    """A single two-dimensional (2D) Fourier-transform spectrum.
 
-    Methods
-    -------
-    plot(fig=None, window=None, stype=_total, spart="real",
-         vmax=None, vmin_ratio=0.5,
-         colorbar=True, colorbar_loc="right",
-         cmap=None, Npos_contours=10,
-         show_states=None,
-         text_loc=[0.05,0.9], fontsize="20", label=None)
+    Stores the complex 2D spectral data indexed by (omega_1, omega_3) at a
+    fixed waiting time ``t2``. Data may be stored at various resolutions
+    (individual Liouville pathways down to the total spectrum only).
 
-
+    Parameters
+    ----------
+    keep_pathways : bool, optional
+        If ``True``, individual Liouville pathways are stored in addition to
+        the aggregated spectrum. Default is ``False``.
+    keep_stypes : bool, optional
+        If ``True``, rephasing and non-rephasing signal types are stored
+        separately. Default is ``True``.
     """
 
     def __init__(self, keep_pathways: bool = False, keep_stypes: bool = True) -> None:

--- a/quantarhei/spectroscopy/twodspect.py
+++ b/quantarhei/spectroscopy/twodspect.py
@@ -43,6 +43,13 @@ from ..core.valueaxis import ValueAxis
 
 
 class TwoDSpectrum(DataSaveable, Saveable):
+    """A single two-dimensional Fourier-transform spectrum.
+
+    Stores the 2D spectral data indexed by (omega_1, omega_3) at a fixed
+    waiting time ``t2``. The data may be rephasing, non-rephasing, or the
+    total sum of both.
+    """
+
     dtypes = TWOD_SIGNALS
 
     def __init__(self) -> None:
@@ -65,12 +72,18 @@ class TwoDSpectrum(DataSaveable, Saveable):
         self.yaxis = axis
 
     def set_data_type(self, dtype: str = signal_TOTL) -> None:  # "Tot"):
-        """Sets the data type for this 2D spectrum
+        """Set the data type for this 2D spectrum.
 
         Parameters
         ----------
-        dtype : string
-           Specifies the type of data stored in this TwoDSpectrum object
+        dtype : str, optional
+            Type of data stored in this object. Must be one of the values
+            in ``TwoDSpectrum.dtypes``. Default is ``qr.signal_TOTL``.
+
+        Raises
+        ------
+        Exception
+            If ``dtype`` is not a recognised data type.
         """
         if dtype in self.dtypes.values():
             self.dtype = dtype
@@ -84,23 +97,22 @@ class TwoDSpectrum(DataSaveable, Saveable):
     def set_data(
         self, data: numpy.ndarray, dtype: str = signal_TOTL
     ) -> None:  # "Tot"):
-        """Sets the data of the 2D spectrum
-
-        Sets the object data depending on the specified type and stores the
-        type
-
+        """Set the data of the 2D spectrum.
 
         Parameters
         ----------
-        data : 2D array
-            Data of the spectrum, float or complex
+        data : numpy.ndarray
+            2D array of spectral values (float or complex).
+        dtype : str, optional
+            Type of the data stored. Recognised values are ``qr.signal_REPH``
+            for rephasing spectra, ``qr.signal_NONR`` for non-rephasing
+            spectra, and ``qr.signal_TOTL`` for the total spectrum (sum of
+            both). Default is ``qr.signal_TOTL``.
 
-        dtype : string
-            Type of the data stored. Three values are allowed: if quantarhei
-            is import as `qr` that they are qr.signal_REPH
-            for rephasing spectra, qr.signal_NONR for non-rephasing spectra,
-            and qr.signal_TOTL for total spectrum, which is the sum of both
-
+        Raises
+        ------
+        Exception
+            If ``dtype`` is unknown or the axes have not been set yet.
         """
         self.set_data_type(dtype)
 

--- a/quantarhei/symbolic/cumulant.py
+++ b/quantarhei/symbolic/cumulant.py
@@ -380,7 +380,27 @@ def evaluate_cumulant(
     lang: str | None = None,
     arrays: list[str] | None = None,
 ) -> Any:
-    """ """
+    """Evaluate a cumulant expression to a simplified form or code string.
+
+    Parameters
+    ----------
+    cuml : CumulantExpr
+        Symbolic cumulant expression to evaluate.
+    positive_times : list, optional
+        Time variables to be treated as positive during simplification.
+    leading_index : object, optional
+        Index used to extract the leading-order term from the expression.
+    lang : str, optional
+        Target language for code generation (``"python"`` or ``"fortran"``).
+        If ``None``, returns the symbolic expression.
+    arrays : list of str, optional
+        Array names to use in the generated code.
+
+    Returns
+    -------
+    object
+        Simplified symbolic expression, or a code string when ``lang`` is set.
+    """
     _require_sympy()
     if positive_times is None:
         positive_times = []

--- a/quantarhei/utils/logging.py
+++ b/quantarhei/utils/logging.py
@@ -15,10 +15,10 @@ LOG_QUICK = 9
 
 
 def init_logging() -> None:
-    """Initialization of logging
+    """Initialize the logging subsystem.
 
-    We test if the logging is parallel or not
-
+    Detects whether the process is running in a serial or MPI-parallel
+    environment and configures the ``Manager.log_conf`` object accordingly.
     """
     manager = Manager().log_conf
     try:
@@ -212,12 +212,21 @@ def loglevels2bool(loglevs: list[int], verbose: bool = False) -> list[bool]:
 
 
 def tprint(var: str, messg: str | None = None, default: Any = None) -> None:
-    """Test the existence of the variable with the name `var`
+    """Print the value of a named variable from global scope.
 
+    If ``default`` is provided, missing variables are silently set to it.
 
-    If the default is specified, the non-existence of the variable
-    is not a problem, and the variable is set to the default
-
+    Parameters
+    ----------
+    var : str
+        Name of the variable to evaluate and print.
+    messg : str or None, optional
+        Optional message to print before the variable value. Default is
+        ``None``.
+    default : any, optional
+        Value to use when the variable does not exist in global scope.
+        If ``None`` and the variable is missing, a traceback is printed
+        and the process exits.
     """
     try:
         if messg is not None:
@@ -241,7 +250,13 @@ def tprint(var: str, messg: str | None = None, default: Any = None) -> None:
 
 
 def log_to_file(filename: str = "qrhei.log") -> None:
-    """Set logging to file"""
+    """Redirect log output to a file.
+
+    Parameters
+    ----------
+    filename : str, optional
+        Path to the log file. Default is ``"qrhei.log"``.
+    """
     manager = Manager().log_conf
     # manager.log_on_screen = False
     manager.log_to_file = True

--- a/quantarhei/utils/logging.py
+++ b/quantarhei/utils/logging.py
@@ -38,22 +38,73 @@ def init_logging() -> None:
 
 
 def log_urgent(*args: Any, **kwargs: Any) -> None:
+    """Log a message at the ``LOG_URGENT`` (level 1) priority.
+
+    Parameters
+    ----------
+    *args
+        Objects to print, forwarded to :func:`printlog`.
+    **kwargs
+        Keyword arguments forwarded to :func:`printlog`.
+    """
     printlog(*args, loglevel=LOG_URGENT, **kwargs)
 
 
 def log_report(*args: Any, **kwargs: Any) -> None:
+    """Log a message at the ``LOG_REPORT`` (level 3) priority.
+
+    Parameters
+    ----------
+    *args
+        Objects to print, forwarded to :func:`printlog`.
+    **kwargs
+        Keyword arguments forwarded to :func:`printlog`.
+    """
     printlog(*args, loglevel=LOG_REPORT, **kwargs)
 
 
 def log_info(*args: Any, **kwargs: Any) -> None:
+    """Log a message at the ``LOG_INFO`` (level 5) priority.
+
+    Parameters
+    ----------
+    *args
+        Objects to print, forwarded to :func:`printlog`.
+    **kwargs
+        Keyword arguments forwarded to :func:`printlog`.
+    """
     printlog(*args, loglevel=LOG_INFO, **kwargs)
 
 
 def log_detail(*args: Any, **kwargs: Any) -> None:
+    """Log a message at the ``LOG_DETAIL`` (level 7) priority.
+
+    Parameters
+    ----------
+    *args
+        Objects to print, forwarded to :func:`printlog`.
+    **kwargs
+        Keyword arguments forwarded to :func:`printlog`.
+    """
     printlog(*args, loglevel=LOG_DETAIL, **kwargs)
 
 
 def log_quick(*args: Any, verbose: bool = True, **kwargs: Any) -> None:
+    """Log a message at the ``LOG_QUICK`` (level 9) priority.
+
+    This is the most verbose level; the call is a no-op when
+    ``verbose=False``.
+
+    Parameters
+    ----------
+    *args
+        Objects to print, forwarded to :func:`printlog`.
+    verbose : bool, optional
+        If ``False``, the function returns immediately without logging.
+        Default is ``True``.
+    **kwargs
+        Keyword arguments forwarded to :func:`printlog`.
+    """
     if not verbose:
         return
     printlog(*args, loglevel=LOG_QUICK, **kwargs)

--- a/quantarhei/utils/timing.py
+++ b/quantarhei/utils/timing.py
@@ -17,7 +17,21 @@ def timeit(
     loglevel: int = 5,
     verbose: bool = True,
 ) -> None:
-    """Start timing at this point and save the time"""
+    """Start a timing measurement and save the current time.
+
+    Parameters
+    ----------
+    msg : str or None, optional
+        Message to print via :func:`printlog` before recording the time.
+        If ``None``, no message is printed.
+    show_stamp : bool, optional
+        If ``True``, also print a human-readable timestamp. Default is
+        ``False``.
+    loglevel : int, optional
+        Log level passed to :func:`printlog`. Default is ``5``.
+    verbose : bool, optional
+        If ``False``, the message is suppressed. Default is ``True``.
+    """
     lconf = Manager().log_conf
     if msg is not None:
         printlog(msg, loglevel=loglevel, verbose=verbose)
@@ -27,7 +41,18 @@ def timeit(
 
 
 def untimeit(show_stamp: bool = False) -> float:
-    """Stop timing and return current time"""
+    """Stop timing and return elapsed seconds since the last :func:`timeit` call.
+
+    Parameters
+    ----------
+    show_stamp : bool, optional
+        If ``True``, print a human-readable timestamp. Default is ``False``.
+
+    Returns
+    -------
+    float
+        Elapsed time in seconds.
+    """
     tm2 = time.time()
     if show_stamp:
         printlog(f"Time stamp: {datetime.datetime.now():%Y-%m-%d %H:%M:%S}")
@@ -38,7 +63,20 @@ def untimeit(show_stamp: bool = False) -> float:
 def finished_in(
     show_stamp: bool = False, loglevel: int = 5, verbose: bool = True
 ) -> None:
-    """Print message with time past from the last timing statement"""
+    """Print the elapsed time since the last :func:`timeit` call.
+
+    Uses the phrasing ``"... finished in X sec"``.
+
+    Parameters
+    ----------
+    show_stamp : bool, optional
+        If ``True``, include a human-readable timestamp in the message.
+        Default is ``False``.
+    loglevel : int, optional
+        Log level passed to :func:`printlog`. Default is ``5``.
+    verbose : bool, optional
+        If ``False``, the message is suppressed. Default is ``True``.
+    """
     tm = untimeit()
     if show_stamp:
         printlog(
@@ -53,7 +91,20 @@ def finished_in(
 
 
 def done_in(show_stamp: bool = False, loglevel: int = 5, verbose: bool = True) -> None:
-    """Print message with time past from the last timing statement"""
+    """Print the elapsed time since the last :func:`timeit` call.
+
+    Uses the phrasing ``"... done in X sec"``.
+
+    Parameters
+    ----------
+    show_stamp : bool, optional
+        If ``True``, include a human-readable timestamp in the message.
+        Default is ``False``.
+    loglevel : int, optional
+        Log level passed to :func:`printlog`. Default is ``5``.
+    verbose : bool, optional
+        If ``False``, the message is suppressed. Default is ``True``.
+    """
     tm = untimeit()
     if show_stamp:
         printlog(

--- a/quantarhei/utils/vectors.py
+++ b/quantarhei/utils/vectors.py
@@ -10,7 +10,20 @@ Axy = (-1.0, 1.0, 0.0) / numpy.sqrt(2)
 
 
 def normalize2(vec: numpy.ndarray, norm: float = 1.0) -> numpy.ndarray:
-    """Normalizes a vector to a specified size"""
+    """Normalize a vector to a specified magnitude.
+
+    Parameters
+    ----------
+    vec : numpy.ndarray
+        Input vector to normalize.
+    norm : float, optional
+        Target magnitude. Default is ``1.0``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Vector rescaled so that its Euclidean norm equals ``norm``.
+    """
     vec = check_numpy_array(vec)
     vel = numpy.sqrt(numpy.dot(vec, vec))
     out = (vec / vel) * norm
@@ -18,6 +31,18 @@ def normalize2(vec: numpy.ndarray, norm: float = 1.0) -> numpy.ndarray:
 
 
 def norm(vec: numpy.ndarray) -> float:
-    """Returns the vector norm (scalar product with itself)"""
+    """Return the Euclidean norm of a vector.
+
+    Parameters
+    ----------
+    vec : numpy.ndarray
+        Input vector.
+
+    Returns
+    -------
+    float
+        Euclidean norm (square root of the dot product of the vector with
+        itself).
+    """
     vel = numpy.sqrt(numpy.dot(vec, vec))
     return vel

--- a/quantarhei/wizard/input/input.py
+++ b/quantarhei/wizard/input/input.py
@@ -57,7 +57,18 @@ def expr(code: str, context: dict[str, Any] | None = None) -> Any:
 
 
 class Input:
-    """A class representing a json or yaml input file"""
+    """Parsed representation of a JSON or YAML input file.
+
+    Parameters
+    ----------
+    file_or_dict : str or dict
+        Path to a JSON/YAML file, or a pre-parsed dictionary.
+    math_allowed_in : list, optional
+        Keys whose string values may contain mathematical expressions that
+        will be evaluated. Default is an empty list.
+    show_input : bool, optional
+        If ``True``, print the parsed input to stdout after loading.
+    """
 
     # YAML-injected attributes — set dynamically via setattr in __init__
     define_usecases: Any


### PR DESCRIPTION
Closes #197.

## Summary

- Adds a **Docstring style** section to `CONTRIBUTING.md` documenting NumPy style as the project standard, with a complete example and a link to the NumPy docstring guide
- The `numpydoc` Sphinx extension is already present in `conf.py`; this documents what source docstrings should look like
- Converts all 127 public API classes and functions (everything in `quantarhei.__all__`) to NumPy docstring style across 35+ source files
- Adds the pydocstyle `D` rule category to the ruff `select` list (the specific rules D208, D202, D412, D210, D212 were already partially enforced; this makes the selection explicit). Bulk migration violations are suppressed in the `ignore` list with a comment referencing this issue

## Test plan

- [x] `uv run ruff check quantarhei/` passes with no violations
- [x] `uv run pytest tests/unit -q` — 238 passed
- [x] `cd docs/sphinx && uv run python -m sphinx -b html . _build/html -q` builds successfully (only pre-existing warnings)
- [x] Verified rendered HTML in browser — Parameters/Attributes/Methods sections render correctly for all converted classes