### PR TITLE
#220 add __repr__ to domain objects

### DIFF
--- a/quantarhei/builders/aggregate_base.py
+++ b/quantarhei/builders/aggregate_base.py
@@ -1937,6 +1937,9 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
             yield a, es1
             a += 1
 
+    def __repr__(self) -> str:
+        return f"Aggregate(name={self.name!r}, nmono={self.nmono})"
+
     def __str__(self) -> str:
         out = "\nquantarhei.Aggregate object"
         out += "\n==========================="

--- a/quantarhei/builders/molecules.py
+++ b/quantarhei/builders/molecules.py
@@ -2271,6 +2271,9 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
 
         return ee, ss
 
+    def __repr__(self) -> str:
+        return f"Molecule(name={self.name!r}, nel={self.nel})"
+
     def __str__(self) -> str:
         """String representation of the Molecule object"""
         out = "\nquantarhei.Molecule object"

--- a/quantarhei/core/time.py
+++ b/quantarhei/core/time.py
@@ -265,6 +265,9 @@ class TimeAxis(ValueAxis):
         else:
             raise Exception("Unknown time axis type")
 
+    def __repr__(self) -> str:
+        return f"TimeAxis(start={self.start}, length={self.length}, step={self.step})"
+
     def shift_to_zero(self) -> None:
         """Shifts the values so that the first one is zero"""
         if self.start != self.data[0]:

--- a/quantarhei/qm/corfunctions/correlationfunctions.py
+++ b/quantarhei/qm/corfunctions/correlationfunctions.py
@@ -239,6 +239,11 @@ class CorrelationFunction(DFunction, UnitsManaged):
                 # FIXME: set cut-off time and temperature
                 # self._set_temperature_and_cutoff_time(self.params[0])
 
+    def __repr__(self) -> str:
+        ftype = self.params[0]["ftype"] if self.params else "unknown"
+        temp = self.temperature if hasattr(self, "temperature") else None
+        return f"CorrelationFunction(ftype={ftype!r}, T={temp})"
+
     def _matsubara(self, kBT: float, ctime: float, nof: int) -> numpy.ndarray:
         """Matsubara frequency part of the Brownian correlation function"""
         msf: float | numpy.ndarray = 0.0

--- a/quantarhei/qm/corfunctions/spectraldensities.py
+++ b/quantarhei/qm/corfunctions/spectraldensities.py
@@ -201,6 +201,10 @@ class SpectralDensity(DFunction, UnitsManaged):
 
                 self.params.append(prms)
 
+    def __repr__(self) -> str:
+        ftype = self.params[0]["ftype"] if self.params else "unknown"
+        return f"SpectralDensity(ftype={ftype!r})"
+
     def _make_overdamped_brownian(self, params: dict, values: Any = None) -> None:
         """Sets the Overdamped Brownian oscillator spectral density"""
         try:

--- a/quantarhei/qm/hilbertspace/hamiltonian.py
+++ b/quantarhei/qm/hilbertspace/hamiltonian.py
@@ -332,6 +332,14 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
         if self._has_remainder_coupling:
             self.JR = numpy.dot(S1, numpy.dot(self.JR, SS))
 
+    def __repr__(self) -> str:
+        dtype = (
+            self.data.dtype
+            if hasattr(self, "_data") and self.data is not None
+            else None
+        )
+        return f"Hamiltonian(dim={self.dim}, dtype={dtype})"
+
     def __str__(self) -> str:
         out = "\nquantarhei.Hamiltonian object"
         out += "\n============================="

--- a/quantarhei/qm/hilbertspace/operators.py
+++ b/quantarhei/qm/hilbertspace/operators.py
@@ -322,6 +322,14 @@ class DensityMatrix(SelfAdjointOperator, Saveable):
         tr = numpy.trace(self.data)
         self.data = self.data / tr
 
+    def __repr__(self) -> str:
+        dtype = (
+            self.data.dtype
+            if hasattr(self, "_data") and self.data is not None
+            else None
+        )
+        return f"DensityMatrix(dim={self.dim}, dtype={dtype})"
+
     def __str__(self) -> str:
         out = "\nquantarhei.DensityMatrix object"
         out += "\n==============================="

--- a/quantarhei/qm/liouvillespace/evolutionsuperoperator.py
+++ b/quantarhei/qm/liouvillespace/evolutionsuperoperator.py
@@ -887,6 +887,9 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
             self.convert_from_RWA(ham, sgn=-1)
             self.is_in_rwa = True
 
+    def __repr__(self) -> str:
+        return f"EvolutionSuperOperator(dim={self.dim})"
+
     def __str__(self) -> str:
         out = "\nquantarhei.EvolutionSuperOperator object"
         out += "\n========================================"


### PR DESCRIPTION
## Summary

- Add concise `__repr__` methods to 8 key domain objects: `Molecule`, `AggregateBase`, `Hamiltonian`, `DensityMatrix`, `EvolutionSuperOperator`, `TimeAxis`, `CorrelationFunction`, and `SpectralDensity`
- Each repr shows the class name and key identifying attributes (e.g. dimensions, types, names) without dumping full matrix data
- Existing `__str__` methods are unchanged

## Examples

```python
>>> mol = Molecule([0.0, 1.0], name="Chl-a")
>>> mol
Molecule(name='Chl-a', nel=2)

>>> ta = TimeAxis(0.0, 1000, 1.0)
>>> ta
TimeAxis(start=0.0, length=1000, step=1.0)

>>> H = agg.get_Hamiltonian()
>>> H
Hamiltonian(dim=4, dtype=float64)
```

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `mypy` passes (via pre-commit)
- [x] All 245 unit tests pass (`pytest tests/unit -x -q`)

Closes #220