### PR TITLE
#342 docs: fix broken toctree directives rendered as raw text on API Reference page

### DIFF
--- a/docs/sphinx/classes.md
+++ b/docs/sphinx/classes.md
@@ -1,8 +1,3 @@
-```{eval-rst}
-.. automodule:: quantarhei
-    :members:
-```
-
 # List of User Level Classes
 
 ## Classes Representing General Concepts


### PR DESCRIPTION
Closes #342.

Removes the \`automodule:: quantarhei\` block from the top of \`classes.md\` which was dumping the module-level docstring (containing raw RST toctree directives) as literal text on the rendered page. The page already has organized toctree sections that correctly link to individual class pages.