### PR TITLE
#218 Remove numpy.set_printoptions side effect from Manager.__init__

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,11 @@
+import os
+
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+import numpy
+
+numpy.set_printoptions(precision=8, sign=" ", legacy="1.13")
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow-running")

--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -182,13 +182,6 @@ class Manager(metaclass=Singleton):
 
     def __init__(self) -> None:
 
-        try:
-            # this is numpy 1.14
-            numpy.set_printoptions(precision=8, sign=" ", legacy="1.13")
-        except TypeError:
-            # before there was no `sign` parameters
-            numpy.set_printoptions(precision=8)
-
         self.current_units: dict[str, str] = {}
 
         # main configuration file


### PR DESCRIPTION
## Summary

- Remove `numpy.set_printoptions(precision=8, sign=' ', legacy='1.13')` from `Manager.__init__` — importing quantarhei no longer silently overwrites the user's numpy print configuration.
- Add `conftest.py` setup: set `MPLBACKEND=Agg` (prevents interactive plot windows during tests) and restore the numpy print options there so doctests continue to pass.

## Test plan

- [x] All 245 unit tests pass
- [x] All doctests pass (`pytest --doctest-modules quantarhei/`)
- [x] ruff lint and format pass
- [x] mypy passes (via pre-commit)
- [x] No interactive plot windows opened during test runs

Closes #218