### PR TITLE
#345 docs: fix typos (Freatures → Features, represetation → representation)

### DIFF
--- a/docs/sphinx/getstarted/details/object.md
+++ b/docs/sphinx/getstarted/details/object.md
@@ -1,3 +1,3 @@
 (object-oriented-label)=
 
-# Object Oriented Freatures of Quantarhei
+# Object Oriented Features of Quantarhei

--- a/docs/sphinx/getstarted/philosophy.md
+++ b/docs/sphinx/getstarted/philosophy.md
@@ -74,7 +74,7 @@ and Bacteriochlorophyll light-harvesting antennae of plants, algae and
 bacteria fit best the idea of an open quantum system as simulated by
 Quantarhei.
 
-### Physics and its represetation in Quantarhei
+### Physics and its representation in Quantarhei
 
 The molecules of these light-harvesting antennae interact strongly with each
 other and they are embedded in protein


### PR DESCRIPTION
Closes #345.

Fixes two typos visible in navigation and section headings:
- "Object Oriented Freatures" → "Object Oriented Features" in `getstarted/details/object.md`
- "Physics and its represetation" → "Physics and its representation" in `getstarted/philosophy.md`