### PR TITLE
#340 docs: add content to Examples section (Molecule, Aggregate, CorrelationFunction)

### DIFF
--- a/docs/sphinx/examples.md
+++ b/docs/sphinx/examples.md
@@ -8,4 +8,6 @@ Contents:
 :maxdepth: 2
 
 examples/molecule
+examples/aggregate
+examples/correlationfunction
 ```

--- a/docs/sphinx/examples/aggregate.md
+++ b/docs/sphinx/examples/aggregate.md
@@ -1,0 +1,51 @@
+# How to Use `Aggregate` Class
+
+The `Aggregate` class combines multiple `Molecule` objects into a coupled
+system. The example below shows how to build a homodimer and diagonalize its
+Hamiltonian.
+
+## Creating an aggregate
+
+```python
+import quantarhei as qr
+
+en = [0.0, 1.0]
+m1 = qr.Molecule(name="Mol1", elenergies=en)
+m2 = qr.Molecule(name="Mol2", elenergies=en)
+
+ag = qr.Aggregate(name="Homodimer")
+ag.add_Molecule(m1)
+ag.add_Molecule(m2)
+
+# set the resonance coupling between molecule 0 and molecule 1
+ag.set_resonance_coupling(0, 1, 0.1)
+
+# build the aggregate in the single-excitation manifold
+ag.build(mult=1)
+
+H = ag.get_Hamiltonian()
+print(H)
+```
+
+## Using physical energy units
+
+Energies can be supplied in wavenumbers by wrapping assignments in an
+`energy_units` context manager:
+
+```python
+import quantarhei as qr
+
+with qr.energy_units("1/cm"):
+    m1 = qr.Molecule(name="Mol1", elenergies=[0.0, 10100.0])
+    m2 = qr.Molecule(name="Mol2", elenergies=[0.0, 10100.0])
+
+ag = qr.Aggregate(name="Homodimer")
+ag.add_Molecule(m1)
+ag.add_Molecule(m2)
+ag.set_resonance_coupling(0, 1, 0.1)
+ag.build(mult=1)
+
+H = ag.get_Hamiltonian()
+with qr.energy_units("1/cm"):
+    print(H)
+```

--- a/docs/sphinx/examples/correlationfunction.md
+++ b/docs/sphinx/examples/correlationfunction.md
@@ -1,0 +1,50 @@
+# How to Use `CorrelationFunction`
+
+`CorrelationFunction` describes the bath-induced fluctuations of a molecular
+transition frequency. It requires a `TimeAxis` and a parameter dictionary that
+specifies the functional form and its physical parameters.
+
+## Creating a correlation function
+
+```python
+from quantarhei import CorrelationFunction, TimeAxis, energy_units
+
+# define the time axis: start, number of steps, step size (in fs)
+ta = TimeAxis(0.0, 1000, 1.0)
+
+temperature = 300.0  # Kelvin
+params = {
+    "ftype": "OverdampedBrownian",
+    "reorg": 20.0,    # reorganization energy in 1/cm
+    "cortime": 100.0, # correlation time in fs
+    "T": temperature,
+    "matsubara": 20,
+}
+
+# supply energy parameters in wavenumbers
+with energy_units("1/cm"):
+    cf = CorrelationFunction(ta, params)
+
+# inspect the reorganization energy
+print("Reorganization energy:", cf.reorganization_energy)
+```
+
+## Accessing the spectral density
+
+```python
+from quantarhei import SpectralDensity, TimeAxis, energy_units
+
+ta = TimeAxis(0.0, 1000, 1.0)
+params = {
+    "ftype": "OverdampedBrownian",
+    "reorg": 20.0,
+    "cortime": 100.0,
+    "T": 300.0,
+    "matsubara": 20,
+}
+
+with energy_units("1/cm"):
+    sd = SpectralDensity(ta, params)
+
+print(sd)
+```

--- a/docs/sphinx/examples/molecule.md
+++ b/docs/sphinx/examples/molecule.md
@@ -1,1 +1,49 @@
 # How to Use `Molecule` Class
+
+The `Molecule` class represents a single quantum-mechanical molecule with a set
+of electronic energy levels. The examples below show the most common operations.
+
+## Creating a molecule
+
+Provide a list of electronic energies (in internal units, or inside a
+`with qr.energy_units(...)` block) and retrieve the Hamiltonian:
+
+```python
+import quantarhei as qr
+
+# electronic energies: ground state at 0, excited state at 1 (internal units)
+en = [0.0, 1.0]
+m = qr.Molecule(elenergies=en)
+
+H = m.get_Hamiltonian()
+print(H)
+```
+
+## Setting a transition dipole moment
+
+Use `set_dipole` to assign the transition dipole moment between two states:
+
+```python
+import quantarhei as qr
+
+en = [0.0, 1.0]
+m = qr.Molecule(elenergies=en)
+
+# set the 0->1 transition dipole along the x-axis
+m.set_dipole(0, 1, [1.0, 0.0, 0.0])
+```
+
+## Adding a vibrational mode
+
+Intramolecular vibrational modes are added with `Mode` and `add_Mode`:
+
+```python
+import quantarhei as qr
+
+en = [0.0, 1.0]
+m = qr.Molecule(elenergies=en)
+
+# create a mode with frequency 0.01 (internal units)
+mod = qr.Mode(frequency=0.01)
+m.add_Mode(mod)
+```


### PR DESCRIPTION
Closes #340.

- Filled in the empty Molecule example page with working code snippets
- Added new Aggregate example page
- Added new CorrelationFunction example page
- Updated examples toctree to include new pages