### PR TITLE
#343 docs: add missing SpectralDensity and PumpProbeSpectrum pages

### DIFF
--- a/docs/sphinx/classes.md
+++ b/docs/sphinx/classes.md
@@ -32,6 +32,7 @@ classes/aggregates
 :maxdepth: 2
 
 classes/correlationfunction
+classes/spectraldensity
 ```
 
 ## Quantum Mechanics
@@ -70,6 +71,7 @@ classes/relaxtensors/foerstertensor
 
 classes/spectroscopy/abs
 classes/spectroscopy/twod
+classes/spectroscopy/pumpprobe
 classes/spectroscopy/labsetup
 classes/spectroscopy/pathwayan
 ```

--- a/docs/sphinx/classes/spectraldensity.md
+++ b/docs/sphinx/classes/spectraldensity.md
@@ -1,0 +1,8 @@
+# SpectralDensity
+
+The `SpectralDensity` class represents the spectral density of a bath coupled to a quantum system. It is closely related to `CorrelationFunction` — the two are related by a Fourier transform.
+
+```{eval-rst}
+.. automodule:: quantarhei.qm.corfunctions.spectraldensities
+    :members:
+```

--- a/docs/sphinx/classes/spectroscopy/pumpprobe.md
+++ b/docs/sphinx/classes/spectroscopy/pumpprobe.md
@@ -1,0 +1,8 @@
+# PumpProbeSpectrum
+
+Pump-probe spectra can be obtained as a projection of a 2D spectrum onto the probe frequency axis. The `PumpProbeSpectrum` and `PumpProbeSpectrumContainer` classes represent these projected spectra.
+
+```{eval-rst}
+.. automodule:: quantarhei.spectroscopy.pumpprobe
+    :members:
+```


### PR DESCRIPTION
Closes #343 (partial — TwoDSpectrum was addressed in #348).

Adds dedicated documentation pages for:
- `SpectralDensity` — bath spectral density, closely related to `CorrelationFunction`
- `PumpProbeSpectrum` / `PumpProbeSpectrumContainer` — pump-probe spectra obtained as projections of 2D spectra

Both pages use `automodule` directives and are added to the API Reference toctree.