### PR TITLE
#380 Fix missing spatial index in TransitionDipoleMoment basis conversion

### DIFF
--- a/quantarhei/builders/aggregate_base.py
+++ b/quantarhei/builders/aggregate_base.py
@@ -2777,7 +2777,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                                     nop._data[i_n, i_m, a] = 0.0
                                     for j_n in self.vibindices[n]:
                                         for j_m in self.vibindices[m]:
-                                            nop._data[i_n, i_m] += (
+                                            nop._data[i_n, i_m, a] += (
                                                 self.FCf[i_ng, j_n]
                                                 * operator._data[j_n, j_m, a]
                                                 * self.FCf[j_m, i_mg]

--- a/tests/unit/builders/test_aggregate_base.py
+++ b/tests/unit/builders/test_aggregate_base.py
@@ -9,7 +9,7 @@ from quantarhei import (
     energy_units,
 )
 from quantarhei.builders.aggregate_test import TestAggregate
-from quantarhei.qm import ReducedDensityMatrix
+from quantarhei.qm import ReducedDensityMatrix, TransitionDipoleMoment
 
 
 def _dimer(with_modes: bool = False, hr: tuple = (0.1, 0.3)) -> Aggregate:
@@ -200,6 +200,31 @@ class TestConvertToGroundVibBasis(unittest.TestCase):
         H = self.vagg.get_Hamiltonian()
         rho = ReducedDensityMatrix(dim=H.dim)
         converted = self.vagg.convert_to_ground_vibbasis(rho)
+        numpy.testing.assert_array_almost_equal(
+            converted._data, numpy.zeros_like(converted._data)
+        )
+
+
+class TestConvertTDMToGroundVibBasis(unittest.TestCase):
+    def setUp(self) -> None:
+        self.vagg = _dimer(with_modes=True)
+
+    def test_convert_tdm_preserves_spatial_components(self) -> None:
+        tdm = self.vagg.get_TransitionDipoleMoment()
+        converted = self.vagg.convert_to_ground_vibbasis(tdm)
+        assert isinstance(converted, TransitionDipoleMoment)
+        for a in range(3):
+            other_components = [b for b in range(3) if b != a]
+            if numpy.any(converted._data[:, :, a] != 0.0):
+                for b in other_components:
+                    assert not numpy.allclose(
+                        converted._data[:, :, a], converted._data[:, :, b]
+                    ), f"Component {a} should differ from {b}"
+
+    def test_convert_tdm_zero_stays_zero(self) -> None:
+        dim = self.vagg.Ntot
+        tdm = TransitionDipoleMoment(dim=dim)
+        converted = self.vagg.convert_to_ground_vibbasis(tdm)
         numpy.testing.assert_array_almost_equal(
             converted._data, numpy.zeros_like(converted._data)
         )


### PR DESCRIPTION
## Summary

- Fixed a bug where `convert_to_ground_vibbasis` wrote to `nop._data[i_n, i_m]` instead of `nop._data[i_n, i_m, a]`, causing all spatial components to be scrambled during Franck-Condon transformation of TransitionDipoleMoment operators
- Added tests exercising this previously untested code path

## Details

The bug was introduced in commit `58099ae` (Oct 2023). The zeroing line correctly used `[i_n, i_m, a]` but the accumulation line was missing the `, a` index, causing numpy to broadcast the scalar into all 3 components.

## Test plan

- [x] New test `test_convert_tdm_preserves_spatial_components` verifies x/y/z stay independent
- [x] New test `test_convert_tdm_zero_stays_zero` verifies zero input → zero output
- [x] All 36 aggregate_base tests pass
- [x] Pre-commit hooks pass

Closes #380