### PR TITLE
#325 chore: remove stale protect_basis comments from examples

### DIFF
--- a/examples/demo_018_ModifiedRedfieldTheory_1.py
+++ b/examples/demo_018_ModifiedRedfieldTheory_1.py
@@ -58,17 +58,12 @@ print("""
 #m.warn_about_basis_change = False
 
 
-#ham.protect_basis()
-#with qr.eigenbasis_of(ham):
 if True:
 
     print("\nCalculating relaxation rates")
 
     RRM = qr.qm.ModifiedRedfieldRateMatrix(ham, sbi, time)
     RRT = qr.qm.ModRedfieldRelaxationTensor(ham, sbi)
-
-    #numpy.save('mod_red_rates_pentamer-1_env', RRM.rates)
-#ham.unprotect_basis()
 
 print("\nRelaxation times from the rate matrix")
 

--- a/examples/demo_200_Secular.py
+++ b/examples/demo_200_Secular.py
@@ -130,12 +130,6 @@ agg.build()
 (Rfld, ham) = agg.get_RelaxationTensor(timeaxis,"standard_Redfield")
 ham = agg.get_Hamiltonian()
 sbi = agg.get_SystemBathInteraction()
-#
-#ham.protect_basis()
-#with qr.eigenbasis_of(ham):
-#    Rfld = qr.qm.RedfieldRelaxationTensor(ham, sbi, as_operators=False)
-#
-#ham.unprotect_basis()
 with qr.eigenbasis_of(ham):
     Rfld.secularize(legacy=False)
 print("Dephasing from Redfield tensor")

--- a/quantarhei/qm/liouvillespace/modredfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/modredfieldtensor.py
@@ -77,8 +77,6 @@ class ModRedfieldRelaxationTensor(RelaxationTensor):
             HH = self.Hamiltonian
             sbi = self.SystemBathInteraction
 
-            # HH.protect_basis()
-            # with eigenbasis_of(HH):
             if True:
                 if self._has_cutoff_time:
                     cft = self.cutoff_time
@@ -105,5 +103,3 @@ class ModRedfieldRelaxationTensor(RelaxationTensor):
                 # calculate dephasing rates and depopulation rates
                 #
                 self.updateStructure()
-
-            # HH.unprotect_basis()

--- a/quantarhei/wizard/examples/ex_018_ModifiedRedfieldTheory_1.py
+++ b/quantarhei/wizard/examples/ex_018_ModifiedRedfieldTheory_1.py
@@ -56,16 +56,11 @@ print("""
 # m.warn_about_basis_change = False
 
 
-# ham.protect_basis()
-# with qr.eigenbasis_of(ham):
 if True:
     print("\nCalculating relaxation rates")
 
     RRM = qr.qm.ModifiedRedfieldRateMatrix(ham, sbi, time)
     RRT = qr.qm.ModRedfieldRelaxationTensor(ham, sbi)
-
-    # numpy.save('mod_red_rates_pentamer-1_env', RRM.rates)
-# ham.unprotect_basis()
 
 print("\nRelaxation times from the rate matrix")
 

--- a/quantarhei/wizard/examples/ex_200_Secular.py
+++ b/quantarhei/wizard/examples/ex_200_Secular.py
@@ -126,12 +126,6 @@ agg.build()
 (Rfld, ham) = agg.get_RelaxationTensor(timeaxis, "standard_Redfield")
 ham = agg.get_Hamiltonian()
 sbi = agg.get_SystemBathInteraction()
-#
-# ham.protect_basis()
-# with qr.eigenbasis_of(ham):
-#    Rfld = qr.qm.RedfieldRelaxationTensor(ham, sbi, as_operators=False)
-#
-# ham.unprotect_basis()
 with qr.eigenbasis_of(ham):
     Rfld.secularize(legacy=False)
 print("Dephasing from Redfield tensor")


### PR DESCRIPTION
## Summary

- Remove commented-out `protect_basis()` / `unprotect_basis()` calls from examples and `modredfieldtensor.py`
- These reference methods being removed in #328

## Files

- `examples/demo_018_ModifiedRedfieldTheory_1.py`
- `examples/demo_200_Secular.py`
- `quantarhei/wizard/examples/ex_018_ModifiedRedfieldTheory_1.py`
- `quantarhei/wizard/examples/ex_200_Secular.py`
- `quantarhei/qm/liouvillespace/modredfieldtensor.py`

Part of #335. Should be merged after #328.