### PR TITLE
#339 docs: fill empty stub pages (Coherent 2D Spectrum, Internals)

### DIFF
--- a/docs/sphinx/classes/spectroscopy/twod.md
+++ b/docs/sphinx/classes/spectroscopy/twod.md
@@ -1,1 +1,25 @@
 # Coherent 2D Spectrum
+
+Quantarhei provides a set of classes for calculating and representing
+coherent two-dimensional (2D) electronic and vibrational spectra. The main
+workflow begins with `TwoDResponseCalculator`, which computes the nonlinear
+optical response of a molecular system and stores the results in a
+`TwoDResponseContainer`. The container can then be converted into a
+`TwoDSpectrumContainer` (where the pulse-field convolution is applied), from
+which individual `TwoDSpectrum` objects are retrieved for plotting and
+analysis.
+
+```{eval-rst}
+.. automodule:: quantarhei.spectroscopy.twodspect
+    :members:
+```
+
+```{eval-rst}
+.. automodule:: quantarhei.spectroscopy.twodcontainer
+    :members:
+```
+
+```{eval-rst}
+.. automodule:: quantarhei.spectroscopy.twodcalculator
+    :members:
+```

--- a/docs/sphinx/internals.md
+++ b/docs/sphinx/internals.md
@@ -1,3 +1,25 @@
 (quantarhei-internals)=
 
 # Quantarhei Internals
+
+This section documents the expert-level classes that power Quantarhei's
+internal machinery. These components are used throughout the library but are
+not typically part of a user's day-to-day workflow. Understanding them is
+useful when extending the library, writing custom propagators, or diagnosing
+performance-sensitive code.
+
+The main internal subsystems are:
+
+- **`qm.liouvillespace`** — relaxation tensors (Redfield, Förster, HEOM) and
+  Liouville-space propagators used to evolve the density matrix.
+- **`qm.corfunctions`** — lineshape functions and bath correlation functions
+  that underpin energy-gap fluctuation models.
+- **`builders.aggregate_base`** — low-level aggregate construction utilities,
+  including Hamiltonian assembly and transition-dipole calculations.
+- **`implementations`** — back-end implementations (e.g. QuTiP-based HEOM
+  solver) that can be swapped depending on the available numerical libraries.
+
+```{note}
+This section is under construction. Full API documentation for each
+subsystem will be added in future releases.
+```


### PR DESCRIPTION
Closes #339 (partial — covers 2D spectrum and Internals pages; Molecule example page addressed in separate PR).

- Added automodule blocks for TwoDSpectrum, TwoDSpectrumContainer, TwoDResponseCalculator to the Coherent 2D Spectrum page
- Added introductory content to the Internals page explaining expert-level classes