### PR TITLE
#207 Add security warning when config is executed as Python code

### DIFF
--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -59,6 +59,11 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from .parallel import DistributedConfiguration
 
+
+class SecurityWarning(UserWarning):
+    """Warning about security-sensitive operations."""
+
+
 #
 # This stops future warnings, notably those in h5py library
 # FIXME: remove this in "future"
@@ -439,17 +444,37 @@ class Manager(metaclass=Singleton):
 
     def _load_uconf(self, fpath: str) -> None:
         """ """
-        # print("Conf path: ", os.path.abspath(fpath))
+        import platform
+        import stat
+
+        warnings.warn(
+            f"Loading configuration from {fpath} — this file is executed as "
+            "Python code. Ensure it comes from a trusted source.",
+            SecurityWarning,
+            stacklevel=2,
+        )
+
+        if platform.system() != "Windows":
+            try:
+                file_mode = os.stat(fpath).st_mode
+                if file_mode & (stat.S_IWGRP | stat.S_IWOTH):
+                    warnings.warn(
+                        f"Configuration file {fpath} is group- or "
+                        "world-writable. Consider running: "
+                        f"chmod 600 {fpath}",
+                        SecurityWarning,
+                        stacklevel=2,
+                    )
+            except OSError:
+                pass
+
         try:
             import importlib.util
 
             spec = importlib.util.spec_from_file_location("qrconf", fpath)
             foo = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(foo)
-            # print("Configuring Manager:")
-            # print(self)
             foo.configure(self)
-            # print("..done")
         except Exception:
             raise Exception()
 

--- a/quantarhei/core/parcel.py
+++ b/quantarhei/core/parcel.py
@@ -47,7 +47,7 @@ class Parcel:
                 with os.fdopen(tmp_fd, "wb") as f:
                     pickle.dump(self, f)
                 os.replace(tmp_path, filename)
-            except:
+            except Exception:
                 os.unlink(tmp_path)
                 raise
         else:


### PR DESCRIPTION
## Summary

- Emits a `SecurityWarning` via `warnings.warn()` whenever `Manager._load_uconf()` executes the user configuration file (`~/.quantarhei/qrhei.py`) as a Python module.
- On Unix/macOS, emits an additional warning if the config file is group- or world-writable, advising `chmod 600`.
- Defines a minimal `SecurityWarning(UserWarning)` class in `quantarhei/core/managers.py`.

This is the **conservative first step** — it adds visibility without changing the config format. A full migration to a data-only format (YAML/TOML) is deferred for maintainer discussion.

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `mypy` passes (pre-commit hook)
- [x] `pytest tests/unit -x -q` — all 245 tests pass
- [ ] Manually verify the warning appears when importing quantarhei with a config file present

Closes #207