### PR TITLE
#215 fix mutable default arguments in constructors

### DIFF
--- a/quantarhei/qm/corfunctions/cfmatrix.py
+++ b/quantarhei/qm/corfunctions/cfmatrix.py
@@ -42,8 +42,10 @@ class CorrelationFunctionMatrix(Saveable):
     """
 
     def __init__(
-        self, timeaxis: TimeAxis = TimeAxis(0.0, 1, 1.0), nob: int = 0, nof: int = 0
+        self, timeaxis: TimeAxis | None = None, nob: int = 0, nof: int = 0
     ) -> None:
+        if timeaxis is None:
+            timeaxis = TimeAxis(0.0, 1, 1.0)
         # Number of baths
         self.nob = nob
 

--- a/quantarhei/spectroscopy/linear_dichroism.py
+++ b/quantarhei/spectroscopy/linear_dichroism.py
@@ -633,8 +633,10 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
         relaxation_tensor: Any = None,
         rate_matrix: Any = None,
         effective_hamiltonian: Any = None,
-        vector_perp_to_membrane: numpy.ndarray = numpy.array([-1, -4, 1]),
+        vector_perp_to_membrane: numpy.ndarray | None = None,
     ) -> None:
+        if vector_perp_to_membrane is None:
+            vector_perp_to_membrane = numpy.array([-1, -4, 1])
 
         # protected properties
         self.TimeAxis = timeaxis


### PR DESCRIPTION
## Summary

- Replace function-call defaults (`TimeAxis(...)` and `numpy.array(...)`) with `None` sentinel + body assignment in `CorrelationFunctionMatrix.__init__` and `LinDichSpectrumCalculator.__init__`
- These were the last remaining instances of mutable/call-based defaults (ruff B006/B008) in the codebase
- Prevents shared mutable state across calls when the default is not explicitly provided

## Test plan

- [x] `ruff check quantarhei/ --select B006,B008` passes with zero violations
- [x] `ruff format quantarhei/` reports no changes needed
- [x] `pytest tests/unit -x -q` — all 245 tests pass

Closes #215