### PR TITLE
#336 refactor: remove if True/False guards and dead commented-out code

### DIFF
--- a/examples/demo_016_FoersterTheory_1.py
+++ b/examples/demo_016_FoersterTheory_1.py
@@ -53,13 +53,11 @@ rho_i1.data[shp-1,shp-1] = 1.0
 #
 # Propagation of the density matrix
 #
-#with qr.eigenbasis_of(H):
-if True:
-    rho_t1 = prop_Foerster.propagate(rho_i1,
-                                 name="Foerster evolution from aggregate")
+rho_t1 = prop_Foerster.propagate(rho_i1,
+                             name="Foerster evolution from aggregate")
 
-    if _show_plots_:
-        rho_t1.plot(coherences=True, axis=[0,Nt*dt,0,1.0], show=False)
+if _show_plots_:
+    rho_t1.plot(coherences=True, axis=[0,Nt*dt,0,1.0], show=False)
 
 #
 # Thermal excited state to compare with
@@ -69,18 +67,16 @@ rho0 = agg.get_DensityMatrix(condition_type="thermal_excited_state",
                              temperature=300)
 
 if _show_plots_:
-    #with qr.eigenbasis_of(H):
-    if True:
-        pop = numpy.zeros((time.length,shp),dtype=numpy.float64)
-        for i in range(1, H.dim):
-            pop[:,i] = numpy.real(rho0.data[i,i])
-            plt.plot(time.data,pop[:,i],'--k')
+    pop = numpy.zeros((time.length,shp),dtype=numpy.float64)
+    for i in range(1, H.dim):
+        pop[:,i] = numpy.real(rho0.data[i,i])
+        plt.plot(time.data,pop[:,i],'--k')
 
-        # plot the termal distrubution
-        plt.plot(time.data,pop[:,1],'--r')
-        plt.plot(time.data,pop[:,2],'--b')
-        plt.plot(time.data,pop[:,3],'--g')
-        plt.show()
+    # plot the termal distrubution
+    plt.plot(time.data,pop[:,1],'--r')
+    plt.plot(time.data,pop[:,2],'--b')
+    plt.plot(time.data,pop[:,3],'--g')
+    plt.show()
 
 #RR = prop_Foerster.RelaxationTensor
 #with qr.eigenbasis_of(H):

--- a/examples/demo_018_ModifiedRedfieldTheory_1.py
+++ b/examples/demo_018_ModifiedRedfieldTheory_1.py
@@ -54,29 +54,16 @@ print("""
 *******************************************************************************
 """)
 
-#m = qr.Manager()
-#m.warn_about_basis_change = False
+print("\nCalculating relaxation rates")
 
-
-if True:
-
-    print("\nCalculating relaxation rates")
-
-    RRM = qr.qm.ModifiedRedfieldRateMatrix(ham, sbi, time)
-    RRT = qr.qm.ModRedfieldRelaxationTensor(ham, sbi)
+RRM = qr.qm.ModifiedRedfieldRateMatrix(ham, sbi, time)
+RRT = qr.qm.ModRedfieldRelaxationTensor(ham, sbi)
 
 print("\nRelaxation times from the rate matrix")
 
-#with qr.eigenbasis_of(ham):
-if True:
-    for i in range(1,ham.dim-1):
-        for j in range(1,ham.dim-1):
-            #if numpy.abs(RRM.rates[i,j]) > 1.0e-10:
-            print(i, "<-", j, ":", 1.0/numpy.real(RRM.data[i,j]))
-                      #, 1.0/numpy.real(RRT.data[i,i,j,j]), numpy.real(RRT.data[i,j,j,j]))
-
-            #else:
-            #    print(i, "<-", j, ": inf")
+for i in range(1, ham.dim-1):
+    for j in range(1, ham.dim-1):
+        print(i, "<-", j, ":", 1.0/numpy.real(RRM.data[i,j]))
 
 
 

--- a/examples/demo_040_2DSpectrumAceto.py
+++ b/examples/demo_040_2DSpectrumAceto.py
@@ -113,13 +113,6 @@ eUt.set_dense_dt(10)
 
 eUt.calculate()
 
-#if _show_plots_:
-if False:
-    with qr.eigenbasis_of(H):
-        eUt.plot_element((2,2,2,2), show=False)
-        eUt.plot_element((1,1,1,1), show=False)
-        eUt.plot_element((1,1,2,2))
-        eUt.plot_element((1,2,1,2))
 
 
 ###############################################################################

--- a/examples/demo_300_ParallelIterators.py
+++ b/examples/demo_300_ParallelIterators.py
@@ -78,7 +78,5 @@ for k, a in qr.block_distributed_list(lst, return_index=True):
 qr.collect_block_distributed_data(containers, setter, retriever, tags=tags)
 
 # printing the result
-#if config.rank == 0:
-if True:
-    print(config.rank, collected_cont)
+print(config.rank, collected_cont)
 

--- a/examples/old_demos/demo_redfieldfoerster.py
+++ b/examples/old_demos/demo_redfieldfoerster.py
@@ -89,9 +89,6 @@ with eigenbasis_of(H):
 #        print(aa, " sum ", numpy.real(rsum))
 
 
-#with eigenbasis_of(H):
-if True:
-    #rho_eq = agg.get_DensityMatrix(condition_type="")
-    Nshow = Nt*dt
-    rho_t1.plot(coherences=False, axis=[0,Nshow,0,1.0])
-    rho_t2.plot(coherences=False, axis=[0,Nshow,0,1.0])
+Nshow = Nt*dt
+rho_t1.plot(coherences=False, axis=[0,Nshow,0,1.0])
+rho_t2.plot(coherences=False, axis=[0,Nshow,0,1.0])

--- a/quantarhei/builders/aggregate_spectroscopy.py
+++ b/quantarhei/builders/aggregate_spectroscopy.py
@@ -517,31 +517,25 @@ class AggregateSpectroscopy(AggregateBase):
                                             #      |-----------|<----
                                             #      |g_i1> <g_i1|
 
-                                            if True:
-                                                # try:
-                                                lp = diag.liouville_pathway(
-                                                    "R_E",
-                                                    i1g,
-                                                    aggregate=self,
-                                                    order=3,
-                                                    relax_order=1,
-                                                    pname=ptp,
-                                                )
-                                                #      |g_i1> <g_i1|
-                                                lp.add_transition((i2e, i1g), -1)
-                                                #      |g_i1> <e_i2|
-                                                lp.add_transition((i3e, i1g), +1)
-                                                #      |e_i3> <e_i2|
-                                                lp.add_transfer((i4g, i5g), (i3e, i2e))
-                                                #      |g_i4> <g_i5|
-                                                lp.add_transition((i6e, i4g), +1)
-                                                #      |e_i6> <g_i5|
-                                                lp.add_transition((i5g, i6e), +1)
-                                                #      |g_i5> <g_i5|
-
-                                            # except:
-
-                                            #    break
+                                            lp = diag.liouville_pathway(
+                                                "R_E",
+                                                i1g,
+                                                aggregate=self,
+                                                order=3,
+                                                relax_order=1,
+                                                pname=ptp,
+                                            )
+                                            #      |g_i1> <g_i1|
+                                            lp.add_transition((i2e, i1g), -1)
+                                            #      |g_i1> <e_i2|
+                                            lp.add_transition((i3e, i1g), +1)
+                                            #      |e_i3> <e_i2|
+                                            lp.add_transfer((i4g, i5g), (i3e, i2e))
+                                            #      |g_i4> <g_i5|
+                                            lp.add_transition((i6e, i4g), +1)
+                                            #      |e_i6> <g_i5|
+                                            lp.add_transition((i5g, i6e), +1)
+                                            #      |g_i5> <g_i5|
 
                                             lp.build()
                                             lst.append(lp)

--- a/quantarhei/builders/molecules.py
+++ b/quantarhei/builders/molecules.py
@@ -2413,56 +2413,55 @@ def generate_1orderP_sec(
             print("Ground state: ", i1g, "of", len(ngs))
 
         # Only thermally allowed starting states are considered
-        if True:  # self.rho0[i1g,i1g] > pop_tol:
-            D2 = numpy.dot(self.dmoments[0, 1, :], self.dmoments[0, 1, :])
-            for i2e in nes:
-                if D2 > dip_tol:  # self.D2[i2e,i1g] > dip_tol:
-                    l += 1
+        D2 = numpy.dot(self.dmoments[0, 1, :], self.dmoments[0, 1, :])
+        for i2e in nes:
+            if D2 > dip_tol:  # self.D2[i2e,i1g] > dip_tol:
+                l += 1
 
-                    #      Diagram P1
-                    #
-                    #
+                #      Diagram P1
+                #
+                #
+                #      |g_i1> <g_i1|
+                # <----|-----------|
+                #      |e_i2> <g_i1|
+                # ---->|-----------|
+                #      |g_i1> <g_i1|
+
+                try:
+                    if verbose > 5:
+                        print(" * Generating P1", i1g, i2e)
+
+                    # FIXME: what should be here???
+                    lp = diag.liouville_pathway(
+                        "NR",
+                        i1g,
+                        aggregate=self,
+                        order=1,
+                        pname="P1",
+                        popt_band=1,
+                        relax_order=1,
+                    )
+
+                    # first transition lineshape
+                    width1 = self.get_transition_width((i2e, i1g))
+                    deph1 = self.get_transition_dephasing((i2e, i1g))
+
                     #      |g_i1> <g_i1|
-                    # <----|-----------|
+                    lp.add_transition(
+                        (i2e, i1g), +1, interval=1, width=width1, deph=deph1
+                    )
                     #      |e_i2> <g_i1|
-                    # ---->|-----------|
+                    lp.add_transition(
+                        (i1g, i2e), +1, interval=1, width=width1, deph=deph1
+                    )
                     #      |g_i1> <g_i1|
 
-                    try:
-                        if verbose > 5:
-                            print(" * Generating P1", i1g, i2e)
+                except Exception:
+                    break
 
-                        # FIXME: what should be here???
-                        lp = diag.liouville_pathway(
-                            "NR",
-                            i1g,
-                            aggregate=self,
-                            order=1,
-                            pname="P1",
-                            popt_band=1,
-                            relax_order=1,
-                        )
-
-                        # first transition lineshape
-                        width1 = self.get_transition_width((i2e, i1g))
-                        deph1 = self.get_transition_dephasing((i2e, i1g))
-
-                        #      |g_i1> <g_i1|
-                        lp.add_transition(
-                            (i2e, i1g), +1, interval=1, width=width1, deph=deph1
-                        )
-                        #      |e_i2> <g_i1|
-                        lp.add_transition(
-                            (i1g, i2e), +1, interval=1, width=width1, deph=deph1
-                        )
-                        #      |g_i1> <g_i1|
-
-                    except Exception:
-                        break
-
-                    lp.build()
-                    lst.append(lp)
-                    k += 1
+                lp.build()
+                lst.append(lp)
+                k += 1
 
 
 def PiMolecule(Molecule: Any) -> None:

--- a/quantarhei/core/frequency.py
+++ b/quantarhei/core/frequency.py
@@ -173,11 +173,7 @@ class FrequencyAxis(ValueAxis, EnergyUnitsManaged):
         time_start: float = 0.0,
     ) -> None:
 
-        # if step > 0:
-        if True:
-            self.step = step
-        # else:
-        #    raise Exception("Parameter step has to be > 0")
+        self.step = step
         self.start = start
         self.length = length
 

--- a/quantarhei/core/valueaxis.py
+++ b/quantarhei/core/valueaxis.py
@@ -131,11 +131,7 @@ class ValueAxis(Saveable):
 
     def __init__(self, start: float = 0.0, length: int = 1, step: float = 1.0) -> None:
 
-        # if step > 0:
-        if True:
-            self.step = step
-        # else:
-        #    raise Exception("Parameter step has to be > 0")
+        self.step = step
         self.start = start
         self.length = length
 

--- a/quantarhei/implementations/qutip/qutip_heom.py
+++ b/quantarhei/implementations/qutip/qutip_heom.py
@@ -346,118 +346,111 @@ def run_simulation(
     ylims = [0, 1]
     colors = ["r", "g", "b", "y", "c", "m", "k"]
 
-    if True:
-        rho_final = []
-        # Transformed
-        fig, axes = plt.subplots(1, 1, figsize=(12, 8))
-        fig2, axes2 = plt.subplots(1, 1, figsize=(12, 8))
+    rho_final = []
+    # Transformed
+    fig, axes = plt.subplots(1, 1, figsize=(12, 8))
+    fig2, axes2 = plt.subplots(1, 1, figsize=(12, 8))
 
-        rho0numpy = SmatrixInv @ to_tensor_rep(rho0) @ Smatrix
+    rho0numpy = SmatrixInv @ to_tensor_rep(rho0) @ Smatrix
 
-        for t in range(t_slices):
-            rho_f = np.zeros((Ndim, Ndim), dtype=complex)
-            for i in range(Ndim):
-                for j in range(Ndim):
-                    for k in range(Ndim):
-                        for l in range(Ndim):
-                            rho_f[i, j] += (
-                                evosuperops_transformed[t][k, l, i, j] * rho0numpy[k, l]
-                            )
-
-            rho_f_to_append = rho_f
-            rho_final.append(rho_f_to_append)
-
-        for n in range(Ndim):
-            for m in range(Ndim):
-                if POPSONLY == True and (n != m):
-                    continue
-
-                if COHERENCESONLY == True:
-                    if n == m:
-                        continue
-
-                    # only coherences with first site/exc)
-                    if n != 0:
-                        continue
-
-                if True:
-                    # sitebasis == True
-                    # excbasis == False
-
-                    """
-                    # qutip calculation
-                    Q = basis(7, n) * basis(7, m).dag()
-                    vals = []
-                    for t in range(t_slices):
-                        # transform rho back into site basis
-                        vals.append(expect(Qobj(rho_final[t]).transform(ekets, True), Q))
-                    """
-
-                    # numpy calculation
-                    Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
-                    vals = []
-                    for t in range(t_slices):
-                        # transform rho back into site basis
-                        vals.append(
-                            np.trace(Smatrix @ rho_final[t] @ SmatrixInv @ Q_np)
+    for t in range(t_slices):
+        rho_f = np.zeros((Ndim, Ndim), dtype=complex)
+        for i in range(Ndim):
+            for j in range(Ndim):
+                for k in range(Ndim):
+                    for l in range(Ndim):
+                        rho_f[i, j] += (
+                            evosuperops_transformed[t][k, l, i, j] * rho0numpy[k, l]
                         )
 
-                    ls = "-"
-                    axes.plot(
-                        np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                        np.real(vals),
-                        label=f"{n + 1}{m + 1}",
-                        color=colors[m % len(colors)],
-                        linestyle=ls,
-                    )
-                    axes.set_xlabel(r"$t$ (fs)", fontsize=30)
-                    axes.set_ylabel(r"vals", fontsize=30)
-                    axes.locator_params(axis="y", nbins=6)
-                    axes.locator_params(axis="x", nbins=6)
-                    axes.set_xlim(xlims)
-                    axes.set_ylim(ylims)
+        rho_f_to_append = rho_f
+        rho_final.append(rho_f_to_append)
 
-                if True:
-                    # sitebasis == False
-                    # excbasis == True
+    for n in range(Ndim):
+        for m in range(Ndim):
+            if POPSONLY == True and (n != m):
+                continue
 
-                    """
-                    # qutip calculation
-                    Q = basis(7, n) * basis(7, m).dag()
-                    vals = []
-                    for t in range(t_slices):
-                        vals.append(expect(Qobj(rho_final[t]), Q))
-                    """
+            if COHERENCESONLY == True:
+                if n == m:
+                    continue
 
-                    # numpy calculation
-                    Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
-                    vals = []
-                    for t in range(t_slices):
-                        vals.append(np.trace(rho_final[t] @ Q_np))
+                # only coherences with first site/exc)
+                if n != 0:
+                    continue
 
-                    ls = "-"
-                    axes2.plot(
-                        np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                        np.real(vals),
-                        label=f"{n + 1}{m + 1}",
-                        color=colors[m % len(colors)],
-                        linestyle=ls,
-                    )
-                    axes2.set_xlabel(r"$t$ (fs)", fontsize=30)
-                    axes2.set_ylabel(r"vals", fontsize=30)
-                    axes2.locator_params(axis="y", nbins=6)
-                    axes2.locator_params(axis="x", nbins=6)
-                    axes2.set_xlim(xlims)
-                    axes2.set_ylim(ylims)
+            # sitebasis == True
+            # excbasis == False
 
-        axes.legend(loc=1)
-        fig.savefig(
-            "fullevo_sitebasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png"
-        )
-        axes2.legend(loc=1)
-        fig2.savefig(
-            "fullevo_exctbasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png"
-        )
+            """
+            # qutip calculation
+            Q = basis(7, n) * basis(7, m).dag()
+            vals = []
+            for t in range(t_slices):
+                # transform rho back into site basis
+                vals.append(expect(Qobj(rho_final[t]).transform(ekets, True), Q))
+            """
+
+            # numpy calculation
+            Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
+            vals = []
+            for t in range(t_slices):
+                # transform rho back into site basis
+                vals.append(np.trace(Smatrix @ rho_final[t] @ SmatrixInv @ Q_np))
+
+            ls = "-"
+            axes.plot(
+                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
+                np.real(vals),
+                label=f"{n + 1}{m + 1}",
+                color=colors[m % len(colors)],
+                linestyle=ls,
+            )
+            axes.set_xlabel(r"$t$ (fs)", fontsize=30)
+            axes.set_ylabel(r"vals", fontsize=30)
+            axes.locator_params(axis="y", nbins=6)
+            axes.locator_params(axis="x", nbins=6)
+            axes.set_xlim(xlims)
+            axes.set_ylim(ylims)
+
+            # sitebasis == False
+            # excbasis == True
+
+            """
+            # qutip calculation
+            Q = basis(7, n) * basis(7, m).dag()
+            vals = []
+            for t in range(t_slices):
+                vals.append(expect(Qobj(rho_final[t]), Q))
+            """
+
+            # numpy calculation
+            Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
+            vals = []
+            for t in range(t_slices):
+                vals.append(np.trace(rho_final[t] @ Q_np))
+
+            ls = "-"
+            axes2.plot(
+                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
+                np.real(vals),
+                label=f"{n + 1}{m + 1}",
+                color=colors[m % len(colors)],
+                linestyle=ls,
+            )
+            axes2.set_xlabel(r"$t$ (fs)", fontsize=30)
+            axes2.set_ylabel(r"vals", fontsize=30)
+            axes2.locator_params(axis="y", nbins=6)
+            axes2.locator_params(axis="x", nbins=6)
+            axes2.set_xlim(xlims)
+            axes2.set_ylim(ylims)
+
+    axes.legend(loc=1)
+    fig.savefig("fullevo_sitebasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")
+    axes2.legend(loc=1)
+    fig2.savefig(
+        "fullevo_exctbasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png"
+    )
 
     evosuperops_transformed_secular = []
     for t in range(t_slices):
@@ -483,195 +476,177 @@ def run_simulation(
                                     evosuperops_transformed[t][k, l, i, j]
                                 )
 
-    if True:
-        rho_final = []
-        # Transformed SECULAR
+    rho_final = []
+    # Transformed SECULAR
 
-        fig, axes = plt.subplots(1, 1, figsize=(12, 8))
-        fig2, axes2 = plt.subplots(1, 1, figsize=(12, 8))
+    fig, axes = plt.subplots(1, 1, figsize=(12, 8))
+    fig2, axes2 = plt.subplots(1, 1, figsize=(12, 8))
 
-        rho0numpy = SmatrixInv @ to_tensor_rep(rho0) @ Smatrix
+    rho0numpy = SmatrixInv @ to_tensor_rep(rho0) @ Smatrix
 
-        for t in range(t_slices):
-            rho_f = np.zeros((Ndim, Ndim), dtype=complex)
-            for i in range(Ndim):
-                for j in range(Ndim):
-                    for k in range(Ndim):
-                        for l in range(Ndim):
-                            rho_f[i, j] += (
-                                evosuperops_transformed_secular[t][k, l, i, j]
-                                * rho0numpy[k, l]
-                            )
-            rho_f_to_append = rho_f
-            rho_final.append(rho_f_to_append)
+    for t in range(t_slices):
+        rho_f = np.zeros((Ndim, Ndim), dtype=complex)
+        for i in range(Ndim):
+            for j in range(Ndim):
+                for k in range(Ndim):
+                    for l in range(Ndim):
+                        rho_f[i, j] += (
+                            evosuperops_transformed_secular[t][k, l, i, j]
+                            * rho0numpy[k, l]
+                        )
+        rho_f_to_append = rho_f
+        rho_final.append(rho_f_to_append)
 
-        for n in range(Ndim):
-            for m in range(Ndim):
-                if POPSONLY == True and (n != m):
+    for n in range(Ndim):
+        for m in range(Ndim):
+            if POPSONLY == True and (n != m):
+                continue
+
+            if COHERENCESONLY == True:
+                if n == m:
                     continue
 
-                if COHERENCESONLY == True:
-                    if n == m:
-                        continue
-
-                    # only coherences with first site/exc)
-                    if n != 0:
-                        continue
-
-                if True:
-                    # sitebasis == True
-                    # excbasis == False
-
-                    """
-                    # qutip calculation
-                    Q = basis(7, n) * basis(7, m).dag()
-                    vals = []
-                    for t in range(t_slices):
-                        # transform rho back into site basis
-                        vals.append(expect(Qobj(rho_final[t]).transform(ekets, True), Q))
-                    """
-
-                    # numpy calculation
-                    Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
-                    vals = []
-                    for t in range(t_slices):
-                        vals.append(
-                            np.trace(Smatrix @ rho_final[t] @ SmatrixInv @ Q_np)
-                        )
-
-                    ls = "--"
-                    axes.plot(
-                        np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                        np.real(vals),
-                        label=f"{n + 1}{m + 1}",
-                        color=colors[m % len(colors)],
-                        linestyle=ls,
-                    )
-                    axes.set_xlabel(r"$t$ (fs)", fontsize=30)
-                    axes.set_ylabel(r"vals", fontsize=30)
-                    axes.locator_params(axis="y", nbins=6)
-                    axes.locator_params(axis="x", nbins=6)
-                    axes.set_xlim(xlims)
-                    axes.set_ylim(ylims)
-
-                if True:
-                    # sitebasis == False
-                    # excbasis == True
-
-                    """
-                    # qutip calculation
-                    Q = basis(7, n) * basis(7, m).dag()
-                    vals = []
-                    for t in range(t_slices):
-                        vals.append(expect(Qobj(rho_final[t]), Q))
-                    """
-
-                    # numpy calculation
-                    Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
-                    vals = []
-                    for t in range(t_slices):
-                        vals.append(np.trace(rho_final[t] @ Q_np))
-
-                    ls = "--"
-                    axes2.plot(
-                        np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                        np.real(vals),
-                        label=f"{n + 1}{m + 1}",
-                        color=colors[m % len(colors)],
-                        linestyle=ls,
-                    )
-                    axes2.set_xlabel(r"$t$ (fs)", fontsize=30)
-                    axes2.set_ylabel(r"vals", fontsize=30)
-                    axes2.locator_params(axis="y", nbins=6)
-                    axes2.locator_params(axis="x", nbins=6)
-                    axes2.set_xlim(xlims)
-                    axes2.set_ylim(ylims)
-
-        axes.legend(loc=1)
-        fig.savefig(
-            "secexc_sitebasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png"
-        )
-        axes2.legend(loc=1)
-        fig2.savefig(
-            "secexc_exctbasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png"
-        )
-
-    if True:
-        # Normal HEOM
-        fig, axes = plt.subplots(1, 1, figsize=(12, 8))
-        fig2, axes2 = plt.subplots(1, 1, figsize=(12, 8))
-        with timer("ODE solver time"):
-            outputFMO_HEOM = HEOMMats.run(rho0, tlist)
-
-        for n in range(Ndim):
-            for m in range(Ndim):
-                if POPSONLY == True and (n != m):
+                # only coherences with first site/exc)
+                if n != 0:
                     continue
 
-                if COHERENCESONLY == True:
-                    if n == m:
-                        continue
+            # sitebasis == True
+            # excbasis == False
 
-                    # only coherences with first site/exc)
-                    if n != 0:
-                        continue
+            """
+            # qutip calculation
+            Q = basis(7, n) * basis(7, m).dag()
+            vals = []
+            for t in range(t_slices):
+                # transform rho back into site basis
+                vals.append(expect(Qobj(rho_final[t]).transform(ekets, True), Q))
+            """
 
-                if True:
-                    # sitebasis == True
-                    # excbasis == False
+            # numpy calculation
+            Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
+            vals = []
+            for t in range(t_slices):
+                vals.append(np.trace(Smatrix @ rho_final[t] @ SmatrixInv @ Q_np))
 
-                    # qutip calculation
-                    Q = basis(Ndim, n) * basis(Ndim, m).dag()
-                    vals = []
-                    for t in range(t_slices):
-                        vals.append(expect(outputFMO_HEOM.states[t], Q))
+            ls = "--"
+            axes.plot(
+                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
+                np.real(vals),
+                label=f"{n + 1}{m + 1}",
+                color=colors[m % len(colors)],
+                linestyle=ls,
+            )
+            axes.set_xlabel(r"$t$ (fs)", fontsize=30)
+            axes.set_ylabel(r"vals", fontsize=30)
+            axes.locator_params(axis="y", nbins=6)
+            axes.locator_params(axis="x", nbins=6)
+            axes.set_xlim(xlims)
+            axes.set_ylim(ylims)
 
-                    axes.plot(
-                        np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                        np.real(vals),
-                        label=f"{m + 1}{n + 1}",
-                        color=colors[n % len(colors)],
-                        linestyle=ls,
-                    )
-                    axes.set_xlabel(r"$t$ (fs)", fontsize=30)
-                    axes.set_ylabel(r"vals", fontsize=30)
-                    axes.locator_params(axis="y", nbins=6)
-                    axes.locator_params(axis="x", nbins=6)
-                    axes.set_xlim(xlims)
-                    axes.set_ylim(ylims)
+            # sitebasis == False
+            # excbasis == True
 
-                if True:
-                    # sitebasis == False
-                    # excbasis == True
+            """
+            # qutip calculation
+            Q = basis(7, n) * basis(7, m).dag()
+            vals = []
+            for t in range(t_slices):
+                vals.append(expect(Qobj(rho_final[t]), Q))
+            """
 
-                    # qutip calculation
-                    Q = basis(Ndim, n) * basis(Ndim, m).dag()
-                    vals = []
-                    for t in range(t_slices):
-                        # transform into exc basis
-                        vals.append(
-                            expect(outputFMO_HEOM.states[t].transform(ekets, False), Q)
-                        )
+            # numpy calculation
+            Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
+            vals = []
+            for t in range(t_slices):
+                vals.append(np.trace(rho_final[t] @ Q_np))
 
-                    axes2.plot(
-                        np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                        np.real(vals),
-                        label=f"{m + 1}{n + 1}",
-                        color=colors[n % len(colors)],
-                        linestyle=ls,
-                    )
-                    axes2.set_xlabel(r"$t$ (fs)", fontsize=30)
-                    axes2.set_ylabel(r"vals", fontsize=30)
-                    axes2.locator_params(axis="y", nbins=6)
-                    axes2.locator_params(axis="x", nbins=6)
-                    axes2.set_xlim(xlims)
-                    axes2.set_ylim(ylims)
+            ls = "--"
+            axes2.plot(
+                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
+                np.real(vals),
+                label=f"{n + 1}{m + 1}",
+                color=colors[m % len(colors)],
+                linestyle=ls,
+            )
+            axes2.set_xlabel(r"$t$ (fs)", fontsize=30)
+            axes2.set_ylabel(r"vals", fontsize=30)
+            axes2.locator_params(axis="y", nbins=6)
+            axes2.locator_params(axis="x", nbins=6)
+            axes2.set_xlim(xlims)
+            axes2.set_ylim(ylims)
 
-        axes.legend(loc=1)
-        fig.savefig(
-            "heom_sitebasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png"
-        )
-        axes2.legend(loc=1)
-        fig2.savefig(
-            "heom_exctbasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png"
-        )
+    axes.legend(loc=1)
+    fig.savefig("secexc_sitebasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")
+    axes2.legend(loc=1)
+    fig2.savefig("secexc_exctbasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")
+
+    # Normal HEOM
+    fig, axes = plt.subplots(1, 1, figsize=(12, 8))
+    fig2, axes2 = plt.subplots(1, 1, figsize=(12, 8))
+    with timer("ODE solver time"):
+        outputFMO_HEOM = HEOMMats.run(rho0, tlist)
+
+    for n in range(Ndim):
+        for m in range(Ndim):
+            if POPSONLY == True and (n != m):
+                continue
+
+            if COHERENCESONLY == True:
+                if n == m:
+                    continue
+
+                # only coherences with first site/exc)
+                if n != 0:
+                    continue
+
+            # sitebasis == True
+            # excbasis == False
+
+            # qutip calculation
+            Q = basis(Ndim, n) * basis(Ndim, m).dag()
+            vals = []
+            for t in range(t_slices):
+                vals.append(expect(outputFMO_HEOM.states[t], Q))
+
+            axes.plot(
+                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
+                np.real(vals),
+                label=f"{m + 1}{n + 1}",
+                color=colors[n % len(colors)],
+                linestyle=ls,
+            )
+            axes.set_xlabel(r"$t$ (fs)", fontsize=30)
+            axes.set_ylabel(r"vals", fontsize=30)
+            axes.locator_params(axis="y", nbins=6)
+            axes.locator_params(axis="x", nbins=6)
+            axes.set_xlim(xlims)
+            axes.set_ylim(ylims)
+
+            # sitebasis == False
+            # excbasis == True
+
+            # qutip calculation
+            Q = basis(Ndim, n) * basis(Ndim, m).dag()
+            vals = []
+            for t in range(t_slices):
+                # transform into exc basis
+                vals.append(expect(outputFMO_HEOM.states[t].transform(ekets, False), Q))
+
+            axes2.plot(
+                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
+                np.real(vals),
+                label=f"{m + 1}{n + 1}",
+                color=colors[n % len(colors)],
+                linestyle=ls,
+            )
+            axes2.set_xlabel(r"$t$ (fs)", fontsize=30)
+            axes2.set_ylabel(r"vals", fontsize=30)
+            axes2.locator_params(axis="y", nbins=6)
+            axes2.locator_params(axis="x", nbins=6)
+            axes2.set_xlim(xlims)
+            axes2.set_ylim(ylims)
+
+    axes.legend(loc=1)
+    fig.savefig("heom_sitebasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")
+    axes2.legend(loc=1)
+    fig2.savefig("heom_exctbasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")

--- a/quantarhei/qm/corfunctions/correlationfunctions.py
+++ b/quantarhei/qm/corfunctions/correlationfunctions.py
@@ -290,18 +290,11 @@ class CorrelationFunction(DFunction, UnitsManaged):
         kBT = kB_intK * temperature
         time = self.axis.data
 
-        # if values is not None:
-        #    cfce = values
+        cfce = (lamb / ctime) * (
+            1.0 / numpy.tan(1.0 / (2.0 * kBT * ctime))
+        ) * numpy.exp(-time / ctime) - 1.0j * (lamb / ctime) * numpy.exp(-time / ctime)
 
-        # else:
-        if True:
-            cfce = (lamb / ctime) * (
-                1.0 / numpy.tan(1.0 / (2.0 * kBT * ctime))
-            ) * numpy.exp(-time / ctime) - 1.0j * (lamb / ctime) * numpy.exp(
-                -time / ctime
-            )
-
-            cfce += (4.0 * lamb * kBT / ctime) * self._matsubara(kBT, ctime, nmatsu)
+        cfce += (4.0 * lamb * kBT / ctime) * self._matsubara(kBT, ctime, nmatsu)
 
         # this is a call to the function inherited from DFunction class
         self._add_me(self.axis, cfce)
@@ -323,14 +316,9 @@ class CorrelationFunction(DFunction, UnitsManaged):
         kBT = kB_intK * temperature
         time = self.axis.data
 
-        # if values is not None:
-        #    cfce = values
-        #
-        # else:
-        if True:
-            cfce = (2.0 * lamb * kBT) * numpy.exp(-time / ctime) - 1.0j * (
-                lamb / ctime
-            ) * numpy.exp(-time / ctime)
+        cfce = (2.0 * lamb * kBT) * numpy.exp(-time / ctime) - 1.0j * (
+            lamb / ctime
+        ) * numpy.exp(-time / ctime)
 
         # this is a call to the function inherited from DFunction class
         self._add_me(self.axis, cfce)
@@ -357,20 +345,13 @@ class CorrelationFunction(DFunction, UnitsManaged):
         # kBT = kB_intK*temperature
         time = self.axis  # .data
 
-        # if values is not None:
-        #    cfce = values
-        #
-        # else:
-        if True:
-            with energy_units("int"):
-                # Make it via SpectralDensity
-                fa = SpectralDensity(time, params)
+        with energy_units("int"):
+            # Make it via SpectralDensity
+            fa = SpectralDensity(time, params)
 
-                cf = fa.get_CorrelationFunction(temperature=temperature)
+            cf = fa.get_CorrelationFunction(temperature=temperature)
 
-                cfce = cf.data
-                # 2.0*lamb*kBT*(numpy.exp(-time/ctime)
-                #              - 1.0j*(lamb/ctime)*numpy.exp(-time/ctime))
+            cfce = cf.data
 
         # this is a call to the function inherited from DFunction class
         self._add_me(self.axis, cfce)

--- a/quantarhei/qm/liouvillespace/Mockevolutionsuperoperator.py
+++ b/quantarhei/qm/liouvillespace/Mockevolutionsuperoperator.py
@@ -821,11 +821,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
             + str(dim)
             + ")"
         )
-        if True:
-            # if remtime <= self.remlast:
-            txt2 = " : remaining time " + str(remtime) + " sec"
-        # else:
-        #    txt2 = " : remaining time ... calculating"
+        txt2 = " : remaining time " + str(remtime) + " sec"
         tlen1 = len(txt1)
         tlen2 = len(txt2)
 

--- a/quantarhei/qm/liouvillespace/heom.py
+++ b/quantarhei/qm/liouvillespace/heom.py
@@ -195,51 +195,26 @@ class KTHierarchy:
             Highest level of the hierarchy to be generated
 
         """
-        if False:
-            return self._generate_indices_2_0to4(N, level)
-
         lret = []
 
-        if False:
-            level_prev = []
-            inilist = [0] * N  # lowest level
-            level_prev.append(inilist)
+        level_prev = []
+        inilist = [0] * N
+        level_prev.append(inilist)
+        lret.append(level_prev)
+
+        for kk in range(level):
+            last_level = kk
+            new_level_prev = []
+            for old_level in level_prev:
+                for nn in range(N):
+                    nlist = old_level.copy()
+                    nlist[nn] += 1
+                    # check if it is already in
+                    if nlist not in new_level_prev:
+                        new_level_prev.append(nlist)
+
+            level_prev = new_level_prev
             lret.append(level_prev)
-
-            for kk in range(level):
-                last_level = kk
-                new_level_prev = []
-                for old_level in level_prev:
-                    doit = False
-                    for nn in range(N):
-                        if old_level[nn] == last_level:
-                            doit = True
-                        if doit:
-                            nlist = old_level.copy()
-                            nlist[nn] += 1
-                            new_level_prev.append(nlist)
-
-                level_prev = new_level_prev
-                lret.append(level_prev)
-        else:
-            level_prev = []
-            inilist = [0] * N
-            level_prev.append(inilist)
-            lret.append(level_prev)
-
-            for kk in range(level):
-                last_level = kk
-                new_level_prev = []
-                for old_level in level_prev:
-                    for nn in range(N):
-                        nlist = old_level.copy()
-                        nlist[nn] += 1
-                        # check if it is already in
-                        if nlist not in new_level_prev:
-                            new_level_prev.append(nlist)
-
-                level_prev = new_level_prev
-                lret.append(level_prev)
 
         return lret
 

--- a/quantarhei/qm/liouvillespace/lindbladform.py
+++ b/quantarhei/qm/liouvillespace/lindbladform.py
@@ -137,33 +137,8 @@ class ElectronicLindbladForm(LindbladForm):
                     Nop = sbi.KK.shape[0]
                     ops = []
                     for k in range(Nop):
-                        if False:
-                            newkk = numpy.zeros(
-                                (agg.Ntot, agg.Ntot), dtype=numpy.float64
-                            )
-                            # populate the operator
-                            for i_el in range(agg.Nel):
-                                for i_vib in agg.vibindices[i_el]:
-                                    vs_i = agg.vibsigs[i_vib]
-                                    st_i = agg.get_VibronicState(vs_i[0], vs_i[1])
-
-                                    for j_el in range(agg.Nel):
-                                        for j_vib in agg.vibindices[j_el]:
-                                            vs_j = agg.vibsigs[j_vib]
-                                            st_j = agg.get_VibronicState(
-                                                vs_j[0], vs_j[1]
-                                            )
-
-                                            # electronic transition operator
-                                            # dressed in Franck-Condon factors
-                                            newkk[i_vib, j_vib] = (
-                                                numpy.real(agg.fc_factor(st_i, st_j))
-                                                * sbi.KK[k, i_el, j_el]
-                                            )
-
-                        else:
-                            KK = sbi.KK[k, :, :]
-                            newkk = agg.cast_to_vibronic(KK)
+                        KK = sbi.KK[k, :, :]
+                        newkk = agg.cast_to_vibronic(KK)
 
                         #                        print(k,newkk.shape)
                         #                        print(newkk)

--- a/quantarhei/qm/liouvillespace/modredfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/modredfieldtensor.py
@@ -83,18 +83,17 @@ class ModRedfieldRelaxationTensor(RelaxationTensor):
             HH = self.Hamiltonian
             sbi = self.SystemBathInteraction
 
-            if True:
-                if self._has_cutoff_time:
-                    cft = self.cutoff_time
-                else:
-                    cft = None
+            if self._has_cutoff_time:
+                cft = self.cutoff_time
+            else:
+                cft = None
 
-                frm = ModifiedRedfieldRateMatrix(
-                    HH,
-                    sbi,  # sbi.TimeAxis,
-                    initialize=True,
-                    cutoff_time=cft,
-                )
+            frm = ModifiedRedfieldRateMatrix(
+                HH,
+                sbi,
+                initialize=True,
+                cutoff_time=cft,
+            )
 
             with eigenbasis_of(HH):
                 #

--- a/quantarhei/qm/liouvillespace/nefoerstertensor.py
+++ b/quantarhei/qm/liouvillespace/nefoerstertensor.py
@@ -319,36 +319,24 @@ def _nsc_kernel_at_t(
     ec = HH[cc, cc]
     ed = HH[dd, dd]
 
-    if False:  # (bb==cc) and (aa==dd):
-        # manually simplified expression for population rates
+    # general expression for all indices
 
-        prod = exp(
-            2.0 * 1j * numpy.imag(gt[bb, ti])
-            - 2.0 * 1j * numpy.imag(gtb_m)
-            - gt[bb, :]
-            - gt[aa, :]
-            + 1j * (ea - eb) * tt
-        )
+    dl: numpy.ndarray = numpy.eye(HH.shape[0], dtype=REAL)
 
-    else:
-        # general expression for all indices
-
-        dl: numpy.ndarray = numpy.eye(HH.shape[0], dtype=REAL)
-
-        tt_i = tt[ti]
-        prod = exp(
-            -conj(gt[aa, ti] + gt[cc, :])
-            - gt[bb, ti]
-            - gt[dd, :]
-            + dl[aa, bb] * (+conj(gt[aa, ti]) + gt[aa, ti])
-            + dl[aa, cc] * (-conj(gt[aa, :]) + gta_m - gt[aa, ti])
-            + dl[aa, dd] * (+conj(gt[aa, :]) + gt[aa, ti] - gta_m)
-            + dl[bb, cc] * (+conj(gt[bb, :]) + gt[bb, ti] - gtb_m)
-            + dl[bb, dd] * (-conj(gt[bb, :]) - gt[bb, ti] + gtb_m)
-            + dl[cc, dd] * (conj(gt[cc, :]) + gt[cc, :])
-            + 1j * ((ea - eb) * tt_i)
-            + 1j * (ec - ed) * tt
-        )
+    tt_i = tt[ti]
+    prod = exp(
+        -conj(gt[aa, ti] + gt[cc, :])
+        - gt[bb, ti]
+        - gt[dd, :]
+        + dl[aa, bb] * (+conj(gt[aa, ti]) + gt[aa, ti])
+        + dl[aa, cc] * (-conj(gt[aa, :]) + gta_m - gt[aa, ti])
+        + dl[aa, dd] * (+conj(gt[aa, :]) + gt[aa, ti] - gta_m)
+        + dl[bb, cc] * (+conj(gt[bb, :]) + gt[bb, ti] - gtb_m)
+        + dl[bb, dd] * (-conj(gt[bb, :]) - gt[bb, ti] + gtb_m)
+        + dl[cc, dd] * (conj(gt[cc, :]) + gt[cc, :])
+        + 1j * ((ea - eb) * tt_i)
+        + 1j * (ec - ed) * tt
+    )
 
     return prod
 

--- a/quantarhei/qm/liouvillespace/redfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/redfieldtensor.py
@@ -327,10 +327,9 @@ class RedfieldRelaxationTensor(RelaxationTensor):
         #
         # Get eigenenergies and transformation matrix of the Hamiltonian
         #
-        if True:
-            # Use _data directly: _implementation must always diagonalize in the
-            # site basis so that Km is the correct eigenbasis coupling operator.
-            hD, SS = numpy.linalg.eigh(ham._data)
+        # Use _data directly: _implementation must always diagonalize in the
+        # site basis so that Km is the correct eigenbasis coupling operator.
+        hD, SS = numpy.linalg.eigh(ham._data)
 
         #
         #  Find all transition frequencies
@@ -476,9 +475,8 @@ class RedfieldRelaxationTensor(RelaxationTensor):
             # save the relaxation tensor
             RR = self._convert_operators_2_tensor(Km, Lm, Ld)
 
-            if True:
-                self.data = RR
-                self._data_initialized = True
+            self.data = RR
+            self._data_initialized = True
 
         self._is_initialized = True
 
@@ -656,9 +654,8 @@ class RedfieldRelaxationTensor(RelaxationTensor):
         """
         if self.as_operators:
             RR = self._convert_operators_2_tensor(self.Km, self.Lm, self.Ld)
-            if True:
-                self.data = RR
-                self._data_initialized = True
+            self.data = RR
+            self._data_initialized = True
 
             self.as_operators = False
 

--- a/quantarhei/qm/liouvillespace/relaxationtensor.py
+++ b/quantarhei/qm/liouvillespace/relaxationtensor.py
@@ -46,29 +46,28 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
                 self.convert_2_tensor()
                 # raise Exception("Cannot be secularized in the operator form")
 
-            if True:
-                if self.data.ndim == 4:
-                    N = self.data.shape[0]
-                    for ii in range(N):
-                        for jj in range(N):
-                            for kk in range(N):
-                                for ll in range(N):
-                                    if not (
-                                        ((ii == jj) and (kk == ll))
-                                        or ((ii == kk) and (jj == ll))
-                                    ):
-                                        self.data[ii, jj, kk, ll] = 0
-                else:
-                    N = self.data.shape[1]
-                    for ii in range(N):
-                        for jj in range(N):
-                            for kk in range(N):
-                                for ll in range(N):
-                                    if not (
-                                        ((ii == jj) and (kk == ll))
-                                        or ((ii == kk) and (jj == ll))
-                                    ):
-                                        self.data[:, ii, jj, kk, ll] = 0
+            if self.data.ndim == 4:
+                N = self.data.shape[0]
+                for ii in range(N):
+                    for jj in range(N):
+                        for kk in range(N):
+                            for ll in range(N):
+                                if not (
+                                    ((ii == jj) and (kk == ll))
+                                    or ((ii == kk) and (jj == ll))
+                                ):
+                                    self.data[ii, jj, kk, ll] = 0
+            else:
+                N = self.data.shape[1]
+                for ii in range(N):
+                    for jj in range(N):
+                        for kk in range(N):
+                            for ll in range(N):
+                                if not (
+                                    ((ii == jj) and (kk == ll))
+                                    or ((ii == kk) and (jj == ll))
+                                ):
+                                    self.data[:, ii, jj, kk, ll] = 0
 
         else:
             super().secularize()

--- a/quantarhei/qm/liouvillespace/systembathinteraction.py
+++ b/quantarhei/qm/liouvillespace/systembathinteraction.py
@@ -243,18 +243,10 @@ class SystemBathInteraction(Saveable):
         for ii in range(1, self.N):
             KK = sys_operators[ii]
 
-            if True:  # isinstance(KK,Operator):
-                if dim == KK.data.shape[0]:
-                    self.KK[ii, :, :] = numpy.real(KK.data)
-                else:
-                    raise Exception(
-                        "Operators in the list are not of the same dimension"
-                    )
+            if dim == KK.data.shape[0]:
+                self.KK[ii, :, :] = numpy.real(KK.data)
             else:
-                raise Exception(
-                    "sys_operators tuple (the first argument)"
-                    " has to contain cu.oqs.hilbertspace.Operator"
-                )
+                raise Exception("Operators in the list are not of the same dimension")
 
     def get_time_axis(self) -> Any:
         """Returns the time axis of the storred correlation functions"""

--- a/quantarhei/qm/liouvillespace/tdredfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/tdredfieldtensor.py
@@ -79,8 +79,7 @@ class TDRedfieldRelaxationTensor(RedfieldRelaxationTensor, TimeDependent):
         #
         # Get eigenenergies and transformation matrix of the Hamiltonian
         #
-        if True:
-            hD, SS = numpy.linalg.eigh(ham._data)
+        hD, SS = numpy.linalg.eigh(ham._data)
 
         #
         #  Find all transition frequencies
@@ -210,9 +209,8 @@ class TDRedfieldRelaxationTensor(RedfieldRelaxationTensor, TimeDependent):
             # save the relaxation tensor
             RR = self._convert_operators_2_tensor(Km, Lm, Ld)
 
-            if True:
-                self.data = RR
-                self._data_initialized = True
+            self.data = RR
+            self._data_initialized = True
 
         self._is_initialized = True
         self.is_time_dependent = True

--- a/quantarhei/spectroscopy/twod22.py
+++ b/quantarhei/spectroscopy/twod22.py
@@ -930,152 +930,148 @@ class TwoDSpectrumCalculator:
         """Sets up the environment for 2D calculation"""
         self.verbose = verbose
 
-        if True:
-            # calculate 2D spectrum using aceto library
+        # calculate 2D spectrum using aceto library
 
-            ###############################################################################
-            #
-            # Create band_system from quantarhei classes
-            #
-            ###############################################################################
+        ###############################################################################
+        #
+        # Create band_system from quantarhei classes
+        #
+        ###############################################################################
 
-            if isinstance(self.system, Aggregate):
-                pass
-
-            else:
-                raise Exception("Molecule 2D not implememted")
-
-            agg = self.system
-
-            #
-            # hamiltonian and transition dipole moment operators
-            #
-            H = agg.get_Hamiltonian()
-            D = agg.get_TransitionDipoleMoment()
-
-            #
-            # Construct band_system object
-            #
-            Nb = 3
-            Ns = numpy.zeros(Nb, dtype=numpy.int_)
-            Ns[0] = 1
-            Ns[1] = agg.nmono
-            Ns[2] = Ns[1] * (Ns[1] - 1) / 2
-            self.sys = band_system(Nb, Ns)
-            self.Ns = Ns
-
-            #
-            # Set energies
-            #
-            en = numpy.zeros(self.sys.Ne, dtype=numpy.float64)
-            # if True:
-            with eigenbasis_of(H):
-                for i in range(self.sys.Ne):
-                    en[i] = H.data[i, i]
-                self.sys.set_energies(en)
-
-                #
-                # Set transition dipole moments
-                #
-                dge_wr = D.data[0 : Ns[0], Ns[0] : Ns[0] + Ns[1], :]
-                def_wr = D.data[
-                    Ns[0] : Ns[0] + Ns[1], (Ns[0] + Ns[1]) : (Ns[0] + Ns[1] + Ns[2]), :
-                ]
-
-                dge = numpy.zeros((3, Ns[0], Ns[1]), dtype=numpy.float64)
-                deff = numpy.zeros((3, Ns[1], Ns[2]), dtype=numpy.float64)
-
-                for i in range(3):
-                    dge[i, :, :] = dge_wr[:, :, i]
-                    deff[i, :, :] = def_wr[:, :, i]
-                self.sys.set_dipoles(0, 1, dge)
-                self.sys.set_dipoles(1, 2, deff)
-
-            #
-            # Relaxation rates
-            #
-            KK_any: Any = agg.get_RedfieldRateMatrix()
-
-            # relaxation rate in single exciton band
-            Kr = KK_any.data[Ns[0] : Ns[0] + Ns[1], Ns[0] : Ns[0] + Ns[1]]  # *10.0
-            # print(1.0/Kr)
-
-            self.sys.init_dephasing_rates()
-            self.sys.set_relaxation_rates(1, Kr)
-
-            #
-            # Lineshape functions
-            #
-            sbi = agg.get_SystemBathInteraction()
-            cfm = sbi.CC
-            cfm.create_double_integral()
-
-            #
-            # Transformation matrices
-            #
-            SS = H.diagonalize()
-            SS1 = SS[1 : Ns[1] + 1, 1 : Ns[1] + 1]
-            SS2 = SS[Ns[1] + 1 :, Ns[1] + 1 :]
-            H.undiagonalize()
-
-            self.sys.set_gofts(cfm._gofts)  # line shape functions
-            self.sys.set_sitep(cfm.cpointer)  # pointer to sites
-            self.sys.set_transcoef(1, SS1)  # matrix of transformation coefficients
-            self.sys.set_transcoef(2, SS2)  # matrix of transformation coefficients
-
-            #
-            # Finding population evolution matrix
-            #
-            prop = PopulationPropagator(self.t1axis, Kr)
-            #      Uee, Uc0 = prop.get_PropagationMatrix(self.t2axis,
-            #                                            corrections=True)
-            self.Uee, cor = prop.get_PropagationMatrix(self.t2axis, corrections=3)
-
-            # FIXME: Order of transfer is set by hand here - needs to be moved
-            # to some reasonable place
-
-            # Ucor = Uee
-            self.Uc0 = cor[0]
-
-            # for ko in range(No+1):
-            #    print("Subtracting ", ko)
-            #    Ucor[:,:,tc] -= cor[ko]
-
-            #
-            # define lab settings
-            #
-            if lab is None:
-                self.lab = lab_settings(lab_settings.FOUR_WAVE_MIXING)
-                X = numpy.array([1.0, 0.0, 0.0], dtype=numpy.float64)
-                self.lab.set_laser_polarizations(X, X, X, X)
-            else:
-                self.lab = lab
-
-            #
-            # Other parameters
-            #
-            # dt = self.t1axis.step
-            self.rmin = 0.0001
-            self.t1s = self.t1axis.data
-            self.t3s = self.t3axis.data
-            self.rwa = rwa
-
-            atype = self.t1axis.atype
-            self.t1axis.atype = "complete"
-            self.oa1 = self.t1axis.get_FrequencyAxis()
-            self.oa1.data += self.rwa
-            self.oa1.start += self.rwa
-            self.t1axis.atype = atype
-
-            atype = self.t3axis.atype
-            self.t3axis.atype = "complete"
-            self.oa3 = self.t3axis.get_FrequencyAxis()
-            self.oa3.data += self.rwa
-            self.oa3.start += self.rwa
-            self.t3axis.atype = atype
+        if isinstance(self.system, Aggregate):
+            pass
 
         else:
-            raise Exception("So far, no 2D outside aceto")
+            raise Exception("Molecule 2D not implememted")
+
+        agg = self.system
+
+        #
+        # hamiltonian and transition dipole moment operators
+        #
+        H = agg.get_Hamiltonian()
+        D = agg.get_TransitionDipoleMoment()
+
+        #
+        # Construct band_system object
+        #
+        Nb = 3
+        Ns = numpy.zeros(Nb, dtype=numpy.int_)
+        Ns[0] = 1
+        Ns[1] = agg.nmono
+        Ns[2] = Ns[1] * (Ns[1] - 1) / 2
+        self.sys = band_system(Nb, Ns)
+        self.Ns = Ns
+
+        #
+        # Set energies
+        #
+        en = numpy.zeros(self.sys.Ne, dtype=numpy.float64)
+        # if True:
+        with eigenbasis_of(H):
+            for i in range(self.sys.Ne):
+                en[i] = H.data[i, i]
+            self.sys.set_energies(en)
+
+            #
+            # Set transition dipole moments
+            #
+            dge_wr = D.data[0 : Ns[0], Ns[0] : Ns[0] + Ns[1], :]
+            def_wr = D.data[
+                Ns[0] : Ns[0] + Ns[1], (Ns[0] + Ns[1]) : (Ns[0] + Ns[1] + Ns[2]), :
+            ]
+
+            dge = numpy.zeros((3, Ns[0], Ns[1]), dtype=numpy.float64)
+            deff = numpy.zeros((3, Ns[1], Ns[2]), dtype=numpy.float64)
+
+            for i in range(3):
+                dge[i, :, :] = dge_wr[:, :, i]
+                deff[i, :, :] = def_wr[:, :, i]
+            self.sys.set_dipoles(0, 1, dge)
+            self.sys.set_dipoles(1, 2, deff)
+
+        #
+        # Relaxation rates
+        #
+        KK_any: Any = agg.get_RedfieldRateMatrix()
+
+        # relaxation rate in single exciton band
+        Kr = KK_any.data[Ns[0] : Ns[0] + Ns[1], Ns[0] : Ns[0] + Ns[1]]  # *10.0
+        # print(1.0/Kr)
+
+        self.sys.init_dephasing_rates()
+        self.sys.set_relaxation_rates(1, Kr)
+
+        #
+        # Lineshape functions
+        #
+        sbi = agg.get_SystemBathInteraction()
+        cfm = sbi.CC
+        cfm.create_double_integral()
+
+        #
+        # Transformation matrices
+        #
+        SS = H.diagonalize()
+        SS1 = SS[1 : Ns[1] + 1, 1 : Ns[1] + 1]
+        SS2 = SS[Ns[1] + 1 :, Ns[1] + 1 :]
+        H.undiagonalize()
+
+        self.sys.set_gofts(cfm._gofts)  # line shape functions
+        self.sys.set_sitep(cfm.cpointer)  # pointer to sites
+        self.sys.set_transcoef(1, SS1)  # matrix of transformation coefficients
+        self.sys.set_transcoef(2, SS2)  # matrix of transformation coefficients
+
+        #
+        # Finding population evolution matrix
+        #
+        prop = PopulationPropagator(self.t1axis, Kr)
+        #      Uee, Uc0 = prop.get_PropagationMatrix(self.t2axis,
+        #                                            corrections=True)
+        self.Uee, cor = prop.get_PropagationMatrix(self.t2axis, corrections=3)
+
+        # FIXME: Order of transfer is set by hand here - needs to be moved
+        # to some reasonable place
+
+        # Ucor = Uee
+        self.Uc0 = cor[0]
+
+        # for ko in range(No+1):
+        #    print("Subtracting ", ko)
+        #    Ucor[:,:,tc] -= cor[ko]
+
+        #
+        # define lab settings
+        #
+        if lab is None:
+            self.lab = lab_settings(lab_settings.FOUR_WAVE_MIXING)
+            X = numpy.array([1.0, 0.0, 0.0], dtype=numpy.float64)
+            self.lab.set_laser_polarizations(X, X, X, X)
+        else:
+            self.lab = lab
+
+        #
+        # Other parameters
+        #
+        # dt = self.t1axis.step
+        self.rmin = 0.0001
+        self.t1s = self.t1axis.data
+        self.t3s = self.t3axis.data
+        self.rwa = rwa
+
+        atype = self.t1axis.atype
+        self.t1axis.atype = "complete"
+        self.oa1 = self.t1axis.get_FrequencyAxis()
+        self.oa1.data += self.rwa
+        self.oa1.start += self.rwa
+        self.t1axis.atype = atype
+
+        atype = self.t3axis.atype
+        self.t3axis.atype = "complete"
+        self.oa3 = self.t3axis.get_FrequencyAxis()
+        self.oa3.data += self.rwa
+        self.oa3.start += self.rwa
+        self.t3axis.atype = atype
 
         self.tc = 0
 

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -177,19 +177,12 @@ class TwoDResponseCalculator:
                 # Relaxation rates
                 #
                 if not self._has_rate_matrix:
-                    # try:
-                    if False:
-                        KK = sys.get_RedfieldRateMatrix()
-                    # except:
-                    else:
-                        # FIXME: This is a quick fix to make a zero rate matrix
-                        class hlp:
-                            def __init__(self, N: int) -> None:
-                                self.data: numpy.ndarray = numpy.zeros(
-                                    (N, N), dtype=REAL
-                                )
+                    # FIXME: This is a quick fix to make a zero rate matrix
+                    class hlp:
+                        def __init__(self, N: int) -> None:
+                            self.data: numpy.ndarray = numpy.zeros((N, N), dtype=REAL)
 
-                        KK = hlp(Ns[1])
+                    KK = hlp(Ns[1])
                 else:
                     KK = self._rate_matrix
 

--- a/quantarhei/wizard/examples/ex_016_FoersterTheory_1.py
+++ b/quantarhei/wizard/examples/ex_016_FoersterTheory_1.py
@@ -47,12 +47,10 @@ rho_i1.data[shp - 1, shp - 1] = 1.0
 #
 # Propagation of the density matrix
 #
-# with qr.eigenbasis_of(H):
-if True:
-    rho_t1 = prop_Foerster.propagate(rho_i1)
+rho_t1 = prop_Foerster.propagate(rho_i1)
 
-    if _show_plots_:
-        rho_t1.plot(coherences=True, axis=[0, Nt * dt, 0, 1.0], show=False)
+if _show_plots_:
+    rho_t1.plot(coherences=True, axis=[0, Nt * dt, 0, 1.0], show=False)
 
 #
 # Thermal excited state to compare with
@@ -64,18 +62,16 @@ rho0 = agg.get_DensityMatrix(
 )
 
 if _show_plots_:
-    # with qr.eigenbasis_of(H):
-    if True:
-        pop = numpy.zeros((time.length, shp), dtype=numpy.float64)
-        for i in range(1, H.dim):
-            pop[:, i] = numpy.real(rho0.data[i, i])
-            plt.plot(time.data, pop[:, i], "--k")
+    pop = numpy.zeros((time.length, shp), dtype=numpy.float64)
+    for i in range(1, H.dim):
+        pop[:, i] = numpy.real(rho0.data[i, i])
+        plt.plot(time.data, pop[:, i], "--k")
 
-        # plot the termal distrubution
-        plt.plot(time.data, pop[:, 1], "--r")
-        plt.plot(time.data, pop[:, 2], "--b")
-        plt.plot(time.data, pop[:, 3], "--g")
-        plt.show()
+    # plot the termal distrubution
+    plt.plot(time.data, pop[:, 1], "--r")
+    plt.plot(time.data, pop[:, 2], "--b")
+    plt.plot(time.data, pop[:, 3], "--g")
+    plt.show()
 
 # RR = prop_Foerster.RelaxationTensor
 # with qr.eigenbasis_of(H):

--- a/quantarhei/wizard/examples/ex_018_ModifiedRedfieldTheory_1.py
+++ b/quantarhei/wizard/examples/ex_018_ModifiedRedfieldTheory_1.py
@@ -52,28 +52,16 @@ print("""
 *******************************************************************************
 """)
 
-# m = qr.Manager()
-# m.warn_about_basis_change = False
+print("\nCalculating relaxation rates")
 
-
-if True:
-    print("\nCalculating relaxation rates")
-
-    RRM = qr.qm.ModifiedRedfieldRateMatrix(ham, sbi, time)
-    RRT = qr.qm.ModRedfieldRelaxationTensor(ham, sbi)
+RRM = qr.qm.ModifiedRedfieldRateMatrix(ham, sbi, time)
+RRT = qr.qm.ModRedfieldRelaxationTensor(ham, sbi)
 
 print("\nRelaxation times from the rate matrix")
 
-# with qr.eigenbasis_of(ham):
-if True:
-    for i in range(1, ham.dim - 1):
-        for j in range(1, ham.dim - 1):
-            # if numpy.abs(RRM.rates[i,j]) > 1.0e-10:
-            print(i, "<-", j, ":", 1.0 / numpy.real(RRM.data[i, j]))
-            # , 1.0/numpy.real(RRT.data[i,i,j,j]), numpy.real(RRT.data[i,j,j,j]))
-
-            # else:
-            #    print(i, "<-", j, ": inf")
+for i in range(1, ham.dim - 1):
+    for j in range(1, ham.dim - 1):
+        print(i, "<-", j, ":", 1.0 / numpy.real(RRM.data[i, j]))
 
 
 if _show_plots_:

--- a/quantarhei/wizard/examples/ex_040_2DSpectrumAceto.py
+++ b/quantarhei/wizard/examples/ex_040_2DSpectrumAceto.py
@@ -107,14 +107,6 @@ eUt.set_dense_dt(10)
 
 eUt.calculate()
 
-# if _show_plots_:
-if False:
-    with qr.eigenbasis_of(H):
-        eUt.plot_element((2, 2, 2, 2), show=False)
-        eUt.plot_element((1, 1, 1, 1), show=False)
-        eUt.plot_element((1, 1, 2, 2))
-        eUt.plot_element((1, 2, 1, 2))
-
 
 ###############################################################################
 #

--- a/quantarhei/wizard/examples/ex_300_ParallelIterators.py
+++ b/quantarhei/wizard/examples/ex_300_ParallelIterators.py
@@ -77,6 +77,4 @@ for k, a in qr.block_distributed_list(lst, return_index=True):
 qr.collect_block_distributed_data(containers, setter, retriever, tags=tags)
 
 # printing the result
-# if config.rank == 0:
-if True:
-    print(config.rank, collected_cont)
+print(config.rank, collected_cont)


### PR DESCRIPTION
Closes #336.

## Summary

Systematic removal of dead code: `if True:` guards (always-entered) and `if False:` blocks (never-entered) across the codebase. All instances have been resolved.

## Changes

### Core library

- **`core/valueaxis.py`**, **`core/frequency.py`** — removed `if True:` wrapping a single assignment
- **`qm/liouvillespace/relaxationtensor.py`** — flattened `if True:` in `secularize()`, fixing indentation of the if/else block
- **`qm/liouvillespace/redfieldtensor.py`** — removed two `if True:` guards around simple assignments
- **`qm/liouvillespace/tdredfieldtensor.py`** — same pattern, two `if True:` guards removed
- **`qm/liouvillespace/modredfieldtensor.py`** — removed `if True:` replacing a `with eigenbasis_of()` block, along with stale `protect_basis` comments
- **`qm/liouvillespace/systembathinteraction.py`** — removed `if True: # isinstance(KK, Operator):` and its dead `else` branch
- **`qm/liouvillespace/lindbladform.py`** — removed 22-line `if False:` dead block (unused operator construction path)
- **`qm/liouvillespace/heom.py`** — removed two `if False:` dead blocks (alternative hierarchy generation implementations)
- **`qm/liouvillespace/nefoerstertensor.py`** — removed `if False: # (bb==cc) and (aa==dd):` dead block
- **`qm/liouvillespace/Mockevolutionsuperoperator.py`** — removed `if True: # if remtime <= self.remlast:` progress display guard
- **`qm/corfunctions/correlationfunctions.py`** — flattened three `if True:` guards in `_make_overdamped_brownian`, `_make_overdamped_brownian_ht`, `_make_underdamped_brownian`
- **`builders/molecules.py`** — removed `if True: # self.rho0[i1g,i1g] > pop_tol:` thermal population guard (condition was intentionally bypassed)
- **`builders/aggregate_spectroscopy.py`** — flattened `if True: # try:` guard in pathway calculation
- **`spectroscopy/twodcalculator.py`** — removed `if False:` dead branch containing an unused `get_RedfieldRateMatrix()` call
- **`spectroscopy/twod22.py`** — removed `if True:` wrapping the entire `bootstrap()` body (148 lines), along with its dead `else: raise Exception("So far, no 2D outside aceto")`
- **`implementations/qutip/qutip_heom.py`** — removed 9 `if True:` guards (3 top-level plotting blocks, each containing 2 nested `if True:` blocks for site/exciton basis selection)

### Examples

- **`examples/demo_016_FoersterTheory_1.py`**, **`wizard/examples/ex_016_FoersterTheory_1.py`** — removed `if True:` guards replacing `with eigenbasis_of(H):` blocks
- **`examples/demo_018_ModifiedRedfieldTheory_1.py`**, **`wizard/examples/ex_018_ModifiedRedfieldTheory_1.py`** — same pattern; removed stale `protect_basis` comments
- **`examples/demo_300_ParallelIterators.py`**, **`wizard/examples/ex_300_ParallelIterators.py`** — flattened `if True:` replacing a commented-out `if config.rank == 0:` check
- **`examples/demo_040_2DSpectrumAceto.py`**, **`wizard/examples/ex_040_2DSpectrumAceto.py`** — removed `if False:` dead plot block
- **`examples/old_demos/demo_redfieldfoerster.py`** — flattened `if True:` replacing `with eigenbasis_of(H):`

## Tests

238 passing.