### PR TITLE
#341 docs: expand Advanced API page to cover relaxation tensors and propagators

### DIFF
--- a/docs/sphinx/advclasses.md
+++ b/docs/sphinx/advclasses.md
@@ -18,3 +18,26 @@ sbi = qr.qm.SystemBathInteraction
 
 classes/systembathinteraction
 ```
+
+## Relaxation Tensors
+
+```{toctree}
+:maxdepth: 2
+
+classes/relaxtensors/relaxtensors
+classes/relaxtensors/redfieldtensor
+classes/relaxtensors/foerstertensor
+```
+
+## Open System Propagation
+
+`LindbladForm` is used for Markovian open-system dynamics, providing a
+Lindblad master-equation relaxation tensor. `EvolutionSuperOperator`
+handles time-evolution of the density matrix and is the primary tool
+for propagating open quantum systems over a time grid.
+
+```{toctree}
+:maxdepth: 2
+
+classes/evolsupop
+```


### PR DESCRIPTION
Closes #341.

Adds two new sections to the Advanced API page:
- Relaxation Tensors: links to the overview page, RedfieldRelaxationTensor, and FoersterRelaxationTensor
- Open System Propagation: note on LindbladForm and EvolutionSuperOperator, with link to the EvolutionSuperOperator page