### PR TITLE
#186 Replace bare except: with except Exception:

### DIFF
--- a/quantarhei/core/parcel.py
+++ b/quantarhei/core/parcel.py
@@ -47,7 +47,7 @@ class Parcel:
                 with os.fdopen(tmp_fd, "wb") as f:
                     pickle.dump(self, f)
                 os.replace(tmp_path, filename)
-            except:
+            except Exception:
                 os.unlink(tmp_path)
                 raise
         else:


### PR DESCRIPTION
## Summary

- Replaces the single bare `except:` clause in `quantarhei/core/parcel.py` with `except Exception:` 
- This prevents accidentally catching `KeyboardInterrupt` and `SystemExit`, which can cause hangs and hide real bugs
- The cleanup-and-reraise pattern behavior is preserved — only the exception filter is narrowed

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] All 245 unit tests pass (`pytest tests/unit -x -q`)
- [x] pre-commit hooks (ruff, ruff-format, mypy) pass

Closes #186