### PR TITLE
#394 #395 Deduplicate band-transition lineshape and site reorg loops

### DIFF
--- a/quantarhei/builders/aggregate_base.py
+++ b/quantarhei/builders/aggregate_base.py
@@ -901,6 +901,37 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return WPM
 
+    def _band_transition_lineshape(
+        self,
+        transition: tuple,
+        matrix: numpy.ndarray,
+        default: float = 0.0,
+        square_interband: bool = True,
+    ) -> float:
+        Nf = transition[0]
+        Ni = transition[1]
+
+        eli = self.elinds[Ni]
+        elf = self.elinds[Nf]
+
+        bi = self.which_band[eli]
+        bf = self.which_band[elf]
+
+        if (bi == 0 and bf == 1) or (bi == 1 and bf == 0):
+            idx = Nf if bi == 0 else Ni
+            return matrix[idx, idx] ** 2
+
+        if (bi == 1 and bf == 2) or (bi == 2 and bf == 1):
+            if square_interband:
+                return (
+                    matrix[Ni, Ni] ** 2
+                    + matrix[Nf, Nf] ** 2
+                    - 2.0 * (matrix[Nf, Ni] ** 2)
+                )
+            return matrix[Ni, Ni] ** 2 + matrix[Nf, Nf] - 2.0 * matrix[Nf, Ni]
+
+        return default
+
     def get_transition_width(self, state1: Any, state2: Any | None = None) -> float:
         """Returns phenomenological width of a given transition
 
@@ -962,42 +993,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
             return -1.0
 
         transition = state1
-
-        Nf = transition[0]
-        Ni = transition[1]
-
-        eli = self.elinds[Ni]
-        elf = self.elinds[Nf]
-
-        # g -> 1 exciton band transitions
-        if (self.which_band[eli] == 0) and (self.which_band[elf] == 1):
-            # this simulates bath correlation function
-            return self.Wd[Nf, Nf] ** 2
-
-        if (self.which_band[eli] == 1) and (self.which_band[elf] == 0):
-            # this simulates bath correlation function
-            return self.Wd[Ni, Ni] ** 2
-
-        # 1 exciton -> 2 exciton transitions
-        if (self.which_band[eli] == 1) and (self.which_band[elf] == 2):
-            # this simulates the term  g_ff + g_ee - 2Re g_fe
-            ret = (
-                self.Wd[Ni, Ni] ** 2
-                + self.Wd[Nf, Nf] ** 2
-                - 2.0 * (self.Wd[Nf, Ni] ** 2)
-            )
-            return ret
-
-        if (self.which_band[eli] == 2) and (self.which_band[elf] == 1):
-            # this simulates the term  g_ff + g_ee - 2Re g_fe
-            ret = (
-                self.Wd[Ni, Ni] ** 2
-                + self.Wd[Nf, Nf] ** 2
-                - 2.0 * (self.Wd[Nf, Ni] ** 2)
-            )
-            return ret
-
-        return 0.0
+        return self._band_transition_lineshape(transition, self.Wd, default=0.0)
 
     def get_transition_dephasing(self, state1: Any, state2: Any | None = None) -> float:
         """Returns phenomenological dephasing of a given transition
@@ -1027,30 +1023,9 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
             return deph
 
         transition = state1
-
-        Nf = transition[0]
-        Ni = transition[1]
-
-        eli = self.elinds[Ni]
-        elf = self.elinds[Nf]
-
-        # g -> 1 exciton band transitions
-        if (self.which_band[eli] == 0) and (self.which_band[elf] == 1):
-            return self.Dr[Nf, Nf] ** 2
-
-        if (self.which_band[eli] == 1) and (self.which_band[elf] == 0):
-            return self.Dr[Ni, Ni] ** 2
-
-        # 1 exciton -> 2 exciton band transitions
-        if (self.which_band[eli] == 1) and (self.which_band[elf] == 2):
-            # this simulates the term  g_ff + g_ee - 2Re g_fe
-            return self.Dr[Ni, Ni] ** 2 + self.Dr[Nf, Nf] - 2.0 * self.Dr[Nf, Ni]
-
-        if (self.which_band[eli] == 2) and (self.which_band[elf] == 1):
-            # this simulates the term  g_ff + g_ee - 2Re g_fe
-            return self.Dr[Ni, Ni] ** 2 + self.Dr[Nf, Nf] - 2.0 * self.Dr[Nf, Ni]
-
-        return -1.0
+        return self._band_transition_lineshape(
+            transition, self.Dr, default=-1.0, square_interband=False
+        )
 
     def transition_dipole(self, state1: Any, state2: Any) -> numpy.ndarray | float:
         """Transition dipole moment between two states
@@ -3036,17 +3011,14 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                 reorg_bath += parm["reorg"]
         return reorg_bath
 
-    def _site_reorg_diag(self, subtract_bath: bool = True) -> numpy.ndarray:
-        """Returns the reorganisation energy of an exciton state"""
-        # SystemBathInteraction
-        sbi = self.get_SystemBathInteraction()
-        # CorrelationFunctionMatrix
-        cfm = sbi.CC
-
-        reorg_site = numpy.zeros(self.Ntot)
-
-        # electronic states corresponding to single excited states
-        elst = numpy.where(self.which_band == 1)[0]
+    def _accumulate_site_reorg(
+        self,
+        reorg_site: numpy.ndarray,
+        cfm: Any,
+        band: int,
+        subtract_bath: bool,
+    ) -> None:
+        elst = numpy.where(self.which_band == band)[0]
         for el1 in elst:
             if subtract_bath:
                 reorgB = self._bath_reorg(cfm, el1 - 1)
@@ -3057,17 +3029,18 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
             for kk in self.vibindices[el1]:
                 reorg_site[kk] += reorg
 
-        elst_dbl1 = numpy.where(self.which_band == 2)[0]
-        for el1 in elst_dbl1:
-            if subtract_bath:
-                reorgB = self._bath_reorg(cfm, el1 - 1)
-            else:
-                reorgB = 0.0
+    def _site_reorg_diag(self, subtract_bath: bool = True) -> numpy.ndarray:
+        """Returns the reorganisation energy of an exciton state"""
+        sbi = self.get_SystemBathInteraction()
+        cfm = sbi.CC
 
-            reorg = cfm.get_reorganization_energy(el1 - 1, el1 - 1) - reorgB
-
-            for kk in self.vibindices[el1]:
-                reorg_site[kk] += reorg
+        reorg_site = numpy.zeros(self.Ntot)
+        self._accumulate_site_reorg(
+            reorg_site, cfm, band=1, subtract_bath=subtract_bath
+        )
+        self._accumulate_site_reorg(
+            reorg_site, cfm, band=2, subtract_bath=subtract_bath
+        )
         return reorg_site
 
     def _excitonic_reorg_diag(


### PR DESCRIPTION
## Summary

- Extract `_band_transition_lineshape` helper to unify the duplicated band-checking dispatch in `get_transition_width` and `get_transition_dephasing`
- Extract `_accumulate_site_reorg` helper to unify the duplicated band 1/band 2 loops in `_site_reorg_diag`

## Details

**`_band_transition_lineshape(transition, matrix, default, square_interband)`**

Both `get_transition_width` (using `self.Wd`) and `get_transition_dephasing` (using `self.Dr`) had identical 4-way band dispatch (ground↔1-exciton, 1-exciton↔2-exciton). The only physics difference: the width formula squares all inter-band terms while the dephasing formula does not. This is captured by the `square_interband` parameter.

**`_accumulate_site_reorg(reorg_site, cfm, band, subtract_bath)`**

`_site_reorg_diag` had two sequential identical loops — one filtering `which_band == 1`, the other `which_band == 2`. Now calls the helper twice with the band parameter.

## Test plan

- [x] All 245 unit tests pass
- [x] No behavior change (pure refactor)