### PR TITLE
#208 Add security warning for .qrp deserialization

### DIFF
--- a/quantarhei/__init__.py
+++ b/quantarhei/__init__.py
@@ -294,6 +294,7 @@ from .core.parallel import (
 ###############################################################################
 # from .core.saveable import load
 # from .core.saveable import read_info
+from .core.parcel import DeserializationWarning as DeserializationWarning
 from .core.parcel import Parcel as Parcel
 from .core.parcel import check_parcel as check_parcel
 from .core.parcel import load_parcel as load_parcel
@@ -719,6 +720,7 @@ __all__ = [
     "DSFeynmanDiagram",
     "DensityMatrix",
     "DensityMatrixEvolution",
+    "DeserializationWarning",
     "Disorder",
     # Evolution / propagation
     "EvolutionSuperOperator",

--- a/quantarhei/core/parcel.py
+++ b/quantarhei/core/parcel.py
@@ -2,11 +2,24 @@ from __future__ import annotations
 
 import os
 import tempfile
+import warnings
 from typing import IO, Any
 
 import dill as pickle
 
 from .managers import Manager
+
+
+class DeserializationWarning(UserWarning):
+    """Warning emitted when loading a .qrp file without trusted=True."""
+
+
+_DESERIALIZATION_WARNING = (
+    "Loading a .qrp file deserializes Python objects using dill, which can "
+    "execute arbitrary code. Only load files from trusted sources. "
+    "Pass trusted=True to suppress this warning. "
+    "See https://github.com/tmancal74/quantarhei/issues/208 for details."
+)
 
 
 class Parcel:
@@ -77,7 +90,7 @@ def save_parcel(
     p.save(filename)
 
 
-def load_parcel(filename: str | IO[bytes]) -> Any:
+def load_parcel(filename: str | IO[bytes], *, trusted: bool = False) -> Any:
     """Loads the object saved as parcel
 
     Parameters
@@ -86,7 +99,16 @@ def load_parcel(filename: str | IO[bytes]) -> Any:
         Filename of the file or file descriptor of the file from which
         and object should be loaded.
 
+    trusted : bool
+        When *False* (default), a :class:`DeserializationWarning` is emitted to
+        inform the caller that deserialization may execute arbitrary code.
+        Set to *True* only when you are certain the file comes from a
+        trusted source.
+
     """
+    if not trusted:
+        warnings.warn(_DESERIALIZATION_WARNING, DeserializationWarning, stacklevel=2)
+
     if isinstance(filename, str):
         with open(filename, "rb") as f:
             obj = pickle.load(f)
@@ -98,7 +120,7 @@ def load_parcel(filename: str | IO[bytes]) -> Any:
     raise Exception("Only Quantarhei Parcels can be loaded")
 
 
-def check_parcel(filename: str | IO[bytes]) -> dict[str, Any]:
+def check_parcel(filename: str | IO[bytes], *, trusted: bool = False) -> dict[str, Any]:
     """Checks the content of a Quantarhei parcel
 
     Parameters
@@ -107,7 +129,16 @@ def check_parcel(filename: str | IO[bytes]) -> dict[str, Any]:
         Filename of the file or file descriptor of the file from which
         and object should be loaded.
 
+    trusted : bool
+        When *False* (default), a :class:`DeserializationWarning` is emitted to
+        inform the caller that deserialization may execute arbitrary code.
+        Set to *True* only when you are certain the file comes from a
+        trusted source.
+
     """
+    if not trusted:
+        warnings.warn(_DESERIALIZATION_WARNING, DeserializationWarning, stacklevel=2)
+
     if isinstance(filename, str):
         with open(filename, "rb") as f:
             obj = pickle.load(f)


### PR DESCRIPTION
## Summary

- `load_parcel()` and `check_parcel()` now emit a `DeserializationWarning` when loading `.qrp` files, informing users that dill deserialization can execute arbitrary code.
- A keyword-only `trusted=True` parameter suppresses the warning for callers who trust the file source.
- `DeserializationWarning` (a `UserWarning` subclass) is exported from the top-level package so users can filter it with `warnings.filterwarnings`.

This is the conservative first step — it does **not** change the serialization format. A full migration to a safe format is deferred for maintainer discussion.

## Test plan

- [x] All 245 existing unit tests pass without modification
- [x] `ruff check` and `ruff format` pass
- [x] `mypy` passes
- [ ] Manually verify warning appears: `python -W all -c "import quantarhei as qr; qr.load_parcel('some.qrp')"`

Closes #208