### PR TITLE
#402 Enable disallow_any_explicit mypy rule globally

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ python_version = "3.10"
 ignore_missing_imports = true
 no_strict_optional = true
 disallow_untyped_defs = true
+disallow_any_explicit = true
 exclude = [
     "quantarhei/wizard/examples",
     "quantarhei/wizard/benchmarks",

--- a/quantarhei/builders/aggregate_base.py
+++ b/quantarhei/builders/aggregate_base.py
@@ -2854,7 +2854,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         raise Exception("Incompatible operator dimension")
 
-    def _accumulate_fc_trace(
+    def _accumulate_fc_trace(  # type: ignore[explicit-any]
         self,
         nop: ReducedDensityMatrix
         | Hamiltonian

--- a/quantarhei/builders/aggregate_base.py
+++ b/quantarhei/builders/aggregate_base.py
@@ -65,21 +65,21 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         # OpenSystem.__init__(self)
 
         self.mnames: dict[str, int] = {}  #
-        self.monomers: list[Any] = []
+        self.monomers: list[Any] = []  # type: ignore[explicit-any]
         self.nmono = 0  #
         self.name = name  #
         self.mult = 0  #
-        self.lab: Any = None  #
+        self.lab: Any = None  # type: ignore[explicit-any]  #
 
         self._has_egcf_matrix = False  #
-        self.egcf_matrix: Any = None
+        self.egcf_matrix: Any = None  # type: ignore[explicit-any]
 
         self._has_system_bath_interaction = False  #
 
         self._has_lindich_axes = False
 
         self.coupling_initiated = False  #
-        self.resonance_coupling: Any = None
+        self.resonance_coupling: Any = None  # type: ignore[explicit-any]
         self._has_velocity_dipoles = False
 
         if molecules is not None:
@@ -109,27 +109,27 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         self.sbi_mult = 0  #
         self.Nel = 0  #
         self.Ntot = 0  #
-        self.Nb: Any = 0  #
+        self.Nb: Any = 0  # type: ignore[explicit-any]  #
 
-        self.vibindices: list[Any] = []
-        self.which_band: Any = None
-        self.elsigs: Any = None
+        self.vibindices: list[Any] = []  # type: ignore[explicit-any]
+        self.which_band: Any = None  # type: ignore[explicit-any]
+        self.elsigs: Any = None  # type: ignore[explicit-any]
 
-        self.HH: Any = None
-        self.HamOp: Any = None
-        self.DD: Any = None
-        self.MM: Any = None
-        self.RR: Any = None
-        self.Wd: Any = None
-        self.Dr: Any = None
-        self.D2: Any = None
+        self.HH: Any = None  # type: ignore[explicit-any]
+        self.HamOp: Any = None  # type: ignore[explicit-any]
+        self.DD: Any = None  # type: ignore[explicit-any]
+        self.MM: Any = None  # type: ignore[explicit-any]
+        self.RR: Any = None  # type: ignore[explicit-any]
+        self.Wd: Any = None  # type: ignore[explicit-any]
+        self.Dr: Any = None  # type: ignore[explicit-any]
+        self.D2: Any = None  # type: ignore[explicit-any]
         self.D2_max: float = 0.0
-        self.sbi: Any = None
+        self.sbi: Any = None  # type: ignore[explicit-any]
 
         self._has_wpm = False
-        self.WPM: Any = None
-        self.sv0: Any = None
-        self.vibsigs: Any = None
+        self.WPM: Any = None  # type: ignore[explicit-any]
+        self.sv0: Any = None  # type: ignore[explicit-any]
+        self.vibsigs: Any = None  # type: ignore[explicit-any]
 
     def clean(self) -> None:
         """Cleans the aggregate object of anything built
@@ -180,8 +180,8 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         """
         # FIXME: Find better way how to store couplings for multilevel molecules!
 
-        self._coupling2mol: list[Any] = []
-        self._mol2coupling: list[Any] = []
+        self._coupling2mol: list[Any] = []  # type: ignore[explicit-any]
+        self._mol2coupling: list[Any] = []  # type: ignore[explicit-any]
 
         # index for coupling between mon1 init1 -> final1 and mon2 init2 -> final2
         # is self._mol2coupling[mon1][init1][final1-init1-1][mon2-mon1-1][init2][final2-init2-1]
@@ -219,7 +219,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         # TODO: add initialization flag
         self.coupling_initiated = True
 
-    def get_resonance_coupling_vec(
+    def get_resonance_coupling_vec(  # type: ignore[explicit-any]
         self, mon1: int, init1: int, fin1: int, mon2: int, init2: int, fin2: int
     ) -> float | numpy.ndarray:
         """returns coupling between mon1 transition init1->fin1 and
@@ -416,7 +416,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return
 
-    def set_coupling_by_Hamiltonian(self, HH: numpy.ndarray) -> None:
+    def set_coupling_by_Hamiltonian(self, HH: numpy.ndarray) -> None:  # type: ignore[explicit-any]
         """set the resonance coupling values according to given electronic
         Hamiltonian (single exciton band is expected - without the ground state).
         Only excitations from the ground state are allowed.
@@ -518,11 +518,11 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         else:
             print(text_warning)
 
-    def get_resonance_coupling(self, i: int, j: int) -> float | numpy.ndarray:
+    def get_resonance_coupling(self, i: int, j: int) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns resonance coupling value between two sites"""
         return self.get_resonance_coupling_vec(i, 0, 1, j, 1, 0)
 
-    def set_resonance_coupling_matrix(
+    def set_resonance_coupling_matrix(  # type: ignore[explicit-any]
         self, coupmat: numpy.ndarray | list | tuple
     ) -> None:
         """Sets resonance coupling values from a matrix"""
@@ -536,7 +536,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         #
         # TESTED
 
-    def dipole_dipole_coupling(
+    def dipole_dipole_coupling(  # type: ignore[explicit-any]
         self, kk: int, ll: int, epsr: float = 1.0, delta: float = 1.0e-5
     ) -> float | numpy.ndarray:
         """Calculates dipole-dipole coupling"""
@@ -560,7 +560,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         #
         # TESTED
 
-    def dipole_dipole_coupling_multilevel(
+    def dipole_dipole_coupling_multilevel(  # type: ignore[explicit-any]
         self,
         mon1: int,
         in1: int,
@@ -637,7 +637,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         # TESTED
 
     # FIXME: This must be set in coordination with objects describing laboratory
-    def set_lindich_axes(self, axis_orthog_membrane: numpy.ndarray) -> None:
+    def set_lindich_axes(self, axis_orthog_membrane: numpy.ndarray) -> None:  # type: ignore[explicit-any]
         """Creates a coordinate system with one axis supplied by the user
         (typically an axis orthogonal to the membrane), and two other axes, all
         of which are orthonormal.
@@ -649,7 +649,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         self._has_lindich_axes = True
 
     # FIXME: This must be set in coordination with objects describing laboratory
-    def get_lindich_axes(self) -> numpy.ndarray:
+    def get_lindich_axes(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         if self._has_lindich_axes:
             return self.q
         raise QuantarheiError("No linear dichroism coordinate system supplied")
@@ -663,7 +663,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
     #
     # Molecues
     #
-    def add_Molecule(self, mono: Any) -> None:
+    def add_Molecule(self, mono: Any) -> None:  # type: ignore[explicit-any]
         """Adds monomer to the aggregate"""
         # If at least one monomer has energy gap correlation function
         # we will try to build system bath interaction for a the aggregate.
@@ -695,7 +695,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         self.monomers.remove(mono)
         self.nmono -= 1
 
-    def get_nearest_Molecule(self, molecule: Any) -> tuple:
+    def get_nearest_Molecule(self, molecule: Any) -> tuple:  # type: ignore[explicit-any]
         """Returns a molecule nearest in the aggregate to a given molecule
 
         Parameters
@@ -724,17 +724,17 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
     #
     # Transition dipole
     #
-    def get_dipole(
+    def get_dipole(  # type: ignore[explicit-any]
         self, n: Any, N: Any = None, M: Any = None, **kwargs: Any
     ) -> numpy.ndarray:
         nm = self.monomers[n]
         return nm.get_dipole(N, M)
 
-    def get_velocity_dipole(self, n: int, N: int, M: int) -> numpy.ndarray:
+    def get_velocity_dipole(self, n: int, N: int, M: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         nm = self.monomers[n]
         return nm.get_velocity_dipole(N, M)
 
-    def get_magnetic_dipole(self, n: int, N: int, M: int) -> numpy.ndarray:
+    def get_magnetic_dipole(self, n: int, N: int, M: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         nm = self.monomers[n]
         return nm.get_magnetic_dipole(N, M)
 
@@ -752,13 +752,13 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
             omax.append(nm.nel - 1)
         return omax
 
-    def set_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:
+    def set_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:  # type: ignore[explicit-any]
         """Sets the dipole moment of a given transition"""
         raise QuantarheiError(
             "Transition dipole moments cannot be set directly. Use aggregate components."
         )
 
-    def fc_factor(self, state1: Any, state2: Any) -> float:
+    def fc_factor(self, state1: Any, state2: Any) -> float:  # type: ignore[explicit-any]
         """Franck-Condon factors between two vibrational states
 
 
@@ -805,7 +805,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return numpy.real(res)
 
-    def map_egcf_to_states(self, mpx: numpy.ndarray) -> numpy.ndarray:
+    def map_egcf_to_states(self, mpx: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Maps the participation matrix on g(t) functions storage
 
         This should work for a simple mapping matrix and first excited band.
@@ -818,7 +818,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         Ng = self.Nb[0]
         Ne1 = self.Nb[1] + Ng
 
-        def _nonzero(vec: numpy.ndarray) -> int | None:
+        def _nonzero(vec: numpy.ndarray) -> int | None:  # type: ignore[explicit-any]
             """Returns a possition in the vector on which value == 1 is found"""
             for kk, vl in enumerate(vec):
                 if vl == 1:
@@ -904,7 +904,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return WPM
 
-    def get_transition_width(self, state1: Any, state2: Any | None = None) -> float:
+    def get_transition_width(self, state1: Any, state2: Any | None = None) -> float:  # type: ignore[explicit-any]
         """Returns phenomenological width of a given transition
 
 
@@ -1002,7 +1002,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return 0.0
 
-    def get_transition_dephasing(self, state1: Any, state2: Any | None = None) -> float:
+    def get_transition_dephasing(self, state1: Any, state2: Any | None = None) -> float:  # type: ignore[explicit-any]
         """Returns phenomenological dephasing of a given transition
 
 
@@ -1055,7 +1055,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return -1.0
 
-    def transition_dipole(self, state1: Any, state2: Any) -> numpy.ndarray | float:
+    def transition_dipole(self, state1: Any, state2: Any) -> numpy.ndarray | float:  # type: ignore[explicit-any]
         """Transition dipole moment between two states
 
         Parameters
@@ -1087,7 +1087,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return eldip * fcfac
 
-    def transition_velocity_dipole(
+    def transition_velocity_dipole(  # type: ignore[explicit-any]
         self, state1: Any, state2: Any
     ) -> numpy.ndarray | float:
         """Transition dipole moment between two states
@@ -1120,7 +1120,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return elvdip * fcfac
 
-    def transition_magnetic(self, state1: Any, state2: Any) -> numpy.ndarray | float:
+    def transition_magnetic(self, state1: Any, state2: Any) -> numpy.ndarray | float:  # type: ignore[explicit-any]
         """Transition magnetic dipole moment between two states
 
         Parameters
@@ -1148,7 +1148,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return magdip * fcfac
 
-    def _get_twoexindx(self, state1: Any, state2: Any) -> tuple | int:
+    def _get_twoexindx(self, state1: Any, state2: Any) -> tuple | int:  # type: ignore[explicit-any]
         """Indices of two molecule with transitions or negative number
         if not found
 
@@ -1202,7 +1202,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return exindxs[0], exindxs[1]
 
-    def _get_exindx(self, state1: Any, state2: Any) -> int:
+    def _get_exindx(self, state1: Any, state2: Any) -> int:  # type: ignore[explicit-any]
         """Index of molecule with transition or negative number if not found
 
         Parameters
@@ -1337,7 +1337,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         """
         return ElectronicState(self, sig, index)
 
-    def get_StateBand(self, state: Any) -> int:
+    def get_StateBand(self, state: Any) -> int:  # type: ignore[explicit-any]
         """Returns band of the corresponding electronic state
 
         This effectively counts the number of excitations in the state
@@ -1363,7 +1363,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return VibronicState(elstate, vsig)
 
-    def coupling_vec(self, state1: Any, state2: Any) -> float | numpy.ndarray:
+    def coupling_vec(self, state1: Any, state2: Any) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Coupling between two aggregate states
 
 
@@ -1380,7 +1380,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         #
         # Coupling between two purely electronic states
         #
-        coup: float | numpy.ndarray = 0.0
+        coup: float | numpy.ndarray = 0.0  # type: ignore[explicit-any]
         if isinstance(state1, ElectronicState) and isinstance(state2, ElectronicState):
             if self.nmono > 1:
                 # coupling within the bands
@@ -1504,7 +1504,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return self.convert_energy_2_current_u(coup)
 
-    def coupling(
+    def coupling(  # type: ignore[explicit-any]
         self, state1: Any, state2: Any, full: bool = False
     ) -> float | numpy.ndarray:
         """Coupling between two aggregate states
@@ -1657,7 +1657,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
     #
     #######################################################################
 
-    def elsignatures(
+    def elsignatures(  # type: ignore[explicit-any]
         self, mult: int = 1, mode: str = "LQ", emax: list | None = None
     ) -> Iterator[tuple[Any, ...]]:
         """Generator of electronic signatures
@@ -1750,7 +1750,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                         excit_lvl += 1
                 mlt += 1
 
-    def _add_excitation(
+    def _add_excitation(  # type: ignore[explicit-any]
         self, inlists: list, strt: list, omax: list
     ) -> Iterator[tuple[Any, Any]]:
         """Adds one excitation to all submitted electronic signatures"""
@@ -1775,7 +1775,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                     yield out, i
             list_idx += 1
 
-    def vibsignatures(self, elsignature: tuple, approx: str | None = None) -> Any:
+    def vibsignatures(self, elsignature: tuple, approx: str | None = None) -> Any:  # type: ignore[explicit-any]
         """Generator of vibrational signatures
 
         Parameters
@@ -1788,7 +1788,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         cs = ElectronicState(self, elsignature)
         return cs.vsignatures(approx=approx)
 
-    def allstates(
+    def allstates(  # type: ignore[explicit-any]
         self,
         mult: int = 1,
         mode: str = "LQ",
@@ -1930,7 +1930,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                     else:
                         self.which_band[ist] = numpy.sum(ess1)
 
-    def elstates(
+    def elstates(  # type: ignore[explicit-any]
         self, mult: int = 1, mode: str = "LQ", save_indices: bool = False
     ) -> Generator[tuple[int, Any], None, None]:
         """Generator of electronic states"""
@@ -2088,11 +2088,11 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         # Matrix of Franck-Condon factors
         FC = numpy.zeros((Ntot, Ntot), dtype=numpy.float64)
         # Matrix of the transition widths (their square roots)
-        Wd: numpy.ndarray = numpy.zeros((Ntot, Ntot), dtype=REAL)
+        Wd: numpy.ndarray = numpy.zeros((Ntot, Ntot), dtype=REAL)  # type: ignore[explicit-any]
         # Matrix of dephasing rates
-        Dr: numpy.ndarray = numpy.zeros((Ntot, Ntot), dtype=REAL)
+        Dr: numpy.ndarray = numpy.zeros((Ntot, Ntot), dtype=REAL)  # type: ignore[explicit-any]
         # Matrix of dephasing transformation coefficients
-        self.Xi: numpy.ndarray = numpy.zeros((Ntot, self.Nel), dtype=REAL)
+        self.Xi: numpy.ndarray = numpy.zeros((Ntot, self.Nel), dtype=REAL)  # type: ignore[explicit-any]
 
         # electronic indices of twice excited state (zero for all other states)
         twoex_indx = numpy.zeros((Ntot, 2), dtype=int)
@@ -2275,7 +2275,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         self.RRm = RRm
 
         # FIXME: make this on-demand (if poissible)
-        trdata: numpy.ndarray = numpy.zeros(
+        trdata: numpy.ndarray = numpy.zeros(  # type: ignore[explicit-any]
             (DD.shape[0], DD.shape[1], DD.shape[2]), dtype=REAL
         )
         trdata[:, :, :] = DD[:, :, :]
@@ -2960,7 +2960,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         raise QuantarheiError("Incompatible operator")
 
-    def cast_to_vibronic(self, KK: numpy.ndarray) -> numpy.ndarray:
+    def cast_to_vibronic(self, KK: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Casts an electronic operator to a vibronic basis"""
         agg = self
 
@@ -3022,7 +3022,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                 count += 1
         return esum / count
 
-    def _bath_reorg(self, cfm: Any, indx: int) -> float:
+    def _bath_reorg(self, cfm: Any, indx: int) -> float:  # type: ignore[explicit-any]
         coft = cfm.cfuncs[cfm.get_index_by_where((indx, indx))]
         reorg_bath = 0.0
         for parm in coft.params:
@@ -3030,7 +3030,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                 reorg_bath += parm["reorg"]
         return reorg_bath
 
-    def _site_reorg_diag(self, subtract_bath: bool = True) -> numpy.ndarray:
+    def _site_reorg_diag(self, subtract_bath: bool = True) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the reorganisation energy of an exciton state"""
         # SystemBathInteraction
         sbi = self.get_SystemBathInteraction()
@@ -3064,7 +3064,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                 reorg_site[kk] += reorg
         return reorg_site
 
-    def _excitonic_reorg_diag(
+    def _excitonic_reorg_diag(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, subtract_bath: bool = True
     ) -> numpy.ndarray:
         """Returns the reorganisation energy of an exciton state"""
@@ -3107,7 +3107,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         return reorg_exct
 
     # FIXME: All these properties have to be meaningfully defined for all open systems
-    def _get_exciton_prop(self, adiabatic: Any = None, HH_in: Any = None) -> tuple:
+    def _get_exciton_prop(self, adiabatic: Any = None, HH_in: Any = None) -> tuple:  # type: ignore[explicit-any]
 
         is_adiabatic = False
         adiabatic_noBath = False
@@ -3147,7 +3147,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return val, SS
 
-    def _extract_diagonal_widths(
+    def _extract_diagonal_widths(  # type: ignore[explicit-any]
         self, Nel: int, Wd_ini: numpy.ndarray, Dr_ini: numpy.ndarray
     ) -> tuple[numpy.ndarray, numpy.ndarray]:
         Wd_in = numpy.zeros(Nel, dtype=REAL)
@@ -3158,7 +3158,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                 Dr_in[ii] = Dr_ini[k, k]
         return Wd_in, Dr_in
 
-    def _compute_coupling_coefficients(
+    def _compute_coupling_coefficients(  # type: ignore[explicit-any]
         self, N_states: int, Nel: int, SS: numpy.ndarray, band_filter: int | None = None
     ) -> numpy.ndarray:
         kap = numpy.zeros((N_states, Nel), dtype=REAL)
@@ -3174,7 +3174,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                     st += 1
         return kap
 
-    def _accumulate_band_linewidths(
+    def _accumulate_band_linewidths(  # type: ignore[explicit-any]
         self,
         N_output: int,
         Nel: int,
@@ -3232,7 +3232,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
             #
             #  Below aa1 = A, aa2 = n, aa3 = K, st_a = k and st_b = l
             #
-            kappa: numpy.ndarray = numpy.zeros((self.Ntot, self.Ntot), dtype=REAL)
+            kappa: numpy.ndarray = numpy.zeros((self.Ntot, self.Ntot), dtype=REAL)  # type: ignore[explicit-any]
 
             if self.mult >= 2:
                 N2b = self.Nb[0] + self.Nb[1] + self.Nb[2]
@@ -3409,7 +3409,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                 self.Wd[0:N1b, 0:N1b] = numpy.diag(Wd_b)
                 self.Dr[0:N1b, 0:N1b] = numpy.diag(Dr_b)
 
-                Wd_c: numpy.ndarray = numpy.zeros((self.Ntot, self.Ntot), dtype=REAL)
+                Wd_c: numpy.ndarray = numpy.zeros((self.Ntot, self.Ntot), dtype=REAL)  # type: ignore[explicit-any]
 
                 for aa in range(N1b, N2b):
                     for bb in range(N1b, N2b):
@@ -3436,7 +3436,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
                                     * kap2[bb, mm]
                                 )
 
-                W_cc: numpy.ndarray = numpy.zeros(Wd_c.shape[0], dtype=REAL)
+                W_cc: numpy.ndarray = numpy.zeros(Wd_c.shape[0], dtype=REAL)  # type: ignore[explicit-any]
                 for diag_idx in range(N2b):
                     W_cc[diag_idx] = Wd_c[diag_idx, diag_idx]
                 W_aux = numpy.diag(numpy.sqrt(W_cc))
@@ -3500,7 +3500,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         self._diagonalized = True
 
-    def _thermal_population(
+    def _thermal_population(  # type: ignore[explicit-any]
         self,
         temp: float = 0.0,
         subtract: numpy.ndarray | None = None,
@@ -3563,7 +3563,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return rho0
 
-    def _thermal_band_population(
+    def _thermal_band_population(  # type: ignore[explicit-any]
         self,
         temperature: float,
         relaxation_theory_limit: str,
@@ -3604,7 +3604,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         raise Exception("Unknown relaxation_theory_limit")
 
-    def _impulsive_population(
+    def _impulsive_population(  # type: ignore[explicit-any]
         self,
         relaxation_theory_limit: str = "weak_coupling",
         temperature: float = 0.0,
@@ -3628,7 +3628,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return rho0
 
-    def get_StateVector(
+    def get_StateVector(  # type: ignore[explicit-any]
         self, condition_type: str | None = None, DD: numpy.ndarray | None = None
     ) -> Any:
         """Returns state vector accordoing to specified conditions
@@ -3665,7 +3665,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
             # abs value of the transition dipole moment
             dabs = numpy.sqrt(DD[:, :, 0] ** 2 + DD[:, :, 1] ** 2 + DD[:, :, 2] ** 2)
 
-            sv0: numpy.ndarray = numpy.zeros(self.Ntot, dtype=COMPLEX)
+            sv0: numpy.ndarray = numpy.zeros(self.Ntot, dtype=COMPLEX)  # type: ignore[explicit-any]
 
             # zero temperature
             sv0[0] = 1.0
@@ -3676,7 +3676,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         raise QuantarheiError("Unknown condition type")
 
-    def get_DensityMatrix(
+    def get_DensityMatrix(  # type: ignore[explicit-any]
         self,
         condition_type: str | None = None,
         relaxation_theory_limit: str = "weak_coupling",
@@ -3840,7 +3840,7 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
         """
         return self.get_band(band=band)
 
-    def get_transition(self, Nf: Any, Ni: Any) -> tuple:
+    def get_transition(self, Nf: Any, Ni: Any) -> tuple:  # type: ignore[explicit-any]
         """Returns relevant info about the energetic transition
 
         Parameters
@@ -3891,32 +3891,32 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return False
 
-    def get_SystemBathInteraction(self) -> Any:
+    def get_SystemBathInteraction(self) -> Any:  # type: ignore[explicit-any]
         """Returns the aggregate SystemBathInteraction object"""
         if self._built:
             return self.sbi
         raise BuildError("Aggregate object not built.")
 
-    def set_SystemBathInteraction(self, sbi: Any) -> None:
+    def set_SystemBathInteraction(self, sbi: Any) -> None:  # type: ignore[explicit-any]
         """Sets the SystemBathInteraction operator for this aggregate"""
         # FIXME: check its compatibility
         self.sbi = sbi
         self.sbi.set_system(self)
 
-    def get_Hamiltonian(self) -> Any:
+    def get_Hamiltonian(self) -> Any:  # type: ignore[explicit-any]
         """Returns the aggregate Hamiltonian"""
         if self._built:
             return self.HamOp  # Hamiltonian(data=self.HH)
         raise BuildError("Aggregate object not built")
 
-    def get_electronic_Hamiltonian(self, full: bool = False) -> Any:
+    def get_electronic_Hamiltonian(self, full: bool = False) -> Any:  # type: ignore[explicit-any]
         """Returns the aggregate electronic Hamiltonian
 
         In case this is a purely electronic aggregate, the output
         is identical to get_Hamiltonian()
 
         """
-        HH: numpy.ndarray = numpy.zeros((self.Nel, self.Nel), dtype=REAL)
+        HH: numpy.ndarray = numpy.zeros((self.Nel, self.Nel), dtype=REAL)  # type: ignore[explicit-any]
         for a, sta in self.elstates(mult=self.mult):
             HH[a, a] = sta.energy()
             for b, stb in self.elstates(mult=self.mult):
@@ -3926,13 +3926,13 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
         return HHel
 
-    def get_TransitionDipoleMoment(self) -> Any:
+    def get_TransitionDipoleMoment(self) -> Any:  # type: ignore[explicit-any]
         """Returns the aggregate transition dipole moment operator"""
         if self._built:
             return self.TrDMOp  # TransitionDipoleMoment(data=self.DD)
         raise BuildError("Aggregate object not built")
 
-    def get_TransitionMagneticDipoleMoment(self) -> Any:
+    def get_TransitionMagneticDipoleMoment(self) -> Any:  # type: ignore[explicit-any]
         """Returns the aggregate transition dipole moment operator"""
         if self._built:
             return TransitionDipoleMoment(data=self.MM)

--- a/quantarhei/builders/aggregate_excitonanalysis.py
+++ b/quantarhei/builders/aggregate_excitonanalysis.py
@@ -77,7 +77,7 @@ class AggregateExcitonAnalysis(AggregateSpectroscopy):
         indx = [i for i in range(self.HH.shape[0])]
         return indx, coefs, sqrs
 
-    def report_on_expansion(self, file: Any = None, state: int = 0, N: int = 5) -> None:
+    def report_on_expansion(self, file: Any = None, state: int = 0, N: int = 5) -> None:  # type: ignore[explicit-any]
         """Prints a short report on the composition of an exciton state
 
         Parameters
@@ -117,7 +117,7 @@ class AggregateExcitonAnalysis(AggregateSpectroscopy):
 
         indx, coefs, sqrs = self.get_expansion_squares(state)
 
-        table_data: list[list[Any]] = []
+        table_data: list[list[Any]] = []  # type: ignore[explicit-any]
         table_data.append(["index", "squares", "coefficients", "state signatures"])
         for i in range(N):
             imax, sqr = _strip_max_coef(indx, sqrs)
@@ -220,7 +220,7 @@ class AggregateExcitonAnalysis(AggregateSpectroscopy):
 
         raise BasisError("Aggregate has to be diagonalized")
 
-    def get_state_energy(self, state: int = 0) -> float | numpy.ndarray:
+    def get_state_energy(self, state: int = 0) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Return the energy of a state with a given index
 
 
@@ -253,7 +253,7 @@ class AggregateExcitonAnalysis(AggregateSpectroscopy):
             return self.convert_energy_2_current_u(self.HD[state])
         raise BasisError("Aggregate has to be diagonalized")
 
-    def exciton_report(
+    def exciton_report(  # type: ignore[explicit-any]
         self,
         file: Any = None,
         start: int = 1,
@@ -393,7 +393,7 @@ class AggregateExcitonAnalysis(AggregateSpectroscopy):
         return self.vibsigs[N]
 
 
-def _strip_max_coef(indx: list, sqrs: numpy.ndarray) -> tuple:
+def _strip_max_coef(indx: list, sqrs: numpy.ndarray) -> tuple:  # type: ignore[explicit-any]
     """Returns the index of the maximum coefficient and the coefficient
     and sets the maximum value to zero.
 

--- a/quantarhei/builders/aggregate_pdeph.py
+++ b/quantarhei/builders/aggregate_pdeph.py
@@ -33,7 +33,7 @@ class AggregatePureDephasing(AggregateExcitonAnalysis):
         self.diagonalize()
 
         Na = self.Ntot
-        xiai: numpy.ndarray = numpy.zeros((Na, self.Nel), dtype=REAL)
+        xiai: numpy.ndarray = numpy.zeros((Na, self.Nel), dtype=REAL)  # type: ignore[explicit-any]
         for aa in range(Na):
             st = 0
             for ii in range(self.Nel):

--- a/quantarhei/builders/aggregate_spectroscopy.py
+++ b/quantarhei/builders/aggregate_spectroscopy.py
@@ -267,7 +267,7 @@ class AggregateSpectroscopy(AggregateBase):
 
 
 def generate_R1g(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -332,7 +332,7 @@ def generate_R1g(  # type: ignore[explicit-any]
 
 
 def _generate_R1g(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     i1g: int,
     i2e: int,
     i3e: int,
@@ -391,7 +391,7 @@ def _generate_R1g(  # type: ignore[explicit-any]
 
 
 def generate_R1gE(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -528,7 +528,7 @@ def generate_R1gE(  # type: ignore[explicit-any]
 
 
 def generate_R2g(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -660,7 +660,7 @@ def generate_R2g(  # type: ignore[explicit-any]
 
 
 def generate_R2gE(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -801,7 +801,7 @@ def generate_R2gE(  # type: ignore[explicit-any]
 
 
 def generate_R3g(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -911,7 +911,7 @@ def generate_R3g(  # type: ignore[explicit-any]
 
 
 def generate_R4g(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1021,7 +1021,7 @@ def generate_R4g(  # type: ignore[explicit-any]
 
 
 def generate_R1f(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1162,7 +1162,7 @@ def generate_R1f(  # type: ignore[explicit-any]
 
 
 def generate_R2f(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1303,7 +1303,7 @@ def generate_R2f(  # type: ignore[explicit-any]
 
 
 def generate_R1fE(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1438,7 +1438,7 @@ def generate_R1fE(  # type: ignore[explicit-any]
 
 
 def generate_R2fE(  # type: ignore[explicit-any]
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1572,7 +1572,11 @@ def generate_R2fE(  # type: ignore[explicit-any]
 
 
 def generate_1orderP_sec(  # type: ignore[explicit-any]
-    self: Any, lst: list, pop_tol: float, dip_tol: float, verbose: int = 0
+    self: AggregateSpectroscopy,
+    lst: list,
+    pop_tol: float,
+    dip_tol: float,
+    verbose: int = 0,
 ) -> None:
 
     ngs = self.get_electronic_groundstate()

--- a/quantarhei/builders/aggregate_spectroscopy.py
+++ b/quantarhei/builders/aggregate_spectroscopy.py
@@ -49,7 +49,7 @@ class AggregateSpectroscopy(AggregateBase):
             verbose=verbose,
         )
 
-    def liouville_pathways_3T(
+    def liouville_pathways_3T(  # type: ignore[explicit-any]
         self,
         ptype: str | tuple | list = "R3g",
         eUt: Any = None,
@@ -113,12 +113,12 @@ class AggregateSpectroscopy(AggregateBase):
         evf_tol = etol
 
         # Check if the ptype is a tuple
-        ptype_tuple: Any
+        ptype_tuple: Any  # type: ignore[explicit-any]
         if not isinstance(ptype, (tuple, list)):
             ptype_tuple = (ptype,)
         else:
             ptype_tuple = ptype
-        lst: list[Any] = []
+        lst: list[Any] = []  # type: ignore[explicit-any]
 
         if verbose > 0:
             print("Pathways", ptype_tuple)
@@ -252,7 +252,7 @@ class AggregateSpectroscopy(AggregateBase):
         else:
             raise ImplementationError("Not implemented yet")
 
-        lst: list[Any] = []
+        lst: list[Any] = []  # type: ignore[explicit-any]
 
         if sec:
             generate_1orderP_sec(self, lst, pop_tol, dip_tol, verbose)
@@ -266,7 +266,7 @@ class AggregateSpectroscopy(AggregateBase):
         return lst
 
 
-def generate_R1g(
+def generate_R1g(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -331,7 +331,7 @@ def generate_R1g(
                                                 k += 1
 
 
-def _generate_R1g(
+def _generate_R1g(  # type: ignore[explicit-any]
     self: Any,
     i1g: int,
     i2e: int,
@@ -390,7 +390,7 @@ def _generate_R1g(
     return lp
 
 
-def generate_R1gE(
+def generate_R1gE(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -527,7 +527,7 @@ def generate_R1gE(
                                                 k += 1
 
 
-def generate_R2g(
+def generate_R2g(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -659,7 +659,7 @@ def generate_R2g(
                                                 k += 1
 
 
-def generate_R2gE(
+def generate_R2gE(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -800,7 +800,7 @@ def generate_R2gE(
                                                 k += 1
 
 
-def generate_R3g(
+def generate_R3g(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -910,7 +910,7 @@ def generate_R3g(
                                     k += 1
 
 
-def generate_R4g(
+def generate_R4g(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -1020,7 +1020,7 @@ def generate_R4g(
                 #    qr.stop()
 
 
-def generate_R1f(
+def generate_R1f(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -1161,7 +1161,7 @@ def generate_R1f(
                                                 k += 1
 
 
-def generate_R2f(
+def generate_R2f(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -1302,7 +1302,7 @@ def generate_R2f(
                                                 k += 1
 
 
-def generate_R1fE(
+def generate_R1fE(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -1437,7 +1437,7 @@ def generate_R1fE(
                                                 k += 1
 
 
-def generate_R2fE(
+def generate_R2fE(  # type: ignore[explicit-any]
     self: Any,
     lst: list,
     eUt2: numpy.ndarray,
@@ -1571,7 +1571,7 @@ def generate_R2fE(
                                                 k += 1
 
 
-def generate_1orderP_sec(
+def generate_1orderP_sec(  # type: ignore[explicit-any]
     self: Any, lst: list, pop_tol: float, dip_tol: float, verbose: int = 0
 ) -> None:
 

--- a/quantarhei/builders/aggregate_states.py
+++ b/quantarhei/builders/aggregate_states.py
@@ -82,7 +82,7 @@ class ElectronicState(UnitsManaged):
         if index is not None:
             self.index = index
         else:
-            self.index = cast(list[Any], self.aggregate.elsigs).index(self.elsignature)
+            self.index = cast(list[Any], self.aggregate.elsigs).index(self.elsignature)  # type: ignore[explicit-any]
 
         #
         # Implementation of vibrational substate generation approximations
@@ -294,7 +294,7 @@ class ElectronicState(UnitsManaged):
             for sig in numpy.ndindex(shp):
                 yield sig
 
-    def vsignatures(
+    def vsignatures(  # type: ignore[explicit-any]
         self,
         approx: str | None = None,
         N: int | None = None,
@@ -381,7 +381,7 @@ class VibronicState(UnitsManaged):
 
         try:
             agg = self.elstate.aggregate
-            self.index = cast(list[Any], agg.vibsigs).index((elstate.elsignature, vsig))
+            self.index = cast(list[Any], agg.vibsigs).index((elstate.elsignature, vsig))  # type: ignore[explicit-any]
         except (AttributeError, ValueError):
             self.index = None
 
@@ -481,7 +481,7 @@ class Coherence:
 
     """
 
-    def __init__(self, state1: Any, state2: Any) -> None:
+    def __init__(self, state1: Any, state2: Any) -> None:  # type: ignore[explicit-any]
 
         self.state1 = state1
         self.state2 = state2

--- a/quantarhei/builders/disorder.py
+++ b/quantarhei/builders/disorder.py
@@ -36,7 +36,7 @@ class Disorder:
         type is requested.
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         data: numpy.ndarray | None = None,
         distribution: str = "Gaussian",
@@ -49,14 +49,14 @@ class Disorder:
 
         self.dtype = dtype
         self.distribution = distribution
-        self.seed_pool: list[Any] = []
+        self.seed_pool: list[Any] = []  # type: ignore[explicit-any]
         self.data = data.copy()
         self.shape = self.data.shape
 
         if seed is not None:
             numpy.random.seed(seed)
 
-    def disorder_update(self, i_dis: int, H: Any, ignore_first: bool = False) -> None:
+    def disorder_update(self, i_dis: int, H: Any, ignore_first: bool = False) -> None:  # type: ignore[explicit-any]
         """Adds disorder to an excitonic Hamiltonian"""
         if (i_dis == 0) and ignore_first:
             return

--- a/quantarhei/builders/interactions.py
+++ b/quantarhei/builders/interactions.py
@@ -8,7 +8,7 @@ import scipy.constants as const
 from ..core.units import eps0_int
 
 
-def dipole_dipole_interaction(
+def dipole_dipole_interaction(  # type: ignore[explicit-any]
     r1: np.ndarray, r2: np.ndarray, d1: np.ndarray, d2: np.ndarray, epsr: float
 ) -> float:
     """Calculates interaction between two dipoles
@@ -43,7 +43,7 @@ def dipole_dipole_interaction(
     return prf * cc / epsr
 
 
-def dipole_dipole(
+def dipole_dipole(  # type: ignore[explicit-any]
     center1: np.ndarray,
     dipole1: np.ndarray,
     center2: np.ndarray,
@@ -65,7 +65,7 @@ def dipole_dipole(
     dr2 = np.dot(dipole2, r12) / R
 
     Edip_dip_Ha = (d12 - 3 * dr1 * dr2) / (R**3)  # interaction energy in hartree
-    nma: Any = 1.0
+    nma: Any = 1.0  # type: ignore[explicit-any]
     Edip_dip_cm1 = Edip_dip_Ha * nma.HaToInvcm
 
     if args:
@@ -78,7 +78,7 @@ def dipole_dipole(
     return Edip_dip_cm1
 
 
-def Oscilator3D(
+def Oscilator3D(  # type: ignore[explicit-any]
     rr1: np.ndarray,
     bond1: np.ndarray,
     AtType1: list,
@@ -137,7 +137,7 @@ def Oscilator3D(
     #        rr2=pos.prepare_alkene(len(rr2),Position=center,vec_x=VecX,vec_y=VecY)
     #
 
-    def molecule_osc_3D(
+    def molecule_osc_3D(  # type: ignore[explicit-any]
         rr: np.ndarray,
         bond: np.ndarray,
         factor: np.ndarray,
@@ -248,7 +248,7 @@ def Oscilator3D(
     return res
 
 
-def GuessBonds(rr: np.ndarray, bond_length: float = 4.0, **kwargs: Any) -> np.ndarray:
+def GuessBonds(rr: np.ndarray, bond_length: float = 4.0, **kwargs: Any) -> np.ndarray:  # type: ignore[explicit-any]
     """Function guesses pairs of atoms between which bond might occure.
 
 

--- a/quantarhei/builders/modes.py
+++ b/quantarhei/builders/modes.py
@@ -97,7 +97,7 @@ class Mode(UnitsManaged, Saveable, OpenSystem):
     #   MODE AS A PART OF A MOLECULE
     #
 
-    def set_Molecule(self, monomer: Any) -> None:
+    def set_Molecule(self, monomer: Any) -> None:  # type: ignore[explicit-any]
         """Assigns this mode to a given monomer.
 
         When set, the mode knows on how many electronic states
@@ -330,7 +330,7 @@ class Mode(UnitsManaged, Saveable, OpenSystem):
     #
 
     @deprecated
-    def get_frequency(self, N: int) -> float | numpy.ndarray:
+    def get_frequency(self, N: int) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns vibrational frequency
 
         Usage of this method is deprecated, use `get_energy` instead
@@ -358,7 +358,7 @@ class Mode(UnitsManaged, Saveable, OpenSystem):
         """
         return self.get_energy(N)
 
-    def get_energy(self, N: int, no_conversion: bool = True) -> float | numpy.ndarray:
+    def get_energy(self, N: int, no_conversion: bool = True) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns frequency of the mode corresponding to Nth electronic state
 
 
@@ -546,7 +546,7 @@ class Mode(UnitsManaged, Saveable, OpenSystem):
         """
         return self.submodes[N]
 
-    def set_mode_environment(self, corfce: Any) -> None:
+    def set_mode_environment(self, corfce: Any) -> None:  # type: ignore[explicit-any]
         """Set linear interaction with a bosonic environment"""
         self.egcf = corfce
         self.has_mode_environment = True

--- a/quantarhei/builders/molecules.py
+++ b/quantarhei/builders/molecules.py
@@ -124,7 +124,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
     # number of vibrational modes
     nmod = Integer("nmod")
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, elenergies: list | numpy.ndarray | None = None, name: str | None = None
     ) -> None:
         if elenergies is None:
@@ -170,11 +170,11 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         # FIXME: check the order of energies (increasing order has
         # to be enforced) no vibrational modes is a default
         self.nmod = 0
-        self.modes: list[Any] = []
+        self.modes: list[Any] = []  # type: ignore[explicit-any]
 
         # allowed transitions are now only between the ground state and
         # the rest of the excited states are dark
-        self.allowed_transitions: list[Any] = []
+        self.allowed_transitions: list[Any] = []  # type: ignore[explicit-any]
 
         # transition dipole moments
         self.dmoments = numpy.zeros((self.nel, self.nel, 3))
@@ -186,10 +186,10 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         self.mmoments = numpy.zeros((self.nel, self.nel, 3), dtype=numpy.complex128)
 
         # matrix of the transition widths
-        self.widths: Any = None
+        self.widths: Any = None  # type: ignore[explicit-any]
 
         # matrix of dephasing rates
-        self.dephs: Any = None
+        self.dephs: Any = None  # type: ignore[explicit-any]
 
         # FIXME: some properties using triangle should be initialized
         # only when used. triangle should stay here, other things
@@ -218,8 +218,8 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         self._has_system_bath_coupling = False
 
         # data attribute can hold PDB coordinates or something else
-        self.model: Any = None
-        self.data: Any = None
+        self.model: Any = None  # type: ignore[explicit-any]
+        self.data: Any = None  # type: ignore[explicit-any]
         self._data_type = None
 
         # how many optical bands the molecule has
@@ -230,10 +230,10 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         self.mult = 1
 
         # here we will store the Hamiltonian, once it is constructed
-        self.HH: Any = None
-        self.D2_max: Any = 0.0
+        self.HH: Any = None  # type: ignore[explicit-any]
+        self.D2_max: Any = 0.0  # type: ignore[explicit-any]
 
-        self.el_rwa_indices: Any = None
+        self.el_rwa_indices: Any = None  # type: ignore[explicit-any]
         self.has_rwa = False
 
         # self.build()
@@ -621,7 +621,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
     def set_egcf(self, transition: tuple, egcf: object) -> None:
         self.set_transition_environment(transition, egcf)
 
-    def get_transition_environment(self, transition: Any) -> Any:
+    def get_transition_environment(self, transition: Any) -> Any:  # type: ignore[explicit-any]
         """Returns energy gap correlation function of a monomer
 
         Parameters
@@ -762,13 +762,13 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         """
         return len(self.modes)
 
-    def get_dipole(self, N: int, M: int) -> numpy.ndarray:
+    def get_dipole(self, N: int, M: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         try:
             return self.dmoments[N, M, :]
         except (IndexError, TypeError):
             raise QuantarheiError()
 
-    def get_velocity_dipole(self, N: int, M: int) -> numpy.ndarray:
+    def get_velocity_dipole(self, N: int, M: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         try:
             if self._has_transition_velocity:
                 return self.dvmoments[N, M, :]
@@ -776,13 +776,13 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         except (IndexError, TypeError, AttributeError):
             raise QuantarheiError()
 
-    def get_magnetic_dipole(self, N: int, M: int) -> numpy.ndarray:
+    def get_magnetic_dipole(self, N: int, M: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         try:
             return self.mmoments[N, M, :]
         except (IndexError, TypeError):
             raise QuantarheiError()
 
-    def set_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:
+    def set_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:  # type: ignore[explicit-any]
         if vec is None:
             n = N[0]
             m = N[1]
@@ -799,7 +799,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         except (IndexError, ValueError):
             raise QuantarheiError()
 
-    def set_velocity_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:
+    def set_velocity_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:  # type: ignore[explicit-any]
 
         if vec is None:
             n = N[0]
@@ -833,7 +833,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
     # except:
     # raise QuantarheiError()
 
-    def set_magnetic_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:
+    def set_magnetic_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:  # type: ignore[explicit-any]
         # vec is probably in atomic units and our units are [Angstrom*1/fs*Debye]
         #        print(vec)
 
@@ -862,7 +862,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         except (IndexError, ValueError):
             raise QuantarheiError()
 
-    def set_magnetic_dipoleR(self, N: Any, M: Any, vec: Any, RR: Any = None) -> None:
+    def set_magnetic_dipoleR(self, N: Any, M: Any, vec: Any, RR: Any = None) -> None:  # type: ignore[explicit-any]
 
         if RR is None:
             n = N[0]
@@ -1058,7 +1058,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
 
         return self.dephs[transition[0], transition[1]]
 
-    def get_energy(self, N: int) -> float | numpy.ndarray:
+    def get_energy(self, N: int) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns energy of the Nth state of the molecule
 
 
@@ -1229,7 +1229,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         if not self._diabatic_initialized:
             Ne = self.nel
 
-            self.diabatic_matrix: list[Any] = []
+            self.diabatic_matrix: list[Any] = []  # type: ignore[explicit-any]
             for ii in range(Ne):
                 self.diabatic_matrix.append([])
                 for jj in range(Ne):
@@ -1240,7 +1240,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         self.diabatic_matrix[element[0]][element[1]].append(factor)
         self.diabatic_matrix[element[1]][element[0]].append(factor)
 
-    def _fill_hmatrix(
+    def _fill_hmatrix(  # type: ignore[explicit-any]
         self, HH: numpy.ndarray, en0: numpy.ndarray, coorval: numpy.ndarray
     ) -> None:
         """Creates Hamiltonian matrix for given values of the coordinates"""
@@ -1282,7 +1282,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
                                         if val[1][lm] == 1:
                                             HH[ii, jj] += val[0] * qq
 
-    def get_potential_1D(
+    def get_potential_1D(  # type: ignore[explicit-any]
         self, mode: int, points: numpy.ndarray, other_modes: list | None = None
     ) -> tuple:
         """Returns the one dimensional diabatic potentials"""
@@ -1360,7 +1360,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
 
         return (pot, pot0)
 
-    def plot_potential_1D(
+    def plot_potential_1D(  # type: ignore[explicit-any]
         self,
         mode: int,
         points: numpy.ndarray,
@@ -1439,7 +1439,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         if show:
             plt.show()
 
-    def plot_dressed_sticks(
+    def plot_dressed_sticks(  # type: ignore[explicit-any]
         self,
         dfce: Any = None,
         xlims: list | None = None,
@@ -1460,7 +1460,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
 
         dx = (xlims[1] - xlims[0]) / nsteps
         xe = numpy.array([xlims[0] + i * dx for i in range(nsteps)])
-        sp1: numpy.ndarray = numpy.zeros(len(xe), dtype=REAL)
+        sp1: numpy.ndarray = numpy.zeros(len(xe), dtype=REAL)  # type: ignore[explicit-any]
 
         with eigenbasis_of(HH):
             y1 = (
@@ -1478,7 +1478,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
                 dip.data[0, :, 0] ** 2 + dip.data[0, :, 1] ** 2 + dip.data[0, :, 2] ** 2
             ) / 3.0
             x0 = numpy.diag(HH.data)
-            sp0: numpy.ndarray = numpy.zeros(len(xe), dtype=REAL)
+            sp0: numpy.ndarray = numpy.zeros(len(xe), dtype=REAL)  # type: ignore[explicit-any]
 
             for kk in range(HH.dim):
                 sp0 += y0[kk] * dfce(xe, x0[kk])
@@ -1512,7 +1512,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         """Sets adiabatic coupling between two states"""
         if not self._adiabatic_initialized:
             self._has_adiabatic = self.triangle.get_list(init=False)
-            self.adiabatic_coupling: Any = self.triangle.get_empty_list()
+            self.adiabatic_coupling: Any = self.triangle.get_empty_list()  # type: ignore[explicit-any]
             self._adiabatic_initialized = True
 
         cp = self.convert_energy_2_internal_u(coupl)
@@ -1550,7 +1550,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
             return 1.0
         return 0.0
 
-    def get_Hamiltonian(self, multi: bool = True, recalculate: bool = False) -> Any:
+    def get_Hamiltonian(self, multi: bool = True, recalculate: bool = False) -> Any:  # type: ignore[explicit-any]
         """Returns the Hamiltonian of the Molecule object
 
 
@@ -1613,7 +1613,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
             self.vibsignatures = vsignatures
 
             # list o signatures of all states
-            self.all_states: list[tuple[Any, ...]] = []
+            self.all_states: list[tuple[Any, ...]] = []  # type: ignore[explicit-any]
             ks = 0
             ke = 0
             for vsig_it in vsignatures:
@@ -1629,7 +1629,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
             #
             # building the Hamiltonian
             #
-            ham: numpy.ndarray = numpy.zeros((ks, ks), dtype=REAL)
+            ham: numpy.ndarray = numpy.zeros((ks, ks), dtype=REAL)  # type: ignore[explicit-any]
 
             # FIXME: creation of the coordinate operators will go to
             # the place where SystemBathInteraction is created
@@ -1638,10 +1638,10 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
             #
             coor_ops = []
             for kk in range(self.nel):
-                in_state: list[Any] = []
+                in_state: list[Any] = []  # type: ignore[explicit-any]
                 coor_ops.append(in_state)
                 for ii in range(self.nmod):
-                    coor: numpy.ndarray = numpy.zeros((ks, ks), dtype=REAL)
+                    coor: numpy.ndarray = numpy.zeros((ks, ks), dtype=REAL)  # type: ignore[explicit-any]
                     in_state.append(coor)
                     # print("State:", kk," - mode:", ii, coor.shape)
 
@@ -1652,8 +1652,8 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
             qq_components = []
             # loop over electronic states
             for i in range(self.nel):
-                el_state: list[Any] = []
-                qq_state: list[Any] = []
+                el_state: list[Any] = []  # type: ignore[explicit-any]
+                qq_state: list[Any] = []  # type: ignore[explicit-any]
                 hh_components.append(el_state)
                 qq_components.append(qq_state)
                 if self.nmod > 0:
@@ -1959,7 +1959,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
 
         """
         # list of Hamiltonian dimensions
-        ldim: Any = [None] * self.nel
+        ldim: Any = [None] * self.nel  # type: ignore[explicit-any]
 
         # loop over electronic states
         for i in range(self.nel):
@@ -1977,11 +1977,11 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
             ldim[i] = Nvib
 
         # dimension of the complete Hamiltonian
-        totdim: Any = numpy.sum(ldim)
+        totdim: Any = numpy.sum(ldim)  # type: ignore[explicit-any]
 
         return totdim, ldim
 
-    def get_TransitionDipoleMoment(self, multi: bool = True) -> Any:
+    def get_TransitionDipoleMoment(self, multi: bool = True) -> Any:  # type: ignore[explicit-any]
         """Returns the transition dipole moment operator"""
         if multi:
             try:
@@ -1991,7 +1991,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
                 totdim = HH.dim
 
             # This will be the operator data
-            dip: numpy.ndarray = numpy.zeros((totdim, totdim, 3), dtype=REAL)
+            dip: numpy.ndarray = numpy.zeros((totdim, totdim, 3), dtype=REAL)  # type: ignore[explicit-any]
 
             ks1 = 0
             for st1 in self.all_states:
@@ -2064,8 +2064,8 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         #
         # Look for pure dephasing environmental interactions on transitions
         #
-        d: dict[Any, Any] = {}
-        where: dict[Any, Any] = {}
+        d: dict[Any, Any] = {}  # type: ignore[explicit-any]
+        where: dict[Any, Any] = {}  # type: ignore[explicit-any]
         for i in range(self.nel):
             if i > 0:
                 break  # transitions not from ground state are not counted
@@ -2184,7 +2184,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
 
         return sbi
 
-    def get_RelaxationTensor(self, *args: Any, **kwargs: Any) -> Any:
+    def get_RelaxationTensor(self, *args: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
         """Returns relaxation tensor, building the molecule if necessary."""
         if not self._built:
             self.build()
@@ -2266,7 +2266,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
     #        ss = numpy.diag(numpy.ones_like(ee))
     #        return ee, ss
 
-    def _get_exciton_prop(self, adiabatic: Any = None, HH_in: Any = None) -> tuple:
+    def _get_exciton_prop(self, adiabatic: Any = None, HH_in: Any = None) -> tuple:  # type: ignore[explicit-any]
 
         is_adiabatic = False
         adiabatic_noBath = False
@@ -2419,7 +2419,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         else:
             raise ImplementationError("Not implemented yet")
 
-        lst: list[Any] = []
+        lst: list[Any] = []  # type: ignore[explicit-any]
 
         if sec:
             generate_1orderP_sec(self, lst, pop_tol, dip_tol, verbose)
@@ -2433,13 +2433,13 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         return lst
 
 
-def generate_1orderP_sec(
+def generate_1orderP_sec(  # type: ignore[explicit-any]
     self: Any, lst: list, pop_tol: float, dip_tol: float, verbose: int
 ) -> None:
     from ..spectroscopy import diagramatics as diag
 
-    ngs: Any = [0]  # self.get_electronic_groundstate()
-    nes: Any = [1]  # self.get_excitonic_band(band=1)
+    ngs: Any = [0]  # type: ignore[explicit-any]  # self.get_electronic_groundstate()
+    nes: Any = [1]  # type: ignore[explicit-any]  # self.get_excitonic_band(band=1)
 
     if verbose > 0:
         print("Liouville pathway of first order")
@@ -2504,9 +2504,9 @@ def generate_1orderP_sec(
                 k += 1
 
 
-def PiMolecule(Molecule: Any) -> None:
+def PiMolecule(Molecule: Any) -> None:  # type: ignore[explicit-any]
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self: Any,
         name: str | None = None,
         elenergies: list | None = None,

--- a/quantarhei/builders/molecules.py
+++ b/quantarhei/builders/molecules.py
@@ -2434,7 +2434,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
 
 
 def generate_1orderP_sec(  # type: ignore[explicit-any]
-    self: Any, lst: list, pop_tol: float, dip_tol: float, verbose: int
+    self: Molecule, lst: list, pop_tol: float, dip_tol: float, verbose: int
 ) -> None:
     from ..spectroscopy import diagramatics as diag
 

--- a/quantarhei/builders/opensystem.py
+++ b/quantarhei/builders/opensystem.py
@@ -37,7 +37,7 @@ class OpenSystem:
     # transition dipole moments
     dmoments = array_property("dmoments")
 
-    def __init__(self, elen: Any) -> None:
+    def __init__(self, elen: Any) -> None:  # type: ignore[explicit-any]
 
         #
         # Analyze energies
@@ -59,7 +59,7 @@ class OpenSystem:
                 which_band.append(nband)
                 nband += 1
 
-        self.which_band: Any = which_band
+        self.which_band: Any = which_band  # type: ignore[explicit-any]
 
         #
         #  We have multiplicity of bands
@@ -91,25 +91,25 @@ class OpenSystem:
         #
         self._is_mapped_on_egcf_matrix = False
         self._has_egcf_matrix = False  #
-        self.egcf_matrix: Any = None
+        self.egcf_matrix: Any = None  # type: ignore[explicit-any]
 
         self.triangle = triangle(self.Nel)
 
         self._egcf_initialized = True
         self._has_egcf = self.triangle.get_list(init=False)
-        self.egcf: Any = self.triangle.get_empty_list()
+        self.egcf: Any = self.triangle.get_empty_list()  # type: ignore[explicit-any]
 
         #
         #   System-bath interaction
         #
         self._has_system_bath_interaction = False
-        self.sbi: Any = None
+        self.sbi: Any = None  # type: ignore[explicit-any]
 
         #
         #  Relaxation tensor information
         #
-        self.RelaxationTensor: Any = None
-        self.RelaxationHamiltonian: Any = None
+        self.RelaxationTensor: Any = None  # type: ignore[explicit-any]
+        self.RelaxationHamiltonian: Any = None  # type: ignore[explicit-any]
         self._has_relaxation_tensor = False
         self._relaxation_theory = "standard_Redfield"
         self.has_Iterm = False
@@ -125,7 +125,7 @@ class OpenSystem:
         #
         self.dmoments = numpy.zeros((self.Nel, self.Nel, 3))
 
-        self.HH: numpy.ndarray | None = None
+        self.HH: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
         #
         # RWA
@@ -136,13 +136,13 @@ class OpenSystem:
         #
         #  Spectroscopic information
         #
-        self.WPM: Any = None  # weighted participation matrix (for spectroscopy)
+        self.WPM: Any = None  # type: ignore[explicit-any]  # weighted participation matrix (for spectroscopy)
         self._has_wpm = False
 
         # Operator objects set by subclasses after build()
-        self.HamOp: Any = None
-        self.TrDMOp: Any = None
-        self.DD: Any = None
+        self.HamOp: Any = None  # type: ignore[explicit-any]
+        self.TrDMOp: Any = None  # type: ignore[explicit-any]
+        self.DD: Any = None  # type: ignore[explicit-any]
 
     def get_temperature(self) -> float:
         """Returns the temperature of the system's environment
@@ -151,17 +151,17 @@ class OpenSystem:
         """
         raise NotImplementedError("get_temperature must be implemented by subclass")
 
-    def _site_reorg_diag(self, subtract_bath: bool = True) -> Any:
+    def _site_reorg_diag(self, subtract_bath: bool = True) -> Any:  # type: ignore[explicit-any]
         """Returns diagonal site reorganization energies. Overridden by AggregateBase."""
         raise NotImplementedError("_site_reorg_diag must be implemented by subclass")
 
-    def _excitonic_reorg_diag(self, SS: Any, subtract_bath: bool = True) -> Any:
+    def _excitonic_reorg_diag(self, SS: Any, subtract_bath: bool = True) -> Any:  # type: ignore[explicit-any]
         """Returns excitonic reorganization energies. Overridden by AggregateBase."""
         raise NotImplementedError(
             "_excitonic_reorg_diag must be implemented by subclass"
         )
 
-    def _get_exciton_prop2(self, adiabatic: Any = None, HH_in: Any = None) -> Any:
+    def _get_exciton_prop2(self, adiabatic: Any = None, HH_in: Any = None) -> Any:  # type: ignore[explicit-any]
         """Returns exciton properties. Overridden by AggregateBase."""
         raise NotImplementedError("_get_exciton_prop2 must be implemented by subclass")
 
@@ -181,14 +181,14 @@ class OpenSystem:
 
         self._diagonalized = True
 
-    def get_Hamiltonian(self) -> Any:
+    def get_Hamiltonian(self) -> Any:  # type: ignore[explicit-any]
         """Returns the Hamiltonian operator"""
         if self._built:
             return self.HamOp
 
         raise BuildError("System has to be built first")
 
-    def get_TransitionDipoleMoment(self) -> Any:
+    def get_TransitionDipoleMoment(self) -> Any:  # type: ignore[explicit-any]
         """Returns the asystem's transition dipole moment operator"""
         if self._built:
             return self.TrDMOp  # TransitionDipoleMoment(data=self.DD)
@@ -321,7 +321,7 @@ class OpenSystem:
         else:
             raise QuantarheiError("Monomer has a correlation function already")
 
-    def get_RWA_suggestion(self) -> float | numpy.ndarray:
+    def get_RWA_suggestion(self) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns a suggestion of the RWA frequency"""
         # return self.convert_energy_2_current_u(self.HH[1,1])
 
@@ -343,7 +343,7 @@ class OpenSystem:
 
         return tuple(lst)
 
-    def set_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:
+    def set_dipole(self, N: Any, M: Any = None, vec: Any = None) -> None:  # type: ignore[explicit-any]
         """Sets transition dipole moment for an electronic transition
 
 
@@ -390,7 +390,7 @@ class OpenSystem:
         except (IndexError, AttributeError):
             raise QuantarheiError()
 
-    def get_dipole(self, *args: Any, **kwargs: Any) -> numpy.ndarray:
+    def get_dipole(self, *args: Any, **kwargs: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the dipole vector for a given electronic transition
 
         There are two ways how to use this function:
@@ -434,7 +434,7 @@ class OpenSystem:
             raise QuantarheiError()
 
     # FIXME: There are two functions with similar results
-    def map_egcf_to_states(self, mpx: numpy.ndarray) -> numpy.ndarray:
+    def map_egcf_to_states(self, mpx: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns a mapping between states and correlation functions"""
         ss = self.SS
         Ng = self.Nb[0]
@@ -448,14 +448,14 @@ class OpenSystem:
 
         return WPM
 
-    def get_lineshape_functions(
+    def get_lineshape_functions(  # type: ignore[explicit-any]
         self, config: dict | int | None = None, timeaxis: Any = None
     ) -> Any:
         """Returns lineshape functions defined for this system"""
         sbi = self.get_SystemBathInteraction()
         return sbi.get_goft_storage(config=config, timeaxis=timeaxis)
 
-    def map_lineshape_to_states(self, mpx: numpy.ndarray) -> numpy.ndarray:
+    def map_lineshape_to_states(self, mpx: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Maps the participation matrix on g(t) functions storage
 
         This should work for a simple mapping matrix and first excited band.
@@ -479,7 +479,7 @@ class OpenSystem:
 
         return WPM
 
-    def get_weighted_participation(self) -> numpy.ndarray:
+    def get_weighted_participation(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns a participation matrix weighted by the mapping onto g(t) storage"""
         self.diagonalize()
 
@@ -496,13 +496,13 @@ class OpenSystem:
 
         return self.WPM
 
-    def get_eigenstate_energies(self) -> numpy.ndarray:
+    def get_eigenstate_energies(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the energies of the system's eigenstates"""
         self.diagonalize()
 
         return self.HD
 
-    def get_F4d(self, which: str = "bbaa") -> numpy.ndarray:
+    def get_F4d(self, which: str = "bbaa") -> numpy.ndarray:  # type: ignore[explicit-any]
         """Get vector of transition dipole moments for 4 wave-mixing
 
         F4 is one of the vectors/matrices needed for orientational average
@@ -515,10 +515,10 @@ class OpenSystem:
 
         """
 
-        def DD(aa: Any, bb: Any) -> numpy.ndarray:
+        def DD(aa: Any, bb: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
             return numpy.dot(self.DD[aa[1], aa[0]], self.DD[bb[1], bb[0]])
 
-        def _setF4(F4: Any, x1: Any, x2: Any, x3: Any, x4: Any) -> None:
+        def _setF4(F4: Any, x1: Any, x2: Any, x3: Any, x4: Any) -> None:  # type: ignore[explicit-any]
             F4[0] = DD(x4, x3) * DD(x2, x1)
             F4[1] = DD(x4, x2) * DD(x3, x1)
             F4[2] = DD(x4, x1) * DD(x3, x2)
@@ -587,7 +587,7 @@ class OpenSystem:
 
         return F4
 
-    def get_SystemBathInteraction(self) -> Any:
+    def get_SystemBathInteraction(self) -> Any:  # type: ignore[explicit-any]
         """Returns the aggregate SystemBathInteraction object"""
         if self._built:
             return self.sbi
@@ -656,7 +656,7 @@ class OpenSystem:
         else:
             raise QuantarheiError()
 
-        relaxT: Any = None
+        relaxT: Any = None  # type: ignore[explicit-any]
 
         #
         # Dictionary of available theories
@@ -1109,7 +1109,7 @@ class OpenSystem:
             relaxation_cutoff_time=relaxation_cutoff_time,
         )
 
-    def get_KTHierarchy(self, depth: int = 2) -> Any:
+    def get_KTHierarchy(self, depth: int = 2) -> Any:  # type: ignore[explicit-any]
         """Returns the Kubo-Tanimura hierarchy of an open system"""
         HH = self.get_Hamiltonian()
         HH.set_rwa([0, 1])
@@ -1123,7 +1123,7 @@ class OpenSystem:
 
         return KTHierarchyPropagator(ta, kth)
 
-    def get_excited_density_matrix(
+    def get_excited_density_matrix(  # type: ignore[explicit-any]
         self, condition: Any = "delta", polarization: numpy.ndarray | None = None
     ) -> object:
         """Returns the density matrix corresponding to excitation condition"""
@@ -1185,7 +1185,7 @@ class OpenSystem:
             print("Excitation condition:", condition)
             raise ImplementationError("Excition condition not implemented.")
 
-    def get_thermal_ReducedDensityMatrix(self) -> Any:
+    def get_thermal_ReducedDensityMatrix(self) -> Any:  # type: ignore[explicit-any]
         """Returns equilibrium density matrix for a give temparature"""
         H = self.get_Hamiltonian()
         T = self.get_temperature()
@@ -1208,7 +1208,7 @@ class OpenSystem:
 
         return rdm
 
-    def integrate_deposited_energy(
+    def integrate_deposited_energy(  # type: ignore[explicit-any]
         self, rho_t: Any, field: numpy.ndarray, ome: float | None = None
     ) -> float | numpy.ndarray:
         r"""Integrates the energy deposited into the system by light
@@ -1270,7 +1270,7 @@ class OpenSystem:
 
         return Manager().convert_energy_2_current_u(val)
 
-    def _get_exciton_prop(
+    def _get_exciton_prop(  # type: ignore[explicit-any]
         self, adiabatic: object = None, HH_in: numpy.ndarray | None = None
     ) -> tuple:
 
@@ -1390,7 +1390,7 @@ class OpenSystem:
 #
 # Auxiliary routines
 #
-def integral_g_dfdt(g: numpy.ndarray, f: numpy.ndarray) -> complex:
+def integral_g_dfdt(g: numpy.ndarray, f: numpy.ndarray) -> complex:  # type: ignore[explicit-any]
     """Numerically compute ∫ g(t) * df/dt(t) dt using central differences.
     Assumes df/dt = 0 at boundaries.
 
@@ -1410,7 +1410,7 @@ def integral_g_dfdt(g: numpy.ndarray, f: numpy.ndarray) -> complex:
     return numpy.sum(g * dfdt)
 
 
-def integral_g_f(g: numpy.ndarray, f: numpy.ndarray, dt: float) -> complex:
+def integral_g_f(g: numpy.ndarray, f: numpy.ndarray, dt: float) -> complex:  # type: ignore[explicit-any]
     """Numerically compute ∫ g(t) * f(t) dt using the trapezoidal rule.
     Assumes uniform time step (dt cancels out, as in the df/dt version).
 

--- a/quantarhei/builders/pdb.py
+++ b/quantarhei/builders/pdb.py
@@ -30,12 +30,12 @@ class PDBFile:
         self.lines: list[str] = []
         self.linecount = 0
 
-        self.molecules: list[Any] = []
+        self.molecules: list[Any] = []  # type: ignore[explicit-any]
 
-        self._resSeqs: list[Any] = []
-        self._uniqueIds: list[Any] = []
-        self._res_lines: dict[Any, Any] = dict()
-        self._unique_lines: dict[Any, Any] = dict()
+        self._resSeqs: list[Any] = []  # type: ignore[explicit-any]
+        self._uniqueIds: list[Any] = []  # type: ignore[explicit-any]
+        self._res_lines: dict[Any, Any] = dict()  # type: ignore[explicit-any]
+        self._unique_lines: dict[Any, Any] = dict()  # type: ignore[explicit-any]
 
         if fname is not None:
             # load file
@@ -69,7 +69,7 @@ class PDBFile:
                 k += 1
         return k
 
-    def get_Molecules(self, model: Any = None) -> list:
+    def get_Molecules(self, model: Any = None) -> list:  # type: ignore[explicit-any]
         """Return all molecules matching a given model definition.
 
         Parameters
@@ -152,7 +152,7 @@ class PDBFile:
 
         return molecules
 
-    def get_chainId(self, molecule: Any) -> str | None:
+    def get_chainId(self, molecule: Any) -> str | None:  # type: ignore[explicit-any]
         lines = molecule.data
         save = None
         for l in lines:
@@ -201,7 +201,7 @@ def line_chainId(line: str) -> str:
     return line[_chainId_min:_chainId_max]
 
 
-def line_xyz(line: str) -> numpy.ndarray:
+def line_xyz(line: str) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Returns coordinates of the line"""
     x = float(line[30:38])
     y = float(line[38:46])

--- a/quantarhei/builders/sysmodes.py
+++ b/quantarhei/builders/sysmodes.py
@@ -35,7 +35,7 @@ class HarmonicMode(SubMode, OpenSystem):
         self._built = False
         self.gamma = 0.0
         self.RT: LindbladForm | None = None
-        self.HH: numpy.ndarray | None = None
+        self.HH: numpy.ndarray | None = None  # type: ignore[explicit-any]
         self.sbi: SystemBathInteraction | None = None
 
     def build(
@@ -95,7 +95,7 @@ class HarmonicMode(SubMode, OpenSystem):
 
         self._diagonalized = True
 
-    def _setup_dipole_moment(
+    def _setup_dipole_moment(  # type: ignore[explicit-any]
         self,
         N: int,
         ad: numpy.ndarray,
@@ -104,7 +104,7 @@ class HarmonicMode(SubMode, OpenSystem):
         pfac: float = 1.0,
     ) -> None:
 
-        DD: numpy.ndarray = numpy.zeros((N, N, 3), dtype=REAL)
+        DD: numpy.ndarray = numpy.zeros((N, N, 3), dtype=REAL)  # type: ignore[explicit-any]
 
         # FIXME: In what units we define transition dipole moment?
         dip = pfac * (ad + aa) / numpy.sqrt(2.0)
@@ -118,7 +118,7 @@ class HarmonicMode(SubMode, OpenSystem):
         self.DD = DD
 
         # FIXME: make this on-demand (if poissible)
-        trdata: numpy.ndarray = numpy.zeros(
+        trdata: numpy.ndarray = numpy.zeros(  # type: ignore[explicit-any]
             (DD.shape[0], DD.shape[1], DD.shape[2]), dtype=REAL
         )
         trdata[:, :, :] = DD[:, :, :]

--- a/quantarhei/builders/vibsystem.py
+++ b/quantarhei/builders/vibsystem.py
@@ -32,12 +32,12 @@ class VibrationalSystem(UnitsManaged, Saveable, OpenSystem):
         self.modes = modes
         self.Nmodes = len(self.modes)
 
-        self.Nb: numpy.ndarray | None = None
+        self.Nb: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
         self.sbi: SystemBathInteraction | None = None
         self._has_sbi = False
 
-        self.HH: numpy.ndarray | None = None
+        self.HH: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
         self._mode_couping_init = False
 
@@ -75,7 +75,7 @@ class VibrationalSystem(UnitsManaged, Saveable, OpenSystem):
 
         """
         if not self._mode_couping_init:
-            self.coupling: numpy.ndarray = numpy.zeros(
+            self.coupling: numpy.ndarray = numpy.zeros(  # type: ignore[explicit-any]
                 (self.Nmodes, self.Nmodes), dtype=REAL
             )
             self._mode_couping_init = True
@@ -84,7 +84,7 @@ class VibrationalSystem(UnitsManaged, Saveable, OpenSystem):
         self.coupling[N, M] = val_int
         self.coupling[M, N] = val_int
 
-    def get_mode_coupling(self, N: int, M: int) -> float | numpy.ndarray:
+    def get_mode_coupling(self, N: int, M: int) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the value of the intermode coupling coefficient in current units
 
         >>> import quantarhei as qr
@@ -105,7 +105,7 @@ class VibrationalSystem(UnitsManaged, Saveable, OpenSystem):
 
         pass
 
-    def _embed_bilinear_interaction(
+    def _embed_bilinear_interaction(  # type: ignore[explicit-any]
         self, i: int, j: int, kappa: float = 1.0
     ) -> numpy.ndarray:
         """Embed a bilinear interaction term kappa * K1 ⊗ K2
@@ -358,7 +358,7 @@ class VibrationalSystem(UnitsManaged, Saveable, OpenSystem):
         self._built = True
 
 
-def group_energies_by_gap(
+def group_energies_by_gap(  # type: ignore[explicit-any]
     energies: numpy.ndarray, threshold: float | None = None, gap_factor: float = 3.0
 ) -> tuple[list, list]:
     """Groups sorted energies into bands separated by significant energy gaps.
@@ -408,7 +408,7 @@ def group_energies_by_gap(
     return band_sizes, gap_indices
 
 
-def reorder_operators_by_energy(
+def reorder_operators_by_energy(  # type: ignore[explicit-any]
     H: numpy.ndarray, operators: list
 ) -> tuple[numpy.ndarray, list, numpy.ndarray]:
     """Reorders a Hamiltonian and other operators according to ascending energies (diagonal elements of H).
@@ -440,7 +440,7 @@ def reorder_operators_by_energy(
     return H_sorted, ops_sorted, perm
 
 
-def reorder_hamiltonian_by_energy(
+def reorder_hamiltonian_by_energy(  # type: ignore[explicit-any]
     H: numpy.ndarray,
 ) -> tuple[numpy.ndarray, numpy.ndarray]:
     """Reorders a Hamiltonian according to ascending energies (diagonal elements of H).
@@ -470,7 +470,7 @@ def reorder_hamiltonian_by_energy(
     return H_sorted, perm
 
 
-def reorder_operators_by_perm(perm: numpy.ndarray, operators: list) -> list:
+def reorder_operators_by_perm(perm: numpy.ndarray, operators: list) -> list:  # type: ignore[explicit-any]
     """Reorders operators according to a specified order."""
     ops_sorted = [op[numpy.ix_(perm, perm)] for op in operators]
     return ops_sorted

--- a/quantarhei/core/conf/qrhei.py
+++ b/quantarhei/core/conf/qrhei.py
@@ -49,7 +49,7 @@ from __future__ import annotations
 from typing import Any
 
 
-def configure(manager: Any) -> None:
+def configure(manager: Any) -> None:  # type: ignore[explicit-any]
     """Configuration of quantarhei computation and logging"""
     ###########################################################################
     # configuration of numerics

--- a/quantarhei/core/datasaveable.py
+++ b/quantarhei/core/datasaveable.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 class DataSaveable:
     """This class defines saving and loading procedure for the data property"""
 
-    def save_data(
+    def save_data(  # type: ignore[explicit-any]
         self, name: str, with_axis: ValueAxis | None = None, **kwargs: Any
     ) -> None:
         """Saves the data into a format determined by the file name extension
@@ -72,7 +72,7 @@ class DataSaveable:
         elif extension == ".mat":
             self._saveMatlab(name, with_axis)
 
-    def load_data(
+    def load_data(  # type: ignore[explicit-any]
         self, name: str, with_axis: ValueAxis | None = None, **kwargs: Any
     ) -> None:
         """Loads the data in a format determined by the file name extension
@@ -108,7 +108,7 @@ class DataSaveable:
         """Implement this method to put protections on data property"""
         pass
 
-    def _data_with_axis(self, axis: ValueAxis) -> numpy.ndarray:
+    def _data_with_axis(self, axis: ValueAxis) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Constructs data array which contains also data from the axis"""
         shpl = list(self.data.shape)  # type: ignore[attr-defined]
 
@@ -130,7 +130,7 @@ class DataSaveable:
             )
         return data
 
-    def _extract_data_with_axis(
+    def _extract_data_with_axis(  # type: ignore[explicit-any]
         self, data: numpy.ndarray, axis: ValueAxis | None
     ) -> numpy.ndarray:
         """Extracts data part and the axis data from the `data` array"""

--- a/quantarhei/core/dfunction.py
+++ b/quantarhei/core/dfunction.py
@@ -182,13 +182,13 @@ class DFunction(Saveable, DataSaveable):
 
     allowed_interp_types = ("linear", "spline", "default")
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, x: ValueAxis | None = None, y: numpy.ndarray | None = None
     ) -> None:
 
         self._loc_init__(x, y)
 
-    def _loc_init__(
+    def _loc_init__(  # type: ignore[explicit-any]
         self, x: ValueAxis | None = None, y: numpy.ndarray | None = None
     ) -> None:
 
@@ -202,7 +202,7 @@ class DFunction(Saveable, DataSaveable):
 
         self._splines_initialized = False
 
-    def _make_me(self, x: ValueAxis, y: numpy.ndarray) -> None:
+    def _make_me(self, x: ValueAxis, y: numpy.ndarray) -> None:  # type: ignore[explicit-any]
         """Creates the DFunction internals"""
         self._has_imag = False
 
@@ -236,7 +236,7 @@ class DFunction(Saveable, DataSaveable):
                 "Second argument has to be one-dimensional numpy.ndarray"
             )
 
-    def _add_me(self, x: ValueAxis, y: numpy.ndarray) -> None:
+    def _add_me(self, x: ValueAxis, y: numpy.ndarray) -> None:  # type: ignore[explicit-any]
         """Adds data to the DFunction"""
         # if the DFunction is not initialized, call _make_me
         if self._has_imag is None:
@@ -351,7 +351,7 @@ class DFunction(Saveable, DataSaveable):
         else:
             raise QuantarheiError("Incompatible axis")
 
-    def at(self, x: Any, approx: str = "default") -> Any:
+    def at(self, x: Any, approx: str = "default") -> Any:  # type: ignore[explicit-any]
         """Return the function value at argument ``x``.
 
         The default interpolation is ``'linear'`` until spline interpolation
@@ -415,12 +415,12 @@ class DFunction(Saveable, DataSaveable):
         if approx == "spline":
             return self._get_spline_approx(x)
 
-    def as_spline_function(self) -> Callable[[Any], Any]:
+    def as_spline_function(self) -> Callable[[Any], Any]:  # type: ignore[explicit-any]
         """Returns this function as a normal function of one argument"""
         if not self._splines_initialized:
             self._set_splines()
 
-        def func(t: Any) -> Any:
+        def func(t: Any) -> Any:  # type: ignore[explicit-any]
             return self.at(t)
 
         return func
@@ -431,7 +431,7 @@ class DFunction(Saveable, DataSaveable):
     #
     #
 
-    def _get_linear_approx(self, x_in: Any) -> Any:
+    def _get_linear_approx(self, x_in: Any) -> Any:  # type: ignore[explicit-any]
         """Returns linear interpolation of the function"""
         # FIXME: we need qr.FLOAT or more flexible, here
         try:
@@ -457,7 +457,7 @@ class DFunction(Saveable, DataSaveable):
 
         return val
 
-    def _approx_point(self, x: float) -> Any:
+    def _approx_point(self, x: float) -> Any:  # type: ignore[explicit-any]
 
         n, dval = self.axis.locate(x)
         if n + 1 >= self.axis.length:
@@ -470,7 +470,7 @@ class DFunction(Saveable, DataSaveable):
             )
         return val
 
-    def _get_spline_approx(self, x: Any) -> Any:
+    def _get_spline_approx(self, x: Any) -> Any:  # type: ignore[explicit-any]
         """Returns spline interpolation of the function"""
         if not self._splines_initialized:
             self._set_splines()
@@ -489,7 +489,7 @@ class DFunction(Saveable, DataSaveable):
         self._splines_initialized = True
         # print("Calculating splines")
 
-    def _spline_value(self, x: Any) -> Any:
+    def _spline_value(self, x: Any) -> Any:  # type: ignore[explicit-any]
         """Returns the splie interpolated value of the function"""
         if self._has_imag:
             ret = self._spline_r(x) + 1j * self._spline_i(x)
@@ -530,7 +530,7 @@ class DFunction(Saveable, DataSaveable):
 
         return f
 
-    def apply_to_data(self, func: Callable[[numpy.ndarray], numpy.ndarray]) -> None:
+    def apply_to_data(self, func: Callable[[numpy.ndarray], numpy.ndarray]) -> None:  # type: ignore[explicit-any]
         """Applies a submitted function to the data
 
 
@@ -776,7 +776,7 @@ class DFunction(Saveable, DataSaveable):
 
         return F
 
-    def fit_exponential(self, guess: list[float] | None = None) -> numpy.ndarray:
+    def fit_exponential(self, guess: list[float] | None = None) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Exponential fit of the function
 
 
@@ -799,7 +799,7 @@ class DFunction(Saveable, DataSaveable):
 
         return popt
 
-    def fit_gaussian(
+    def fit_gaussian(  # type: ignore[explicit-any]
         self, N: int = 1, guess: list[float] | None = None, Nsvf: int = 251
     ) -> numpy.ndarray:
         # from scipy.signal import savgol_filter
@@ -861,7 +861,7 @@ class DFunction(Saveable, DataSaveable):
             # plt.plot(x, y2sm)
             # plt.show()
 
-        def funcf(x: Any, *p: Any) -> Any:
+        def funcf(x: Any, *p: Any) -> Any:  # type: ignore[explicit-any]
             return _n_gaussians(x, *p)
 
         # minimize, leastsq,
@@ -886,7 +886,7 @@ class DFunction(Saveable, DataSaveable):
 
         return popt  # , pcov
 
-    def plot(
+    def plot(  # type: ignore[explicit-any]
         self,
         fig: Any = None,
         title: str | None = None,
@@ -1056,7 +1056,7 @@ class DFunction(Saveable, DataSaveable):
         return fname, ext
 
 
-def _exp_fcion(t: Any, *params: Any) -> Any:
+def _exp_fcion(t: Any, *params: Any) -> Any:  # type: ignore[explicit-any]
 
     np = len(params)
     ret = 0.0
@@ -1073,7 +1073,7 @@ def _exp_fcion(t: Any, *params: Any) -> Any:
     return ret
 
 
-def _gaussian(
+def _gaussian(  # type: ignore[explicit-any]
     x: Any, height: float, center: float, fwhm: float, offset: float = 0.0
 ) -> Any:
     """Gaussian function with a possible offset
@@ -1104,7 +1104,7 @@ def _gaussian(
     )
 
 
-def _n_gaussians(x: Any, *params: Any) -> Any:
+def _n_gaussians(x: Any, *params: Any) -> Any:  # type: ignore[explicit-any]
     """Sum of N Gaussian functions plus an offset from zero
 
     Parameters

--- a/quantarhei/core/implementations.py
+++ b/quantarhei/core/implementations.py
@@ -9,7 +9,7 @@ from ..exceptions import ImplementationError
 from .managers import Manager
 
 
-def implementation(
+def implementation(  # type: ignore[explicit-any]
     package: str = "",
     taskname: str = "",
     at_runtime: bool = False,
@@ -19,7 +19,7 @@ def implementation(
     """Decorator to select numerical implememtation"""
     m = Manager()
 
-    def decorate_at_runtime(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorate_at_runtime(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[explicit-any]
         """Decoration at run time
 
         The wrapper decides which function to return at runtime.
@@ -27,7 +27,7 @@ def implementation(
         """
 
         @wraps(func)
-        def wrapper(*arg: Any, **kwargs: Any) -> Any:
+        def wrapper(*arg: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
             fc = get_function(
                 func,
                 package,
@@ -39,7 +39,7 @@ def implementation(
 
         return wrapper
 
-    def decorate_at_loadtime(func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorate_at_loadtime(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[explicit-any]
         """Decoration at load time
 
         The wrapper decides which function to return when the Manager module
@@ -55,7 +55,7 @@ def implementation(
         )
 
         @wraps(func)
-        def wrapper(*arg: Any, **kwargs: Any) -> Any:
+        def wrapper(*arg: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
             return fc(*arg, **kwargs)
 
         return wrapper
@@ -71,7 +71,7 @@ def implementation(
 #
 
 
-def load_function(lib: str, fce: str) -> Callable[..., Any]:
+def load_function(lib: str, fce: str) -> Callable[..., Any]:  # type: ignore[explicit-any]
     """Load the module and get the desired function"""
     try:
         a = import_module(lib)
@@ -86,7 +86,7 @@ def load_function(lib: str, fce: str) -> Callable[..., Any]:
     return fc
 
 
-def get_function(
+def get_function(  # type: ignore[explicit-any]
     func: Callable[..., Any],
     package: str,
     taskname: str,

--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -53,6 +53,7 @@ property needs to be basis managed, one should use a predefined type
 from __future__ import annotations
 
 import os
+import types
 import warnings
 from typing import Any
 
@@ -577,7 +578,9 @@ class Manager(metaclass=Singleton):
         raise UnitsError("Unknown type of units")
 
     #    @deprecated
-    def cu_energy(self, val: float | numpy.ndarray, units: str = "1/cm") -> Any:  # type: ignore[explicit-any]
+    def cu_energy(  # type: ignore[explicit-any, return]
+        self, val: float | numpy.ndarray, units: str = "1/cm"
+    ) -> float | numpy.ndarray | None:
         """Converst to current energy units"""
         if units in self.units["energy"]:
             x = conversion_facs_energy[units]
@@ -591,7 +594,9 @@ class Manager(metaclass=Singleton):
             return i_val
 
     #    @deprecated
-    def iu_energy(self, val: float | numpy.ndarray, units: str = "1/cm") -> Any:  # type: ignore[explicit-any]
+    def iu_energy(  # type: ignore[explicit-any, return]
+        self, val: float | numpy.ndarray, units: str = "1/cm"
+    ) -> float | numpy.ndarray | None:
         """Converst to internal energy units"""
         if units in self.units["energy"]:
             x = conversion_facs_energy[units]
@@ -906,7 +911,12 @@ class units_context_manager:
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
         pass
 
 
@@ -943,7 +953,12 @@ class energy_units(units_context_manager):
         self.manager._in_energy_units_context = True
         self.manager._in_eu_count += 1
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
         if exc_val is not None and self.units != self.units_backup:
             warnings.warn(
                 f"An exception exited a 'with energy_units(\"{self.units}\")' block. "
@@ -999,7 +1014,12 @@ class length_units(units_context_manager):
         self.units_backup = self.manager.get_current_units("length")
         self.manager.set_current_units(self.utype, self.units)
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
         if exc_val is not None and self.units != self.units_backup:
             warnings.warn(
                 f"An exception exited a 'with length_units(\"{self.units}\")' block. "
@@ -1019,7 +1039,12 @@ class basis_context_manager:
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
         pass
 
 
@@ -1063,7 +1088,12 @@ class eigenbasis_of(basis_context_manager):
         if self.manager.warn_about_basis_change:
             print("\nQr >>>  ... setting context done")
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
 
         if self.manager.warn_about_basis_change:
             print("\nQr >>> Returning from basis context manager. Cleaning ...")

--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -203,7 +203,7 @@ class Manager(metaclass=Singleton):
             os.mkdir(self.conf_path)
 
             # write default configuration
-            self.main_conf: dict[str, Any] = {
+            self.main_conf: dict[str, Any] = {  # type: ignore[explicit-any]
                 "units": "units.json",
                 "implementations": "implementations.json",
             }
@@ -220,7 +220,7 @@ class Manager(metaclass=Singleton):
             with open(self.cfile) as f:
                 self.main_conf = json.load(f)
 
-        self.current_basis_operator: Any = None
+        self.current_basis_operator: Any = None  # type: ignore[explicit-any]
 
         #
         # Flags for all contexts which are enforced or prevented by functions
@@ -317,16 +317,16 @@ class Manager(metaclass=Singleton):
 
         self.basis_stack: list[int] = []
         self.basis_stack.append(0)
-        self.basis_transformations: list[Any] = []
+        self.basis_transformations: list[Any] = []  # type: ignore[explicit-any]
         self.basis_transformations.append(1)
-        self.basis_registered: dict[int, list[Any]] = {}
+        self.basis_registered: dict[int, list[Any]] = {}  # type: ignore[explicit-any]
 
         self.warn_about_basis_change = False
         self.warn_about_basis_changing_objects = False
 
         self._saved_units: dict[str, str] = {}
 
-        self.save_dict: dict[str, Any] = {}
+        self.save_dict: dict[str, Any] = {}  # type: ignore[explicit-any]
 
         #
         # Configuration controlable from qrhei (conf file and qrhei script)
@@ -498,7 +498,7 @@ class Manager(metaclass=Singleton):
 
         return numpy.complex128
 
-    def store_current_basis_operator(self, op: Any) -> None:
+    def store_current_basis_operator(self, op: Any) -> None:  # type: ignore[explicit-any]
         self.current_basis_operator = op
 
     def remove_current_basis_operator(self) -> None:
@@ -577,7 +577,7 @@ class Manager(metaclass=Singleton):
         raise UnitsError("Unknown type of units")
 
     #    @deprecated
-    def cu_energy(self, val: float | numpy.ndarray, units: str = "1/cm") -> Any:
+    def cu_energy(self, val: float | numpy.ndarray, units: str = "1/cm") -> Any:  # type: ignore[explicit-any]
         """Converst to current energy units"""
         if units in self.units["energy"]:
             x = conversion_facs_energy[units]
@@ -591,14 +591,14 @@ class Manager(metaclass=Singleton):
             return i_val
 
     #    @deprecated
-    def iu_energy(self, val: float | numpy.ndarray, units: str = "1/cm") -> Any:
+    def iu_energy(self, val: float | numpy.ndarray, units: str = "1/cm") -> Any:  # type: ignore[explicit-any]
         """Converst to internal energy units"""
         if units in self.units["energy"]:
             x = conversion_facs_energy[units]
             i_val = x * val
             return i_val
 
-    def convert_energy_2_internal_u(
+    def convert_energy_2_internal_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         """Convert energy from currently used units to internal units
@@ -627,7 +627,7 @@ class Manager(metaclass=Singleton):
         else:
             return val * cfact
 
-    def convert_energy_2_current_u(
+    def convert_energy_2_current_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         """Converts energy from internal units to currently used units
@@ -656,7 +656,7 @@ class Manager(metaclass=Singleton):
         else:
             return val / cfact
 
-    def convert_frequency_2_internal_u(
+    def convert_frequency_2_internal_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         """Converts frequency from currently used units to internal units
@@ -669,7 +669,7 @@ class Manager(metaclass=Singleton):
         """
         return val * conversion_facs_frequency[self.current_units["frequency"]]
 
-    def convert_frequency_2_current_u(
+    def convert_frequency_2_current_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         """Converts frequency from internal units to currently used units
@@ -682,7 +682,7 @@ class Manager(metaclass=Singleton):
         """
         return val / conversion_facs_frequency[self.current_units["frequency"]]
 
-    def convert_length_2_internal_u(
+    def convert_length_2_internal_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         """Converts length from currently used units to internal units
@@ -695,7 +695,7 @@ class Manager(metaclass=Singleton):
         """
         return val * conversion_facs_length[self.current_units["length"]]
 
-    def convert_length_2_current_u(
+    def convert_length_2_current_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         """Converts frequency from internal units to currently used units
@@ -736,12 +736,12 @@ class Manager(metaclass=Singleton):
         imp_id = self.implementation_points[imp]
         self.current_implementations[imp_id] = choice
 
-    def register_implementation(
+    def register_implementation(  # type: ignore[explicit-any]
         self, imp_point: str, prefix: str, asint: Any = None
     ) -> None:
         pass
 
-    def commit_implementation(
+    def commit_implementation(  # type: ignore[explicit-any]
         self, imp_point: str, prefix: str, asint: Any = None
     ) -> None:
         pass
@@ -751,14 +751,14 @@ class Manager(metaclass=Singleton):
         l = len(self.basis_stack)
         return self.basis_stack[l - 1]
 
-    def set_new_basis(self, SS: Any) -> int:
+    def set_new_basis(self, SS: Any) -> int:  # type: ignore[explicit-any]
         nb = self.get_current_basis() + 1
         self.basis_stack.append(nb)
         self.basis_transformations.append(SS)
         self.basis_registered[nb] = []
         return nb
 
-    def transform_to_current_basis(self, operator: Any) -> None:
+    def transform_to_current_basis(self, operator: Any) -> None:  # type: ignore[explicit-any]
         """Transforms an operator to the currently used basis
 
         Parameters
@@ -805,7 +805,7 @@ class Manager(metaclass=Singleton):
             operator.set_current_basis(cb)
             self.register_with_basis(cb, operator)
 
-    def register_with_basis(self, nb: int, operator: Any) -> None:
+    def register_with_basis(self, nb: int, operator: Any) -> None:  # type: ignore[explicit-any]
         self.basis_registered[nb].append(operator)
 
 
@@ -818,22 +818,22 @@ class Managed:
 class UnitsManaged(Managed):
     """Base class for objects with management of units"""
 
-    def convert_energy_2_internal_u(
+    def convert_energy_2_internal_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         return self.manager.convert_energy_2_internal_u(val)
 
-    def convert_energy_2_current_u(
+    def convert_energy_2_current_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         return self.manager.convert_energy_2_current_u(val)
 
-    def convert_length_2_internal_u(
+    def convert_length_2_internal_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         return self.manager.convert_length_2_internal_u(val)
 
-    def convert_length_2_current_u(
+    def convert_length_2_current_u(  # type: ignore[explicit-any]
         self, val: float | numpy.ndarray
     ) -> float | numpy.ndarray:
         return self.manager.convert_length_2_current_u(val)
@@ -849,10 +849,10 @@ class EnergyUnitsManaged(Managed):
     utype = "energy"
     units = "1/fs"
 
-    def convert_2_internal_u(self, val: float | numpy.ndarray) -> float | numpy.ndarray:
+    def convert_2_internal_u(self, val: float | numpy.ndarray) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         return self.manager.convert_energy_2_internal_u(val)
 
-    def convert_2_current_u(self, val: float | numpy.ndarray) -> float | numpy.ndarray:
+    def convert_2_current_u(self, val: float | numpy.ndarray) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         return self.manager.convert_energy_2_current_u(val)
 
     def unit_repr(self) -> str:
@@ -868,10 +868,10 @@ class LengthUnitsManaged(Managed):
     utype = "length"
     units = "A"
 
-    def convert_2_internal_u(self, val: float | numpy.ndarray) -> float | numpy.ndarray:
+    def convert_2_internal_u(self, val: float | numpy.ndarray) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         return self.manager.convert_length_2_internal_u(val)
 
-    def convert_2_current_u(self, val: float | numpy.ndarray) -> float | numpy.ndarray:
+    def convert_2_current_u(self, val: float | numpy.ndarray) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         return self.manager.convert_length_2_current_u(val)
 
     def unit_repr(self) -> str:
@@ -906,7 +906,7 @@ class units_context_manager:
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
         pass
 
 
@@ -943,7 +943,7 @@ class energy_units(units_context_manager):
         self.manager._in_energy_units_context = True
         self.manager._in_eu_count += 1
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
         if exc_val is not None and self.units != self.units_backup:
             warnings.warn(
                 f"An exception exited a 'with energy_units(\"{self.units}\")' block. "
@@ -999,7 +999,7 @@ class length_units(units_context_manager):
         self.units_backup = self.manager.get_current_units("length")
         self.manager.set_current_units(self.utype, self.units)
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
         if exc_val is not None and self.units != self.units_backup:
             warnings.warn(
                 f"An exception exited a 'with length_units(\"{self.units}\")' block. "
@@ -1019,7 +1019,7 @@ class basis_context_manager:
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
         pass
 
 
@@ -1035,7 +1035,7 @@ class eigenbasis_of(basis_context_manager):
         The operator whose eigenbasis is used inside the context block.
     """
 
-    def __init__(self, operator: Any) -> None:
+    def __init__(self, operator: Any) -> None:  # type: ignore[explicit-any]
         super().__init__()
         self.op = operator
         self.manager.store_current_basis_operator(self.op)
@@ -1063,7 +1063,7 @@ class eigenbasis_of(basis_context_manager):
         if self.manager.warn_about_basis_change:
             print("\nQr >>>  ... setting context done")
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:  # type: ignore[explicit-any]
 
         if self.manager.warn_about_basis_change:
             print("\nQr >>> Returning from basis context manager. Cleaning ...")

--- a/quantarhei/core/matrixdata.py
+++ b/quantarhei/core/matrixdata.py
@@ -27,7 +27,7 @@ class MatrixData:
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, dims: Any = (0), name: str | None = None, data: Any = None
     ) -> None:
 
@@ -94,7 +94,7 @@ class MatrixData:
         """Returns the matrix rank, i.e. the number of its indices"""
         return self.data.ndim
 
-    def set_data(self, data: numpy.ndarray) -> None:
+    def set_data(self, data: numpy.ndarray) -> None:  # type: ignore[explicit-any]
         """Sets the data of the object
 
         Parameters

--- a/quantarhei/core/parcel.py
+++ b/quantarhei/core/parcel.py
@@ -31,7 +31,7 @@ class Parcel:
     :func:`~quantarhei.load_parcel` helpers for the common save/load workflow.
     """
 
-    def set_content(self, obj: Any) -> None:
+    def set_content(self, obj: Any) -> None:  # type: ignore[explicit-any]
         """Set the content of the parcel"""
         self.content = obj
         self.class_name = f"{obj.__class__.__module__}.{obj.__class__.__name__}"
@@ -68,7 +68,7 @@ class Parcel:
             pickle.dump(self, filename)
 
 
-def save_parcel(
+def save_parcel(  # type: ignore[explicit-any]
     obj: Any, filename: str | IO[bytes], comment: str | None = None
 ) -> None:
     """Saves a given object as a parcel
@@ -91,7 +91,7 @@ def save_parcel(
     p.save(filename)
 
 
-def load_parcel(filename: str | IO[bytes], *, trusted: bool = False) -> Any:
+def load_parcel(filename: str | IO[bytes], *, trusted: bool = False) -> Any:  # type: ignore[explicit-any]
     """Loads the object saved as parcel
 
     Parameters
@@ -121,7 +121,7 @@ def load_parcel(filename: str | IO[bytes], *, trusted: bool = False) -> Any:
     raise QuantarheiError("Only Quantarhei Parcels can be loaded")
 
 
-def check_parcel(filename: str | IO[bytes], *, trusted: bool = False) -> dict[str, Any]:
+def check_parcel(filename: str | IO[bytes], *, trusted: bool = False) -> dict[str, Any]:  # type: ignore[explicit-any]
     """Checks the content of a Quantarhei parcel
 
     Parameters

--- a/quantarhei/core/saveable.py
+++ b/quantarhei/core/saveable.py
@@ -57,7 +57,7 @@ class Saveable:
             if not isinstance(filename, str):
                 filename.seek(0)
 
-    def load(self, filename: str | IO[bytes], test: bool = False) -> Any:
+    def load(self, filename: str | IO[bytes], test: bool = False) -> Any:  # type: ignore[explicit-any]
         """Load an object from a file and return it.
 
         Parameters
@@ -87,7 +87,7 @@ class Saveable:
         str40 = str(uuid.uuid4())
         return str40
 
-    def savedir(
+    def savedir(  # type: ignore[explicit-any]
         self,
         dirname: str,
         tag: Any = None,
@@ -129,9 +129,9 @@ class Saveable:
         p.set_comment("Hashes")
         p.save(hfile)
 
-    def loaddir(self, dirname: str) -> dict[Any, Any]:
+    def loaddir(self, dirname: str) -> dict[Any, Any]:  # type: ignore[explicit-any]
         """Returns a directory of objects saved into a directory"""
-        out: dict[Any, Any] = {}
+        out: dict[Any, Any] = {}  # type: ignore[explicit-any]
         hfile = os.path.join(dirname, "_hashes_.qrp")
         hashes = load_parcel(hfile)
 
@@ -143,7 +143,7 @@ class Saveable:
 
         return out
 
-    def scopy(self) -> Any:
+    def scopy(self) -> Any:  # type: ignore[explicit-any]
         """Creates a copy of the object by saving and loading it"""
         with TemporaryDirectory() as td:
             fname = os.path.join(td, "ssave.qrp")
@@ -153,10 +153,10 @@ class Saveable:
 
         return no
 
-    def deepcopy(self) -> Any:
+    def deepcopy(self) -> Any:  # type: ignore[explicit-any]
         """Returns a deep copy of the self"""
         return copy.deepcopy(self)
 
-    def copy(self) -> Any:
+    def copy(self) -> Any:  # type: ignore[explicit-any]
         """Returns a shallow copy of the self"""
         return copy.copy(self)

--- a/quantarhei/core/singleton.py
+++ b/quantarhei/core/singleton.py
@@ -20,7 +20,7 @@ class Singleton(type):
     _instances: dict[type, Singleton] = {}
     _lock: threading.Lock = threading.Lock()
 
-    def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+    def __call__(cls, *args: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
         with cls._lock:
             if cls not in cls._instances:
                 cls._instances[cls] = super().__call__(*args, **kwargs)

--- a/quantarhei/core/stochastics.py
+++ b/quantarhei/core/stochastics.py
@@ -8,7 +8,7 @@ import numpy as np
 
 
 # correlation functions
-def cor(lam: float, g: float, a: float, b: float, t: Any) -> Any:
+def cor(lam: float, g: float, a: float, b: float, t: Any) -> Any:  # type: ignore[explicit-any]
     # return lam*(a-1j*b)*np.exp(-g*np.abs(t))
     # om = a
     # T = b
@@ -23,7 +23,7 @@ def cor(lam: float, g: float, a: float, b: float, t: Any) -> Any:
     return re + 1j * im
 
 
-def run() -> tuple[Any, Any, Any]:
+def run() -> tuple[Any, Any, Any]:  # type: ignore[explicit-any]
     g11 = 1.0 / 200
     l11 = 0.2
     l12 = 0.2

--- a/quantarhei/core/triangle.py
+++ b/quantarhei/core/triangle.py
@@ -15,10 +15,10 @@ class triangle(Saveable):
     def get_empty_list(self) -> list[None]:
         return self.get_list(init=None)
 
-    def get_list(self, init: Any = None) -> list[Any]:
+    def get_list(self, init: Any = None) -> list[Any]:  # type: ignore[explicit-any]
         return [init] * (((self.N**2) - self.N) // 2 + self.N)
 
-    def locate(
+    def locate(  # type: ignore[explicit-any]
         self, i: int, j: int, transpose: bool = True, report_transpose: bool = False
     ) -> Any:
 

--- a/quantarhei/core/unique.py
+++ b/quantarhei/core/unique.py
@@ -60,13 +60,13 @@ class unique_list:
 
     def __init__(self, N: int = 0) -> None:
         if N == 0:
-            self._storage: list[Any] = []
+            self._storage: list[Any] = []  # type: ignore[explicit-any]
             self._indices: list[int] = []
         else:
             self._storage = []
             self._indices = [-1] * N
 
-    def append(self, obj: Any) -> None:
+    def append(self, obj: Any) -> None:  # type: ignore[explicit-any]
         """Appends a new object to the list
 
         Examples
@@ -85,7 +85,7 @@ class unique_list:
             ind = self._storage.index(obj)
             self._indices.append(ind)
 
-    def set_element(self, i: int, obj: Any) -> None:
+    def set_element(self, i: int, obj: Any) -> None:  # type: ignore[explicit-any]
         """Sets an object to the specified position"""
         # FIXME: when replacing an element, the list may get corrupted
 
@@ -99,7 +99,7 @@ class unique_list:
             ind = self._storage.index(obj)
             self._indices[i] = ind
 
-    def get_element(self, i: int) -> Any:
+    def get_element(self, i: int) -> Any:  # type: ignore[explicit-any]
         """Returns an element residing on a given position"""
         k = self._indices[i]
         if k == -1:
@@ -126,10 +126,10 @@ class unique_list:
         return len(self._storage)
 
     # @deprecated
-    def get_unique_element(self) -> list[Any]:
+    def get_unique_element(self) -> list[Any]:  # type: ignore[explicit-any]
         return self._storage
 
-    def get_unique_elements(self) -> list[Any]:
+    def get_unique_elements(self) -> list[Any]:  # type: ignore[explicit-any]
         """Returns a list of elements stored
 
         Examples
@@ -155,11 +155,11 @@ class unique_triangle_array:
         self.triangle = triangle(self.N)
         self._storgage = unique_list(N=N)
 
-    def set_element(self, i: int, j: int, obj: Any) -> None:
+    def set_element(self, i: int, j: int, obj: Any) -> None:  # type: ignore[explicit-any]
         I = self.triangle.locate(i, j)
         self._storgage.set_element(I, obj)
 
-    def get_element(self, i: int, j: int) -> Any:
+    def get_element(self, i: int, j: int) -> Any:  # type: ignore[explicit-any]
         I = self.triangle.locate(i, j)
         return self._storgage.get_element(I)
 
@@ -167,10 +167,10 @@ class unique_triangle_array:
         return len(self._storgage._storage)
 
     # @deprecated
-    def get_unique_element(self) -> list[Any]:
+    def get_unique_element(self) -> list[Any]:  # type: ignore[explicit-any]
         return self._storgage._storage
 
-    def get_unique_elements(self) -> list[Any]:
+    def get_unique_elements(self) -> list[Any]:  # type: ignore[explicit-any]
         return self._storgage._storage
 
 
@@ -180,12 +180,12 @@ class unique_array:
         self.M = M
         self._storage = unique_list(N=self.N * self.M)
 
-    def get_element(self, i: int, j: int) -> Any:
+    def get_element(self, i: int, j: int) -> Any:  # type: ignore[explicit-any]
         if ((i < self.N) and (j < self.M)) and ((i >= 0) and (j >= 0)):
             return self._storage.get_element((self.M - 1) * i + j)
         raise QuantarheiError("Index out of range")
 
-    def set_element(self, i: int, j: int, obj: Any) -> None:
+    def set_element(self, i: int, j: int, obj: Any) -> None:  # type: ignore[explicit-any]
         if ((i < self.N) and (j < self.M)) and ((i >= 0) and (j >= 0)):
             self._storage.set_element((self.M - 1) * i + j, obj)
         else:
@@ -195,8 +195,8 @@ class unique_array:
         return len(self._storgage._storage)  # type: ignore[attr-defined]
 
     # @deprecated
-    def get_unique_element(self) -> list[Any]:
+    def get_unique_element(self) -> list[Any]:  # type: ignore[explicit-any]
         return self._storage._storage
 
-    def get_unique_elements(self) -> list[Any]:
+    def get_unique_elements(self) -> list[Any]:  # type: ignore[explicit-any]
         return self._storage._storage

--- a/quantarhei/core/units.py
+++ b/quantarhei/core/units.py
@@ -100,7 +100,7 @@ eps0_int = 1.0e19 / (4.0 * const.pi * J2int)
 #
 
 
-def convert(
+def convert(  # type: ignore[explicit-any]
     val: float | numpy.ndarray, in_units: str, to: str | None = None
 ) -> float | numpy.ndarray:
     """Convert a value from one set of units to another.
@@ -135,7 +135,7 @@ def convert(
     return ne
 
 
-def in_current_units(
+def in_current_units(  # type: ignore[explicit-any]
     val: float | numpy.ndarray, in_units: str
 ) -> float | numpy.ndarray:
     """Convert a value from given units into the current global units.

--- a/quantarhei/core/valueaxis.py
+++ b/quantarhei/core/valueaxis.py
@@ -136,7 +136,7 @@ class ValueAxis(Saveable):
         self.start = start
         self.length = length
 
-        self.data: numpy.ndarray = numpy.linspace(
+        self.data: numpy.ndarray = numpy.linspace(  # type: ignore[explicit-any]
             start, start + (length - 1) * step, length, dtype=REAL
         )
 

--- a/quantarhei/core/wrappers.py
+++ b/quantarhei/core/wrappers.py
@@ -11,18 +11,18 @@ from ..exceptions import QuantarheiError
 from .managers import Manager
 
 
-def deprecated(
+def deprecated(  # type: ignore[explicit-any]
     func: Callable[..., Any] | None = None,
     *,
     alternative: str | None = None,
 ) -> Callable[..., Any]:
-    def decorator(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
+    def decorator(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[explicit-any]
         message = f"{wrapped_func.__qualname__} is deprecated"
         if alternative is not None:
             message = f"{message}; use {alternative} instead"
 
         @wraps(wrapped_func)
-        def wrapper(*arg: Any, **kwargs: Any) -> Any:
+        def wrapper(*arg: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
             warnings.warn(
                 message,
                 DeprecationWarning,
@@ -38,9 +38,9 @@ def deprecated(
     return decorator(func)
 
 
-def prevent_basis_context(func: Callable[..., Any]) -> Callable[..., Any]:
+def prevent_basis_context(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[explicit-any]
     @wraps(func)
-    def wrapper(*arg: Any, **kwargs: Any) -> Any:
+    def wrapper(*arg: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
         m = Manager()
         if m._in_eigenbasis_of_context and m._enforce_contexts:
             raise QuantarheiError(
@@ -52,9 +52,9 @@ def prevent_basis_context(func: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def enforce_basis_context(func: Callable[..., Any]) -> Callable[..., Any]:
+def enforce_basis_context(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[explicit-any]
     @wraps(func)
-    def wrapper(*arg: Any, **kwargs: Any) -> Any:
+    def wrapper(*arg: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
         m = Manager()
         if (not m._in_eigenbasis_of_context) and m._enforce_contexts:
             raise QuantarheiError(
@@ -65,9 +65,9 @@ def enforce_basis_context(func: Callable[..., Any]) -> Callable[..., Any]:
     return wrapper
 
 
-def prevent_energy_units_context(func: Callable[..., Any]) -> Callable[..., Any]:
+def prevent_energy_units_context(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[explicit-any]
     @wraps(func)
-    def wrapper(*arg: Any, **kwargs: Any) -> Any:
+    def wrapper(*arg: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
         m = Manager()
         if m._in_energy_units_context and m._enforce_contexts:
             raise QuantarheiError(
@@ -79,9 +79,9 @@ def prevent_energy_units_context(func: Callable[..., Any]) -> Callable[..., Any]
     return wrapper
 
 
-def enforce_energy_units_context(func: Callable[..., Any]) -> Callable[..., Any]:
+def enforce_energy_units_context(func: Callable[..., Any]) -> Callable[..., Any]:  # type: ignore[explicit-any]
     @wraps(func)
-    def wrapper(*arg: Any, **kwargs: Any) -> Any:
+    def wrapper(*arg: Any, **kwargs: Any) -> Any:  # type: ignore[explicit-any]
         m = Manager()
         if not m._in_energy_units_context and m._enforce_contexts:
             raise QuantarheiError(

--- a/quantarhei/functions/dfce1.py
+++ b/quantarhei/functions/dfce1.py
@@ -36,7 +36,7 @@ class Cos(DFunction):
 
     """
 
-    def __init__(self, x: Any, omega: float, phi: float = 0.0) -> None:
+    def __init__(self, x: Any, omega: float, phi: float = 0.0) -> None:  # type: ignore[explicit-any]
         super().__init__()
         self._make_me(x, numpy.cos(omega * x.data + phi))
 
@@ -75,7 +75,7 @@ class Tukey(DFunction):
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, x: Any, r: float, sym: bool = True, x_offset: float = 0.0
     ) -> None:
         super().__init__()

--- a/quantarhei/implementations/aceto/band_system.py
+++ b/quantarhei/implementations/aceto/band_system.py
@@ -10,30 +10,30 @@ from ...exceptions import QuantarheiError
 class band_system:
     """Python implementation of acetosys band_system class"""
 
-    def __init__(self, Nb: int, Ns: Any) -> None:
+    def __init__(self, Nb: int, Ns: Any) -> None:  # type: ignore[explicit-any]
         self.Nb = Nb
         # the type of Ns should be default fortran integer
         self.Ns = numpy.array(Ns, dtype=numpy.int32)
         self.Ne = numpy.sum(Ns)
 
-        self.en: numpy.ndarray | None = None
-        self.om01: numpy.ndarray | None = None
-        self.om12: numpy.ndarray | None = None
-        self.nn01: numpy.ndarray | None = None
-        self.nn12: numpy.ndarray | None = None
-        self.dd01: numpy.ndarray | None = None
-        self.dd12: numpy.ndarray | None = None
-        self.Kr11: numpy.ndarray | None = None
-        self.Kr22: numpy.ndarray | None = None
-        self.Kd01: numpy.ndarray | None = None
-        self.Kd11: numpy.ndarray | None = None
-        self.Kd12: numpy.ndarray | None = None
-        self.gofts: numpy.ndarray | None = None
-        self.ptn: numpy.ndarray | None = None
-        self.SS1: numpy.ndarray | None = None
-        self.SS2: numpy.ndarray | None = None
+        self.en: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.om01: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.om12: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.nn01: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.nn12: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.dd01: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.dd12: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.Kr11: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.Kr22: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.Kd01: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.Kd11: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.Kd12: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.gofts: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.ptn: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.SS1: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.SS2: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
-    def set_energies(self, en: Any) -> None:
+    def set_energies(self, en: Any) -> None:  # type: ignore[explicit-any]
         self.en = numpy.asfortranarray(en)
         self.om01 = numpy.zeros(
             (self.Ns[0], self.Ns[1]), dtype=numpy.float64, order="F"
@@ -50,7 +50,7 @@ class band_system:
                     self.en[self.Ns[0] + i] - self.en[self.Ns[0] + self.Ns[1] + j]
                 )
 
-    def set_dipoles(self, Nbi: int, Nbf: int, dab: Any) -> None:
+    def set_dipoles(self, Nbi: int, Nbf: int, dab: Any) -> None:  # type: ignore[explicit-any]
 
         # FIXME: some of the arrays need to be turned in 'F'order
         if not (dab.shape == (3, self.Ns[Nbi], self.Ns[Nbf])):
@@ -121,14 +121,14 @@ class band_system:
         print("Trasfer from |4> to |(1,3)> = 0")
         print(self.dd12[3, 1], self.nn12[:, 3, 1])
 
-    def set_gofts(self, gofts: Any) -> None:
+    def set_gofts(self, gofts: Any) -> None:  # type: ignore[explicit-any]
         self.gofts = numpy.asfortranarray(gofts)
 
-    def set_sitep(self, ptn: Any) -> None:
+    def set_sitep(self, ptn: Any) -> None:  # type: ignore[explicit-any]
         self.ptn = ptn
         self.fptn = numpy.asfortranarray(self.ptn + 1)
 
-    def set_transcoef(self, Nb: int, SS: Any) -> None:
+    def set_transcoef(self, Nb: int, SS: Any) -> None:  # type: ignore[explicit-any]
         if Nb == 1:
             self.SS1 = numpy.asfortranarray(SS)
         elif Nb == 2:
@@ -136,7 +136,7 @@ class band_system:
         else:
             raise QuantarheiError("Attempt to assign unsupported block")
 
-    def set_relaxation_rates(self, Nb: int, RR: Any) -> None:
+    def set_relaxation_rates(self, Nb: int, RR: Any) -> None:  # type: ignore[explicit-any]
         if Nb == 1:
             self.Kr11 = numpy.asfortranarray(RR)
         elif Nb == 2:
@@ -181,6 +181,6 @@ class band_system:
             (self.Ns[1], self.Ns[2]), dtype=numpy.float64, order="F"
         )
 
-    def set_population_propagation_matrix(self, Ueet2: Any) -> None:
+    def set_population_propagation_matrix(self, Ueet2: Any) -> None:  # type: ignore[explicit-any]
         """Set the population evolution matrix of certain t2 time"""
         self.Ueet2 = numpy.asfortranarray(Ueet2)

--- a/quantarhei/implementations/aceto/lab_settings.py
+++ b/quantarhei/implementations/aceto/lab_settings.py
@@ -8,9 +8,9 @@ class lab_settings:
 
     def __init__(self, exptype: int) -> None:
         self.exptype = exptype
-        self.orient_aver: numpy.ndarray | None = None
+        self.orient_aver: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
-    def set_laser_polarizations(
+    def set_laser_polarizations(  # type: ignore[explicit-any]
         self, e1: numpy.ndarray, e2: numpy.ndarray, e3: numpy.ndarray, e4: numpy.ndarray
     ) -> None:
         self.p1 = e1
@@ -29,7 +29,7 @@ class lab_settings:
         F4[2] = numpy.dot(e4, e1) * numpy.dot(e3, e2)
         self.orient_aver = numpy.dot(numpy.transpose(M4), F4)
 
-    def oafactor(
+    def oafactor(  # type: ignore[explicit-any]
         self, d1: numpy.ndarray, d2: numpy.ndarray, d3: numpy.ndarray, d4: numpy.ndarray
     ) -> numpy.ndarray:
         F4 = numpy.zeros(3, dtype=numpy.float64)

--- a/quantarhei/implementations/aceto/nr3td.py
+++ b/quantarhei/implementations/aceto/nr3td.py
@@ -21,7 +21,7 @@ from typing import Any
 #
 
 
-def nr3_r1g(
+def nr3_r1g(  # type: ignore[explicit-any]
     lab: Any, sys: Any, it2: int, t1s: Any, t3s: Any, rwa: float, rmin: float, resp: Any
 ) -> None:
     """Calculates R2g response function"""
@@ -31,7 +31,7 @@ def nr3_r1g(
     pass
 
 
-def nr3_r2g(
+def nr3_r2g(  # type: ignore[explicit-any]
     lab: Any, sys: Any, it2: int, t1s: Any, t3s: Any, rwa: float, rmin: float, resp: Any
 ) -> None:
     """Calculates R2g response function
@@ -89,7 +89,7 @@ def nr3_r2g(
     pass
 
 
-def nr3_r2gt10(
+def nr3_r2gt10(  # type: ignore[explicit-any]
     lab: Any, sys: Any, it2: int, t3s: Any, rwa: float, rmin: float, resp: Any
 ) -> None:
     """Calculates R2g response function
@@ -130,7 +130,7 @@ def nr3_r2gt10(
     pass
 
 
-def nr3_r3g(
+def nr3_r3g(  # type: ignore[explicit-any]
     lab: Any, sys: Any, it2: int, t1s: Any, t3s: Any, rwa: float, rmin: float, resp: Any
 ) -> None:
     """Calculates R3g response function"""
@@ -161,7 +161,7 @@ def nr3_r3g(
     pass
 
 
-def nr3_r4g(
+def nr3_r4g(  # type: ignore[explicit-any]
     lab: Any, sys: Any, it2: int, t1s: Any, t3s: Any, rwa: float, rmin: float, resp: Any
 ) -> None:
     """Calculates R4g response function"""
@@ -171,7 +171,7 @@ def nr3_r4g(
     pass
 
 
-def nr3_r1fs(
+def nr3_r1fs(  # type: ignore[explicit-any]
     lab: Any,
     sys: Any,
     it2: int,
@@ -198,7 +198,7 @@ def nr3_r1fs(
     pass
 
 
-def nr3_r2fs(
+def nr3_r2fs(  # type: ignore[explicit-any]
     lab: Any,
     sys: Any,
     it2: int,
@@ -230,7 +230,7 @@ def nr3_r2fs(
 #  Energy transfer pathways
 #
 #
-def nr3_r2g_trans(
+def nr3_r2g_trans(  # type: ignore[explicit-any]
     lab: Any, sys: Any, it2: int, t1s: Any, t3s: Any, rwa: float, rmin: float, resp: Any
 ) -> None:
     """Calculates R2g response function
@@ -274,7 +274,7 @@ def nr3_r2g_trans(
     pass
 
 
-def nr3_r2g_trN(
+def nr3_r2g_trN(  # type: ignore[explicit-any]
     lab: Any,
     sys: Any,
     No: int,
@@ -332,7 +332,7 @@ def nr3_r2g_trN(
     pass
 
 
-def nr3_r1g_trans(
+def nr3_r1g_trans(  # type: ignore[explicit-any]
     lab: Any, sys: Any, it2: int, t1s: Any, t3s: Any, rwa: float, rmin: float, resp: Any
 ) -> None:
     """Calculates R2g response function
@@ -376,7 +376,7 @@ def nr3_r1g_trans(
     pass
 
 
-def nr3_r1fs_trans(
+def nr3_r1fs_trans(  # type: ignore[explicit-any]
     lab: Any, sys: Any, it2: int, t1s: Any, t3s: Any, rwa: float, rmin: float, resp: Any
 ) -> None:
     """Calculates R1f* transfer response function"""
@@ -388,7 +388,7 @@ def nr3_r1fs_trans(
     pass
 
 
-def nr3_r2fs_trans(
+def nr3_r2fs_trans(  # type: ignore[explicit-any]
     lab: Any, sys: Any, it2: int, t1s: Any, t3s: Any, rwa: float, rmin: float, resp: Any
 ) -> None:
     """Calculates R1f* transfer response function"""

--- a/quantarhei/implementations/python/redfieldrates.py
+++ b/quantarhei/implementations/python/redfieldrates.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy
 
 
-def ssRedfieldRateMatrix(
+def ssRedfieldRateMatrix(  # type: ignore[explicit-any]
     Na: int,
     Nk: int,
     KI: numpy.ndarray,

--- a/quantarhei/implementations/qutip/qutip_heom.py
+++ b/quantarhei/implementations/qutip/qutip_heom.py
@@ -53,9 +53,9 @@ fmo_ham = numpy.array([
 """
 
 
-def prepare_simulation(Ham: Any, sbi: Any, depth: int) -> dict[str, Any]:
+def prepare_simulation(Ham: Any, sbi: Any, depth: int) -> dict[str, Any]:  # type: ignore[explicit-any]
 
-    qutip_data: dict[str, Any] = dict(depth=depth)
+    qutip_data: dict[str, Any] = dict(depth=depth)  # type: ignore[explicit-any]
 
     # number of states
     Ngr = 1
@@ -111,7 +111,7 @@ def prepare_simulation(Ham: Any, sbi: Any, depth: int) -> dict[str, Any]:
     return qutip_data
 
 
-def run_simulation(
+def run_simulation(  # type: ignore[explicit-any]
     kthprop: Any, rhoi: Any, options: dict[str, Any] | None = None
 ) -> Any:
 

--- a/quantarhei/models/bacteriochlorophylls.py
+++ b/quantarhei/models/bacteriochlorophylls.py
@@ -22,7 +22,7 @@ class BacterioChlorophyll(MolecularModel, EnergyUnitsManaged):
         self.default_dipole_lengths[0, 1] = 5.8
         self.default_dipole_lengths[1, 0] = 5.8
 
-    def set_default_energies(self, elenergies: Any) -> None:
+    def set_default_energies(self, elenergies: Any) -> None:  # type: ignore[explicit-any]
         k = 0
         for en in elenergies:
             self.default_energies[k] = self.convert_2_internal_u(en)
@@ -34,7 +34,7 @@ class BacterioChlorophyll(MolecularModel, EnergyUnitsManaged):
         self.default_dipole_lengths[transition[0], transition[1]] = val
         self.default_dipole_lengths[transition[1], transition[0]] = val
 
-    def transition_dipole(
+    def transition_dipole(  # type: ignore[explicit-any]
         self,
         transition: tuple[int, int] = (0, 1),
         data_type: str | None = None,
@@ -67,7 +67,7 @@ class BacterioChlorophyll(MolecularModel, EnergyUnitsManaged):
 
         return d
 
-    def position_of_center(
+    def position_of_center(  # type: ignore[explicit-any]
         self, data_type: str | None = None, data: Any = None
     ) -> numpy.ndarray:
         """Returns the position of the molecular center"""
@@ -101,7 +101,7 @@ class BacterioChlorophyll(MolecularModel, EnergyUnitsManaged):
 
         return pos
 
-    def pi_conjugated_system(
+    def pi_conjugated_system(  # type: ignore[explicit-any]
         self, data_type: str | None = None, data: Any = None
     ) -> None:
         """Returns the atoms and atom types in the pi-conjugated system

--- a/quantarhei/models/chlorophylls.py
+++ b/quantarhei/models/chlorophylls.py
@@ -30,7 +30,7 @@ class ChlorophyllA(MolecularModel):
 
         self.set_default_dipole_length((0, 1), dp_length)
 
-    def transition_dipole(
+    def transition_dipole(  # type: ignore[explicit-any]
         self,
         transition: tuple[int, int] = (0, 1),
         data_type: str | None = None,
@@ -63,7 +63,7 @@ class ChlorophyllA(MolecularModel):
 
         return d
 
-    def position_of_center(
+    def position_of_center(  # type: ignore[explicit-any]
         self, data_type: str | None = None, data: Any = None
     ) -> numpy.ndarray:
         """Returns the position of the molecular center"""
@@ -97,7 +97,7 @@ class ChlorophyllA(MolecularModel):
 
         return pos
 
-    def pi_conjugated_system(
+    def pi_conjugated_system(  # type: ignore[explicit-any]
         self, data_type: str | None = None, data: Any = None
     ) -> None:
         """Returns the atoms and atom types in the pi-conjugated system
@@ -144,7 +144,7 @@ class ChlorophyllB(MolecularModel):
 
         self.set_default_dipole_length((0, 1), dp_length)
 
-    def transition_dipole(
+    def transition_dipole(  # type: ignore[explicit-any]
         self,
         transition: tuple[int, int] = (0, 1),
         data_type: str | None = None,
@@ -177,7 +177,7 @@ class ChlorophyllB(MolecularModel):
 
         return d
 
-    def position_of_center(
+    def position_of_center(  # type: ignore[explicit-any]
         self, data_type: str | None = None, data: Any = None
     ) -> numpy.ndarray:
         """Returns the position of the molecular center"""
@@ -211,7 +211,7 @@ class ChlorophyllB(MolecularModel):
 
         return pos
 
-    def pi_conjugated_system(
+    def pi_conjugated_system(  # type: ignore[explicit-any]
         self, data_type: str | None = None, data: Any = None
     ) -> None:
         """Returns the atoms and atom types in the pi-conjugated system

--- a/quantarhei/models/molecularmodel.py
+++ b/quantarhei/models/molecularmodel.py
@@ -23,7 +23,7 @@ class MolecularModel(EnergyUnitsManaged):
             (self.nstate, self.nstate), dtype=numpy.float64
         )
 
-    def set_default_energies(self, elenergies: Any) -> None:
+    def set_default_energies(self, elenergies: Any) -> None:  # type: ignore[explicit-any]
         k = 0
         for en in elenergies:
             self.default_energies[k] = self.convert_2_internal_u(en)

--- a/quantarhei/models/spectdens.py
+++ b/quantarhei/models/spectdens.py
@@ -18,10 +18,10 @@ class DatabaseEntry:
     def __init__(self) -> None:
         pass
 
-    def get_CorrelationFunction(self, temperature: Any) -> Any:
+    def get_CorrelationFunction(self, temperature: Any) -> Any:  # type: ignore[explicit-any]
         pass
 
-    def get_SpectralDensity(self, axis: Any = None) -> Any:
+    def get_SpectralDensity(self, axis: Any = None) -> Any:  # type: ignore[explicit-any]
         pass
 
 
@@ -35,7 +35,7 @@ class SpectralDensityDatabaseEntry(DatabaseEntry):
 
     direct_implementation = DatabaseEntry.SPECTRAL_DENSITY
 
-    def get_CorrelationFunction(self, temperature: Any) -> Any:
+    def get_CorrelationFunction(self, temperature: Any) -> Any:  # type: ignore[explicit-any]
         """Returns CorrelationFunction based on SpectralDensity"""
         return self.get_SpectralDensity().get_CorrelationFunction(temperature)
 
@@ -49,9 +49,9 @@ class CorrelationFunctionDatabaseEntry(DatabaseEntry):
     """
 
     direct_implementation = DatabaseEntry.CORRELATION_FUNCTION
-    temperature: Any
+    temperature: Any  # type: ignore[explicit-any]
 
-    def get_SpectralDensity(self, axis: Any = None) -> Any:
+    def get_SpectralDensity(self, axis: Any = None) -> Any:  # type: ignore[explicit-any]
         """Returns SpectralDensity on CorrelationFunction based"""
         temperature = self.temperature
         return self.get_CorrelationFunction(temperature).get_SpectralDensity()
@@ -100,7 +100,7 @@ class DataDefinedEntry(DatabaseEntry):
         else:
             raise QuantarheiError("Data not defined in any expected way")
 
-    def get_data(self) -> Any:
+    def get_data(self) -> Any:  # type: ignore[explicit-any]
         """Returns spectral density data
 
         Should return a numpy array with two columns of data to construct the
@@ -140,7 +140,7 @@ class SpectralDensityDB:
         if verbose:
             print("Initializing Spectral Density Database")
 
-        self.entries: dict[str, Any] = {}
+        self.entries: dict[str, Any] = {}  # type: ignore[explicit-any]
         self.loaded: dict[str, bool] = {}
         self.entry_count = 0
 
@@ -222,7 +222,7 @@ class SpectralDensityDB:
 
         return out
 
-    def get_SpectralDensity(self, axis: Any, ident: str | None = None) -> Any:
+    def get_SpectralDensity(self, axis: Any, ident: str | None = None) -> Any:  # type: ignore[explicit-any]
         """Returns spectral density based on an identificator"""
         import importlib
 

--- a/quantarhei/models/spectral_densities/example_data_defined.py
+++ b/quantarhei/models/spectral_densities/example_data_defined.py
@@ -11,7 +11,7 @@ class example_data_defined_array(DataDefinedEntry):
     identificator = "Example 1"
     units = "1/cm"
 
-    def get_data(self) -> numpy.ndarray:
+    def get_data(self) -> numpy.ndarray:  # type: ignore[explicit-any]
 
         data = numpy.array(
             [

--- a/quantarhei/models/spectral_densities/renger_2002.py
+++ b/quantarhei/models/spectral_densities/renger_2002.py
@@ -24,7 +24,7 @@ class renger_2002a(SpectralDensityDatabaseEntry):
         self.identificator = "Renger_JCP_2002"
         self.alt_ident = ["Renger", "Renger2002"]
 
-    def get_SpectralDensity(self, axis: Any = None) -> Any:
+    def get_SpectralDensity(self, axis: Any = None) -> Any:  # type: ignore[explicit-any]
 
         # Calling the spec dens calculated from b777 in rengers paper
         # alternative_form gives the polynomial version of the same spec dens

--- a/quantarhei/models/spectral_densities/wendling_2000.py
+++ b/quantarhei/models/spectral_densities/wendling_2000.py
@@ -28,7 +28,7 @@ class wendling_2000a(SpectralDensityDatabaseEntry):
         self.identificator = "Wendling_JPCB_104_2000_5825"
         self.alt_ident = ["Wendling", "Wendling2000"]
 
-    def get_SpectralDensity(self, axis: Any = None) -> Any:
+    def get_SpectralDensity(self, axis: Any = None) -> Any:  # type: ignore[explicit-any]
 
         #
         # Data from the paper
@@ -110,7 +110,7 @@ class wendling_2000a(SpectralDensityDatabaseEntry):
         #
         # All contributions consist of underdamped harmonic oscillators
         #
-        params: dict[str, Any] = dict(ftype="UnderdampedBrownian")
+        params: dict[str, Any] = dict(ftype="UnderdampedBrownian")  # type: ignore[explicit-any]
 
         #
         # Create and sum-up spectral densities

--- a/quantarhei/qm/corfunctions/cfmatrix.py
+++ b/quantarhei/qm/corfunctions/cfmatrix.py
@@ -62,26 +62,26 @@ class CorrelationFunctionMatrix(Saveable):
         self.cpointer[:, :] = 0
 
         # empty list for functions
-        self.cfuncs: list[Any] | None = None
+        self.cfuncs: list[Any] | None = None  # type: ignore[explicit-any]
 
         # FIXME: reorganization energies should be defined through _A2 and _A4
         # reorganization energies
-        self.lambdas: numpy.ndarray | None = None
-        self.where: list[Any] | None = None
+        self.lambdas: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.where: list[Any] | None = None  # type: ignore[explicit-any]
 
         # Actual storage of functions
         # here we store correlation functions
-        self._cofts: numpy.ndarray | None = None
+        self._cofts: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
         # here we store their first integrals
-        self._hofts: numpy.ndarray | None = None
+        self._hofts: numpy.ndarray | None = None  # type: ignore[explicit-any]
         self._has_hofts = False
 
         # here we store their second integrals
-        self._gofts: numpy.ndarray | None = None
+        self._gofts: numpy.ndarray | None = None  # type: ignore[explicit-any]
         self._has_gofts = False
 
-        self.data: numpy.ndarray | None = None
+        self.data: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
         # TimeAxis on which the functions are defined
         self.timeAxis = timeaxis
@@ -96,8 +96,8 @@ class CorrelationFunctionMatrix(Saveable):
 
         # FIXME: implement transformation of the matrix
         self._is_transformed = False
-        self._A2: numpy.ndarray | None = None
-        self._A4: numpy.ndarray | None = None
+        self._A2: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self._A4: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
         self._initiate_storage()
 
@@ -223,7 +223,7 @@ class CorrelationFunctionMatrix(Saveable):
         temp = self._check_temperature_consistency()
         return temp
 
-    def get_correlation_function(self, n: int, m: int) -> Any:
+    def get_correlation_function(self, n: int, m: int) -> Any:  # type: ignore[explicit-any]
         """Returns correlation function associated with sites n and m
 
         Parameters
@@ -234,7 +234,7 @@ class CorrelationFunctionMatrix(Saveable):
         # return self.data[self.cpointer[n,m],:]
         return self.cfuncs[self.cpointer[n, m]]
 
-    def get_reorganization_energy(self, n: int, m: int) -> float | numpy.ndarray:
+    def get_reorganization_energy(self, n: int, m: int) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns reorganization energie in the site basis"""
         # FIXME: should this use _A2  ????
         assert self.lambdas is not None
@@ -261,7 +261,7 @@ class CorrelationFunctionMatrix(Saveable):
             return lm
         raise QuantarheiError("Correlation function matrix is not initialized.")
 
-    def get_coft(self, n: int, m: int) -> numpy.ndarray:
+    def get_coft(self, n: int, m: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns correlation function corresponding to two states n and m
 
         Parameters
@@ -272,7 +272,7 @@ class CorrelationFunctionMatrix(Saveable):
         assert self._cofts is not None
         return self._cofts[self.cpointer[n, m], :]
 
-    def get_hoft(self, n: int, m: int) -> numpy.ndarray:
+    def get_hoft(self, n: int, m: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns first integral of the correlation function from the matrix
 
         Parameters
@@ -283,7 +283,7 @@ class CorrelationFunctionMatrix(Saveable):
         assert self._hofts is not None
         return self._hofts[self.cpointer[n, m], :]
 
-    def get_goft(self, n: int, m: int) -> numpy.ndarray:
+    def get_goft(self, n: int, m: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the lineshape function from the matrix
 
         Parameters
@@ -294,7 +294,7 @@ class CorrelationFunctionMatrix(Saveable):
         assert self._gofts is not None
         return self._gofts[self.cpointer[n, m], :]
 
-    def get_coft4(self, a: int, b: int, c: int, d: int) -> numpy.ndarray:
+    def get_coft4(self, a: int, b: int, c: int, d: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         if self._is_transformed:
             assert self._A4 is not None
             assert self._cofts is not None
@@ -304,7 +304,7 @@ class CorrelationFunctionMatrix(Saveable):
             return ret
         raise QuantarheiError()
 
-    def get_coft_matrix(self, t: float | None = None) -> numpy.ndarray:
+    def get_coft_matrix(self, t: float | None = None) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns full matrix of correlation functions
 
         It is expected that the matrix is transformed into new basis after
@@ -328,7 +328,7 @@ class CorrelationFunctionMatrix(Saveable):
                 # FIXME: some consistent treatment of the cutoff time is needed
                 Nt = self._cofts.shape[1]
 
-                ret: numpy.ndarray = numpy.zeros(
+                ret: numpy.ndarray = numpy.zeros(  # type: ignore[explicit-any]
                     (nos, nos, nos, nos, Nt), dtype=COMPLEX
                 )
                 # for k in range(self.nof):
@@ -349,7 +349,7 @@ class CorrelationFunctionMatrix(Saveable):
             return ret
         raise QuantarheiError()
 
-    def get_hoft4(self, a: int, b: int, c: int, d: int) -> numpy.ndarray:
+    def get_hoft4(self, a: int, b: int, c: int, d: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         if self._is_transformed:
             assert self._A4 is not None
             assert self._hofts is not None
@@ -359,7 +359,7 @@ class CorrelationFunctionMatrix(Saveable):
             return ret
         raise QuantarheiError()
 
-    def get_hoft_matrix(self, t: float | None = None) -> numpy.ndarray:
+    def get_hoft_matrix(self, t: float | None = None) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns full matrix of once integrated correlation functions
 
         It is expected that the matrix is transformed into new basis after
@@ -384,7 +384,7 @@ class CorrelationFunctionMatrix(Saveable):
                 # FIXME: some consistent treatment of the cutoff time is needed
                 Nt = self._cofts.shape[1]
 
-                ret: numpy.ndarray = numpy.zeros(
+                ret: numpy.ndarray = numpy.zeros(  # type: ignore[explicit-any]
                     (nos, nos, nos, nos, Nt), dtype=COMPLEX
                 )
                 # for k in range(self.nof):
@@ -404,7 +404,7 @@ class CorrelationFunctionMatrix(Saveable):
             return ret
         raise QuantarheiError()
 
-    def get_goft4(self, a: int, b: int, c: int, d: int) -> numpy.ndarray:
+    def get_goft4(self, a: int, b: int, c: int, d: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the matrix of the goft functions"""
         if self._is_transformed:
             assert self._A4 is not None
@@ -415,7 +415,7 @@ class CorrelationFunctionMatrix(Saveable):
             return ret
         raise QuantarheiError()
 
-    def get_goft_matrix(self, t: float | None = None) -> numpy.ndarray:
+    def get_goft_matrix(self, t: float | None = None) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns full matrix of lineshape functions
 
         It is expected that the matrix is transformed into new basis after
@@ -440,7 +440,7 @@ class CorrelationFunctionMatrix(Saveable):
                 # FIXME: some consistent treatment of the cutoff time is needed
                 Nt = self._cofts.shape[1]
 
-                ret: numpy.ndarray = numpy.zeros(
+                ret: numpy.ndarray = numpy.zeros(  # type: ignore[explicit-any]
                     (nos, nos, nos, nos, Nt), dtype=COMPLEX
                 )
                 # for k in range(self.nof):
@@ -460,7 +460,7 @@ class CorrelationFunctionMatrix(Saveable):
             return ret
         raise QuantarheiError()
 
-    def set_correlation_function(
+    def set_correlation_function(  # type: ignore[explicit-any]
         self, fce: Any, where: list, iof: int | None = None
     ) -> int:
         """Sets a correlation function to the matrix
@@ -530,7 +530,7 @@ class CorrelationFunctionMatrix(Saveable):
 
         return ret
 
-    def _update_where(self, iof: int, fce: Any, where: list) -> None:
+    def _update_where(self, iof: int, fce: Any, where: list) -> None:  # type: ignore[explicit-any]
         """Updates the location information for a correlation function"""
         assert self.where is not None
         assert self._A2 is not None
@@ -579,7 +579,7 @@ class CorrelationFunctionMatrix(Saveable):
     def init_site_mapping(self) -> None:
         """Initializes the internals to allow four-index correlation functions"""
         nos = self.nob + 1
-        one: numpy.ndarray = numpy.eye(nos, dtype=REAL)
+        one: numpy.ndarray = numpy.eye(nos, dtype=REAL)  # type: ignore[explicit-any]
 
         self.transform(one)
 
@@ -588,7 +588,7 @@ class CorrelationFunctionMatrix(Saveable):
     #   TO BE TRANSPLANTED TO OPEN SYSTEMS
     #
     #
-    def transform(self, SS: numpy.ndarray) -> None:
+    def transform(self, SS: numpy.ndarray) -> None:  # type: ignore[explicit-any]
         """Transform the system-bath interaction characteristics"""
         # FIXME: This must go somewhere alse. It is system dependent
 
@@ -597,7 +597,7 @@ class CorrelationFunctionMatrix(Saveable):
         nof = self.nof
 
         self._A4 = numpy.zeros((nos, nos, nos, nos, nof), dtype=REAL)
-        self._C4: numpy.ndarray = numpy.zeros((nos, nos, nos, nos, nos), dtype=REAL)
+        self._C4: numpy.ndarray = numpy.zeros((nos, nos, nos, nos, nos), dtype=REAL)  # type: ignore[explicit-any]
 
         assert self._A2 is not None
         for a in range(nos):

--- a/quantarhei/qm/corfunctions/correlationfunctions.py
+++ b/quantarhei/qm/corfunctions/correlationfunctions.py
@@ -106,12 +106,12 @@ class CorrelationFunction(DFunction, UnitsManaged):
     )
 
     energy_units: str
-    lamb: float | numpy.ndarray
-    temperature: float | numpy.ndarray
+    lamb: float | numpy.ndarray  # type: ignore[explicit-any]
+    temperature: float | numpy.ndarray  # type: ignore[explicit-any]
     axis: TimeAxis
 
     @enforce_energy_units_context
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, axis: Any = None, params: Any = None, values: Any = None
     ) -> None:
         super().__init__()
@@ -245,9 +245,9 @@ class CorrelationFunction(DFunction, UnitsManaged):
         temp = self.temperature if hasattr(self, "temperature") else None
         return f"CorrelationFunction(ftype={ftype!r}, T={temp})"
 
-    def _matsubara(self, kBT: float, ctime: float, nof: int) -> numpy.ndarray:
+    def _matsubara(self, kBT: float, ctime: float, nof: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Matsubara frequency part of the Brownian correlation function"""
-        msf: float | numpy.ndarray = 0.0
+        msf: float | numpy.ndarray = 0.0  # type: ignore[explicit-any]
         nut = 2.0 * numpy.pi * kBT
         time = self.axis.data
         for i in range(0, nof):
@@ -368,7 +368,7 @@ class CorrelationFunction(DFunction, UnitsManaged):
         # check temperature and update cutoff time
         self._set_temperature_and_cutoff_time(temperature, 5.0 / ctime)
 
-    def _make_underdamped(self, params: dict, values: Any = None) -> None:
+    def _make_underdamped(self, params: dict, values: Any = None) -> None:  # type: ignore[explicit-any]
         from .spectraldensities import SpectralDensity
 
         temperature = params["T"]
@@ -397,7 +397,7 @@ class CorrelationFunction(DFunction, UnitsManaged):
         # check temperature and update cutoff time
         self._set_temperature_and_cutoff_time(temperature, 5.0 * ctime)
 
-    def _make_B777(self, params: dict, values: Any = None) -> None:
+    def _make_B777(self, params: dict, values: Any = None) -> None:  # type: ignore[explicit-any]
         from .spectraldensities import SpectralDensity
 
         temperature = params["T"]
@@ -426,7 +426,7 @@ class CorrelationFunction(DFunction, UnitsManaged):
         # check temperature and update cutoff time
         self._set_temperature_and_cutoff_time(temperature, 5.0 * ctime)
 
-    def _make_CP29_spectral_density(self, params: dict, values: Any = None) -> None:
+    def _make_CP29_spectral_density(self, params: dict, values: Any = None) -> None:  # type: ignore[explicit-any]
         from .spectraldensities import SpectralDensity
 
         temperature = params["T"]
@@ -456,7 +456,7 @@ class CorrelationFunction(DFunction, UnitsManaged):
         # check temperature and update cutoff time
         self._set_temperature_and_cutoff_time(temperature, 5.0 * ctime)
 
-    def _make_value_defined(self, params: dict, values: Any) -> None:
+    def _make_value_defined(self, params: dict, values: Any) -> None:  # type: ignore[explicit-any]
 
         lamb = params["reorg"]
         temperature = params["T"]
@@ -598,23 +598,23 @@ class CorrelationFunction(DFunction, UnitsManaged):
         by analytical formula. Returns `False` if the object was constructed
         by numerical transformation from spectral density.
         """
-        return bool(cast(dict[str, Any], self.params)["ftype"] in self.analytical_types)
+        return bool(cast(dict[str, Any], self.params)["ftype"] in self.analytical_types)  # type: ignore[explicit-any]
 
-    def get_temperature(self) -> float | numpy.ndarray:
+    def get_temperature(self) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the temperature of the correlation function"""
         return self.temperature
 
-    def get_reorganization_energy(self) -> float | numpy.ndarray:
+    def get_reorganization_energy(self) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the reorganization energy of the correlation function"""
         return self.convert_energy_2_current_u(self.lamb)
 
-    def get_correlation_time(self) -> float | numpy.ndarray:
+    def get_correlation_time(self) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns correlation time associated with the first component
         of the bath correlation function
         """
         return self.params[0]["cortime"]
 
-    def measure_reorganization_energy(self) -> float | numpy.ndarray:
+    def measure_reorganization_energy(self) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates the reorganization energy of the correlation function
 
         Calculates the reorganization energy of the correlation function by
@@ -632,7 +632,7 @@ class CorrelationFunction(DFunction, UnitsManaged):
             cfce = CorrelationFunction(self.axis, self.params)
         return cfce
 
-    def get_SpectralDensity(self, fa: FrequencyAxis | None = None) -> Any:
+    def get_SpectralDensity(self, fa: FrequencyAxis | None = None) -> Any:  # type: ignore[explicit-any]
         """Returns a SpectralDensity corresponding to this CorrelationFunction.
         If a FrequencyAxis object is included, the SpectralDensity
         object will be returned with that FrequencyAxis instance as its
@@ -726,7 +726,7 @@ class LineshapeFunction(DFunction, UnitsManaged):
     """
 
     @enforce_energy_units_context
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, axis: Any = None, params: Any = None, values: Any = None, lfactor: int = 1
     ) -> None:
         self.lfactor = lfactor
@@ -783,7 +783,7 @@ class FTCorrelationFunction(DFunction, UnitsManaged):
 
     energy_params = ("reorg", "omega", "freq")
 
-    def __init__(self, axis: Any, params: Any, values: Any = None) -> None:
+    def __init__(self, axis: Any, params: Any, values: Any = None) -> None:  # type: ignore[explicit-any]
         super().__init__()
 
         if not isinstance(axis, FrequencyAxis):
@@ -793,7 +793,7 @@ class FTCorrelationFunction(DFunction, UnitsManaged):
             self.axis = axis
 
         # handle params
-        self.params: (
+        self.params: (  # type: ignore[explicit-any]
             list[Any] | dict[Any, Any]
         ) = []  # this will always be a list of components
         p2calc = []
@@ -870,7 +870,7 @@ class OddFTCorrelationFunction(DFunction, UnitsManaged):
 
     """
 
-    def __init__(self, axis: Any, params: Any, values: Any = None) -> None:
+    def __init__(self, axis: Any, params: Any, values: Any = None) -> None:  # type: ignore[explicit-any]
         super().__init__()
 
         if not isinstance(axis, FrequencyAxis):
@@ -946,7 +946,7 @@ class EvenFTCorrelationFunction(DFunction, UnitsManaged):
 
     """
 
-    def __init__(self, axis: Any, params: Any, values: Any = None) -> None:
+    def __init__(self, axis: Any, params: Any, values: Any = None) -> None:  # type: ignore[explicit-any]
         super().__init__()
 
         if not isinstance(axis, FrequencyAxis):
@@ -997,7 +997,7 @@ class EvenFTCorrelationFunction(DFunction, UnitsManaged):
 
 
 # FIXME: these functions can go to DFunction
-def c2g(timeaxis: TimeAxis, coft: numpy.ndarray) -> numpy.ndarray:
+def c2g(timeaxis: TimeAxis, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Converts correlation function to lineshape function
 
     Explicit numerical double integration of the correlation
@@ -1025,7 +1025,7 @@ def c2g(timeaxis: TimeAxis, coft: numpy.ndarray) -> numpy.ndarray:
     return goft
 
 
-def c2h(timeaxis: TimeAxis, coft: numpy.ndarray) -> numpy.ndarray:
+def c2h(timeaxis: TimeAxis, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Integrates correlation function in time with an open upper limit
 
     Explicit numerical integration of the correlation
@@ -1050,7 +1050,7 @@ def c2h(timeaxis: TimeAxis, coft: numpy.ndarray) -> numpy.ndarray:
     return hoft
 
 
-def h2g(timeaxis: TimeAxis, coft: numpy.ndarray) -> numpy.ndarray:
+def h2g(timeaxis: TimeAxis, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Integrates and integrated correlation function
 
     Explicit numerical integration of the correlation

--- a/quantarhei/qm/corfunctions/distributions.py
+++ b/quantarhei/qm/corfunctions/distributions.py
@@ -6,6 +6,6 @@ import numpy
 
 
 class BoseEinsteinDistribution:
-    def __init__(self, freq_axis: Any, temperature: float) -> None:
+    def __init__(self, freq_axis: Any, temperature: float) -> None:  # type: ignore[explicit-any]
         kBT = temperature
         self.data = 1.0 / (numpy.exp(freq_axis.data / kBT) - 1.0)

--- a/quantarhei/qm/corfunctions/functionstorage.py
+++ b/quantarhei/qm/corfunctions/functionstorage.py
@@ -9,7 +9,7 @@ from ...core.time import TimeAxis
 from ...exceptions import QuantarheiError
 
 
-def _normalize_integrals(integrals: Any) -> list[str]:
+def _normalize_integrals(integrals: Any) -> list[str]:  # type: ignore[explicit-any]
     """Return a stable list of integral-time labels from config metadata."""
     if integrals is None:
         return []
@@ -55,7 +55,7 @@ def _parse_time_label(label: str) -> list[tuple[int, str]]:
     return terms
 
 
-def _generate_time_argument_labels(response_times: dict[str, Any]) -> list[str]:
+def _generate_time_argument_labels(response_times: dict[str, Any]) -> list[str]:  # type: ignore[explicit-any]
     """Generate all supported line-shape-function time arguments.
 
     The ordinary arguments are all non-empty ordered combinations of response
@@ -102,7 +102,7 @@ def _generate_time_argument_labels(response_times: dict[str, Any]) -> list[str]:
     return unique_labels
 
 
-def _default_storage_config(one_jump: bool = False) -> dict[str, Any]:
+def _default_storage_config(one_jump: bool = False) -> dict[str, Any]:  # type: ignore[explicit-any]
     """Return the standard third-order response storage configuration."""
     t2_integral = {"s2"} if one_jump else None
     return {
@@ -129,7 +129,7 @@ class FunctionStorage:
 
     import numpy
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         N: int = 1,
         timeaxis: Any = None,
@@ -143,7 +143,7 @@ class FunctionStorage:
         #
         # This dictionary describes what g(t) values will be stored and how
         #
-        self.config: dict[str, Any]
+        self.config: dict[str, Any]  # type: ignore[explicit-any]
         if config is None or config == 0:
             self.config = _default_storage_config(one_jump=False)
         elif config == 1:
@@ -281,7 +281,7 @@ class FunctionStorage:
         # Storage dimensions; they correspond to the submitted time axes
         if isinstance(timeaxis, TimeAxis):
             self.Ndim = 1
-            dim_arr: numpy.ndarray = numpy.zeros(self.Ndim, dtype=numpy.int32)
+            dim_arr: numpy.ndarray = numpy.zeros(self.Ndim, dtype=numpy.int32)  # type: ignore[explicit-any]
             dim_arr[0] = timeaxis.length
         else:
             self.Ndim = len(timeaxis)
@@ -308,7 +308,7 @@ class FunctionStorage:
         # self.time_index = {"t2":-1,"t1":0,"t1+t2":0, "t3":1,"t2+t3":1,"t1+t3":(0,1),"t1+t2+t3":(0,1)}
         self.time_index = time_index
 
-        reshapes: dict[str, list[Any]] = dict()
+        reshapes: dict[str, list[Any]] = dict()  # type: ignore[explicit-any]
         for dms in self.time_index:
             val = self.time_index[dms]
             if isinstance(val, int):
@@ -389,13 +389,13 @@ class FunctionStorage:
 
         # 2D view of the data for fast access
         self._data2d = self.data.reshape((self.N, self.data_stride))
-        self._last_reset_values: dict[str, Any] | None = None
+        self._last_reset_values: dict[str, Any] | None = None  # type: ignore[explicit-any]
         self._data_initialized = False
 
         #
         # Here the g(t) functions are stored
         #
-        self.funcs: dict[Any, Any] = {}
+        self.funcs: dict[Any, Any] = {}  # type: ignore[explicit-any]
 
         # The number of stored functions
         self.Nf = 0
@@ -452,7 +452,7 @@ class FunctionStorage:
             + self.size_units
         )
 
-    def __setitem__(self, index: Any, value: Any) -> None:
+    def __setitem__(self, index: Any, value: Any) -> None:  # type: ignore[explicit-any]
         """Set the value(s) of the storage"""
         if isinstance(index, tuple):
             if len(index) == 2:
@@ -475,7 +475,7 @@ class FunctionStorage:
         else:
             raise QuantarheiError()
 
-    def __getitem__(self, index: Any) -> Any:
+    def __getitem__(self, index: Any) -> Any:  # type: ignore[explicit-any]
         """Returns the stored function"""
         if isinstance(index, tuple):
             if len(index) == 2:
@@ -529,7 +529,7 @@ class FunctionStorage:
         else:
             raise QuantarheiError()
 
-    def set_goft(self, N: Any, func: Any = None) -> None:
+    def set_goft(self, N: Any, func: Any = None) -> None:  # type: ignore[explicit-any]
         """Sets the values for a given stored function."""
         #
         # The argument N must be an integer or a list of indices by which the function should
@@ -543,7 +543,7 @@ class FunctionStorage:
         #
         # Check the consistency of the submitted time axes
         #
-        self.ta: list[Any] = []  # This is a synonym for the self.timeaxis
+        self.ta: list[Any] = []  # type: ignore[explicit-any]  # This is a synonym for the self.timeaxis
         if isinstance(self.timeaxis, (tuple, list)):
             self.ta = list(self.timeaxis)
             # self.t1a = self.timeaxis[0]
@@ -624,7 +624,7 @@ class FunctionStorage:
             # make larger variables the object properties
             self.mapping = mapping
 
-    def _fce_already_stored(self, func: Any) -> int:
+    def _fce_already_stored(self, func: Any) -> int:  # type: ignore[explicit-any]
         """If the function was already stored in the object, the function returns its position,
         otherwise it returns -1.
 
@@ -695,7 +695,7 @@ class FunctionStorage:
                 elif len(tt_dim) == 1:
                     tt += sign * self.ta[axis].data
                 else:
-                    index_list: list[slice | None] = [None] * len(tt_dim)
+                    index_list: list[slice | None] = [None] * len(tt_dim)  # type: ignore[explicit-any]
                     index_list[axes.index(axis)] = _colon_
                     tt += sign * self.ta[axis].data.__getitem__(tuple(index_list))
 
@@ -747,7 +747,7 @@ class FunctionStorage:
         """Returns the number of assigned sites"""
         return (self.mapping >= 0).sum()
 
-    def get_mapping_matrix(self) -> numpy.ndarray:
+    def get_mapping_matrix(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns a matrix that maps site index on the function index
 
 
@@ -776,7 +776,7 @@ class FunctionStorage:
 
         return mtrx
 
-    def get_reorganization_energies(self) -> numpy.ndarray:
+    def get_reorganization_energies(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the estimate of the reoganization energies of the stored functions"""
         label = "t1"
         axis = self.ta[0]
@@ -821,7 +821,7 @@ class FastFunctionStorage(FunctionStorage):
         three-time (t1, t2, t3) configuration is used.
     """
 
-    def __getitem__(self, index: Any) -> Any:
+    def __getitem__(self, index: Any) -> Any:  # type: ignore[explicit-any]
         i, j = index
 
         # if the index is integer
@@ -847,7 +847,7 @@ class FastFunctionStorage(FunctionStorage):
 class SingleGoft(FunctionStorage):
     """Storage of a single lineshape function"""
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any = None,
         dtype: Any = numpy.complex64,
@@ -858,7 +858,7 @@ class SingleGoft(FunctionStorage):
             N=1, timeaxis=timeaxis, dtype=dtype, show_config=show_config, config=config
         )
 
-    def __getitem__(self, index: Any) -> Any:
+    def __getitem__(self, index: Any) -> Any:  # type: ignore[explicit-any]
         """Returns the stored function"""
         j = index
         start = 0

--- a/quantarhei/qm/corfunctions/spectraldensities.py
+++ b/quantarhei/qm/corfunctions/spectraldensities.py
@@ -109,7 +109,7 @@ class SpectralDensity(DFunction, UnitsManaged):
     )
     analytical_types = "OverdampedBrownian"
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, axis: Any = None, params: Any = None, values: Any = None
     ) -> None:
         super().__init__()
@@ -206,7 +206,7 @@ class SpectralDensity(DFunction, UnitsManaged):
         ftype = self.params[0]["ftype"] if self.params else "unknown"
         return f"SpectralDensity(ftype={ftype!r})"
 
-    def _make_overdamped_brownian(self, params: dict, values: Any = None) -> None:
+    def _make_overdamped_brownian(self, params: dict, values: Any = None) -> None:  # type: ignore[explicit-any]
         """Sets the Overdamped Brownian oscillator spectral density"""
         try:
             ctime = params["cortime"]
@@ -234,7 +234,7 @@ class SpectralDensity(DFunction, UnitsManaged):
         for i in range(2):
             self.lim_omega[i] += lim_omega[i]
 
-    def _make_underdamped_brownian(self, params: dict, values: Any = None) -> None:
+    def _make_underdamped_brownian(self, params: dict, values: Any = None) -> None:  # type: ignore[explicit-any]
 
         # temperature = params["T"]
         ctime = params["gamma"]
@@ -269,7 +269,7 @@ class SpectralDensity(DFunction, UnitsManaged):
             self.lim_omega[i] += lim_omega[i]
 
     # See Valkunas, Abramavicius, Mančal, 2013, Wiley-VCH
-    def _make_underdamped(self, params: dict, values: Any = None) -> None:
+    def _make_underdamped(self, params: dict, values: Any = None) -> None:  # type: ignore[explicit-any]
         SPEED_OF_LIGHT = 2.99 * (10**8)
 
         # use the units in which params was defined
@@ -300,11 +300,11 @@ class SpectralDensity(DFunction, UnitsManaged):
     # See Renger, Journal of Chemical Physics 2002
     # See Jang, Newton, Silbey, J Chem Phys. 2007 for alternate form
     # (See Kell et al, 2013, J. Phys. Chem. B.)
-    def _make_B777(self, params: dict, values: Any = None) -> None:
+    def _make_B777(self, params: dict, values: Any = None) -> None:  # type: ignore[explicit-any]
 
         with energy_units("int"):
             omega = self.axis.data
-            cfce: Any = 0
+            cfce: Any = 0  # type: ignore[explicit-any]
 
             if not params["alternative_form"]:
                 try:
@@ -364,7 +364,7 @@ class SpectralDensity(DFunction, UnitsManaged):
         self.lim_omega[0] = 0.0
         self.lim_omega[1] = 0.0
 
-    def _make_CP29_spectral_density(self, params: dict, values: Any = None) -> None:
+    def _make_CP29_spectral_density(self, params: dict, values: Any = None) -> None:  # type: ignore[explicit-any]
         # This pectral density is based on the one calculated from FLN by
         # Rätsep et al. J. Phys. Chem. B 2008, 112, 110-118. It consist of a
         # Gaussian on the low-frequency side and a Lagrangian on the high-frequency
@@ -416,7 +416,7 @@ class SpectralDensity(DFunction, UnitsManaged):
         self.lim_omega[0] = 0.0
         self.lim_omega[1] = 0.0
 
-    def _make_value_defined(self, values: Any = None) -> None:
+    def _make_value_defined(self, values: Any = None) -> None:  # type: ignore[explicit-any]
         """Value defined spectral density"""
         if values is None:
             raise QuantarheiError()
@@ -529,7 +529,7 @@ class SpectralDensity(DFunction, UnitsManaged):
             return self.temperature
         raise QuantarheiError("SpectralDensity was not assigned temperature")
 
-    def get_reorganization_energy(self) -> float | numpy.ndarray:
+    def get_reorganization_energy(self) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the reorganization energy of the cspectral density"""
         return self.convert_energy_2_current_u(self.lamb)
 
@@ -557,7 +557,7 @@ class SpectralDensity(DFunction, UnitsManaged):
         """Creates a copy of the current correlation function"""
         return SpectralDensity(self.axis, self.params)
 
-    def get_CorrelationFunction(
+    def get_CorrelationFunction(  # type: ignore[explicit-any]
         self, temperature: float | None = None, ta: Any = None
     ) -> CorrelationFunction:
         """Returns correlation function corresponding to the spectral density.

--- a/quantarhei/qm/hilbertspace/dmoment.py
+++ b/quantarhei/qm/hilbertspace/dmoment.py
@@ -13,7 +13,9 @@ from .operators import SelfAdjointOperator
 
 
 class TransitionDipoleMoment(SelfAdjointOperator, BasisManaged):
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:  # type: ignore[explicit-any]
+    def __init__(
+        self, dim: int | None = None, data: numpy.ndarray | None = None
+    ) -> None:  # type: ignore[explicit-any]
 
         if not ((dim is None) and (data is None)):
             # Set the currently used basis

--- a/quantarhei/qm/hilbertspace/dmoment.py
+++ b/quantarhei/qm/hilbertspace/dmoment.py
@@ -13,7 +13,7 @@ from .operators import SelfAdjointOperator
 
 
 class TransitionDipoleMoment(SelfAdjointOperator, BasisManaged):
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:
+    def __init__(self, dim: int | None = None, data: Any = None) -> None:  # type: ignore[explicit-any]
 
         if not ((dim is None) and (data is None)):
             # Set the currently used basis
@@ -47,7 +47,7 @@ class TransitionDipoleMoment(SelfAdjointOperator, BasisManaged):
         )
         return (a and b) and c
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """This function transforms the Operator into a different basis, using
         a given transformation matrix.
         """
@@ -59,7 +59,7 @@ class TransitionDipoleMoment(SelfAdjointOperator, BasisManaged):
         for i in range(3):
             self._data[:, :, i] = numpy.dot(S1, numpy.dot(self._data[:, :, i], SS))
 
-    def dipole_strength(
+    def dipole_strength(  # type: ignore[explicit-any]
         self,
         from_state: int | None = None,
         to_state: int | None = None,
@@ -88,7 +88,7 @@ class TransitionDipoleMoment(SelfAdjointOperator, BasisManaged):
             d[i] = self.data[fstate, tstate, i]
         return numpy.dot(d, d)
 
-    def get_compoment_data(self, n: int) -> numpy.ndarray:
+    def get_compoment_data(self, n: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns a component data of the transition dipole moment operator"""
         return self.data[:, :, n]
 

--- a/quantarhei/qm/hilbertspace/dmoment.py
+++ b/quantarhei/qm/hilbertspace/dmoment.py
@@ -13,9 +13,9 @@ from .operators import SelfAdjointOperator
 
 
 class TransitionDipoleMoment(SelfAdjointOperator, BasisManaged):
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, dim: int | None = None, data: numpy.ndarray | None = None
-    ) -> None:  # type: ignore[explicit-any]
+    ) -> None:
 
         if not ((dim is None) and (data is None)):
             # Set the currently used basis

--- a/quantarhei/qm/hilbertspace/evolutionoperator.py
+++ b/quantarhei/qm/hilbertspace/evolutionoperator.py
@@ -4,7 +4,7 @@ from typing import Any
 
 
 class EvolutionOperator:
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any,
         dim: int | None = None,
@@ -17,7 +17,7 @@ class EvolutionOperator:
 
         pass
 
-    def apply(opvec: Any) -> Any:
+    def apply(opvec: Any) -> Any:  # type: ignore[explicit-any]
         """Apply the evolution operator to an operator or state vector
 
         Returns
@@ -27,7 +27,7 @@ class EvolutionOperator:
         """
         pass
 
-    def apply_left(opvec: Any) -> Any:
+    def apply_left(opvec: Any) -> Any:  # type: ignore[explicit-any]
         """Apply the evolution operator to an operator or vector on the left
 
         Returns

--- a/quantarhei/qm/hilbertspace/hamiltonian.py
+++ b/quantarhei/qm/hilbertspace/hamiltonian.py
@@ -32,11 +32,11 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
     """
 
     _has_remainder_coupling = False
-    JR: numpy.ndarray
+    JR: numpy.ndarray  # type: ignore[explicit-any]
 
     data = ManagedRealArray("data")
 
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:
+    def __init__(self, dim: int | None = None, data: Any = None) -> None:  # type: ignore[explicit-any]
         # self.data = data
         # FIXME: how to avoid the Operator breaking the EnergyUnits management ????
         if not ((dim is None) and (data is None)):
@@ -47,15 +47,15 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
                     "to be represented by a selfadjoint matrix"
                 )
 
-        self.rwa_indices: numpy.ndarray | None = None
-        self.rwa_energies: Any = None
+        self.rwa_indices: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.rwa_energies: Any = None  # type: ignore[explicit-any]
         self.has_rwa = False
         # In future, the Hamiltonian should have a block structure
         # reflected in the data storage, for now we are fine just with
         # knowing that the blocks are there
         self.Nblocks = 1
 
-    def set_rwa(self, rwa_indices: Any, rwa_energy: float | None = None) -> None:
+    def set_rwa(self, rwa_indices: Any, rwa_energy: float | None = None) -> None:  # type: ignore[explicit-any]
         """Set the block indices for the Rotating Wave Approximation (RWA).
 
         Parameters
@@ -112,7 +112,7 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
 
         # average energies in every block
         with energy_units("int"):
-            en_block: numpy.ndarray = numpy.zeros(self.Nblocks, dtype=REAL)
+            en_block: numpy.ndarray = numpy.zeros(self.Nblocks, dtype=REAL)  # type: ignore[explicit-any]
             for block in range(self.Nblocks):
                 if block < self.Nblocks - 1:
                     upper = self.rwa_indices[block + 1]
@@ -141,7 +141,7 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
         # we have information on RWA
         self.has_rwa = True
 
-    def get_RWA_skeleton(self) -> numpy.ndarray:
+    def get_RWA_skeleton(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the Hamiltonian matrix with RWA energies"""
         HH = self.data
         shape = HH.shape[0]
@@ -150,11 +150,11 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
             HOmega[ii] = self.convert_2_current_u(self.rwa_energies[ii])
         return HOmega
 
-    def get_RWA_data(self) -> numpy.ndarray:
+    def get_RWA_data(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns Hamiltonian matrix with RWA energies subtracted"""
         return self.data - numpy.diag(self.get_RWA_skeleton())
 
-    def diagonalize(self, coupling_cutoff: float | None = None) -> Any:
+    def diagonalize(self, coupling_cutoff: float | None = None) -> Any:  # type: ignore[explicit-any]
         """Diagonalizes the Hamiltonian matrix
 
         Parameters
@@ -226,7 +226,7 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
         if coupling_cutoff < 0.0:
             raise QuantarheiError("Coupling cutoff value must be positive")
 
-        JR: numpy.ndarray = numpy.zeros((self.dim, self.dim), dtype=REAL)
+        JR: numpy.ndarray = numpy.zeros((self.dim, self.dim), dtype=REAL)  # type: ignore[explicit-any]
         # go through all couplings and remove small ones
         for ii in range(self.dim):
             for jj in range(ii + 1, self.dim):
@@ -238,7 +238,7 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
         self.JR = JR
         self._has_remainder_coupling = True
 
-    def subtract_cutoff_coupling(self, coupling_cutoff: Any) -> None:
+    def subtract_cutoff_coupling(self, coupling_cutoff: Any) -> None:  # type: ignore[explicit-any]
         """Subtracts the cut-off coupling from all coupling elements
 
         We supress the couplings by a given amount. If the coupling is
@@ -268,7 +268,7 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
 
             coupcut = self.convert_2_internal_u(coupling_cutoff)
 
-            JR: numpy.ndarray = numpy.zeros((self.dim, self.dim), dtype=REAL)
+            JR: numpy.ndarray = numpy.zeros((self.dim, self.dim), dtype=REAL)  # type: ignore[explicit-any]
             # go through all couplings and remove small ones
             for ii in range(self.dim):
                 for jj in range(ii + 1, self.dim):
@@ -304,7 +304,7 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
             self.JR[:, :] = 0.0
             self._has_remainder_coupling = False
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """Transformation of the Hamiltonian and the remainder coupling
 
 
@@ -363,7 +363,7 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
         return out
 
 
-def _find_band(x: int, starts: Any) -> int:
+def _find_band(x: int, starts: Any) -> int:  # type: ignore[explicit-any]
     """Given an integer x and a sorted list of interval starts (starting with 0),
     returns the index of the interval x belongs to.
 

--- a/quantarhei/qm/hilbertspace/hamiltonian.py
+++ b/quantarhei/qm/hilbertspace/hamiltonian.py
@@ -36,7 +36,9 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
 
     data = ManagedRealArray("data")
 
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:  # type: ignore[explicit-any]
+    def __init__(
+        self, dim: int | None = None, data: numpy.ndarray | None = None
+    ) -> None:  # type: ignore[explicit-any]
         # self.data = data
         # FIXME: how to avoid the Operator breaking the EnergyUnits management ????
         if not ((dim is None) and (data is None)):
@@ -48,14 +50,16 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
                 )
 
         self.rwa_indices: numpy.ndarray | None = None  # type: ignore[explicit-any]
-        self.rwa_energies: Any = None  # type: ignore[explicit-any]
+        self.rwa_energies: numpy.ndarray | None = None  # type: ignore[explicit-any]
         self.has_rwa = False
         # In future, the Hamiltonian should have a block structure
         # reflected in the data storage, for now we are fine just with
         # knowing that the blocks are there
         self.Nblocks = 1
 
-    def set_rwa(self, rwa_indices: Any, rwa_energy: float | None = None) -> None:  # type: ignore[explicit-any]
+    def set_rwa(
+        self, rwa_indices: list[int] | numpy.ndarray, rwa_energy: float | None = None
+    ) -> None:  # type: ignore[explicit-any]
         """Set the block indices for the Rotating Wave Approximation (RWA).
 
         Parameters

--- a/quantarhei/qm/hilbertspace/hamiltonian.py
+++ b/quantarhei/qm/hilbertspace/hamiltonian.py
@@ -36,9 +36,9 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
 
     data = ManagedRealArray("data")
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, dim: int | None = None, data: numpy.ndarray | None = None
-    ) -> None:  # type: ignore[explicit-any]
+    ) -> None:
         # self.data = data
         # FIXME: how to avoid the Operator breaking the EnergyUnits management ????
         if not ((dim is None) and (data is None)):
@@ -57,9 +57,9 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
         # knowing that the blocks are there
         self.Nblocks = 1
 
-    def set_rwa(
+    def set_rwa(  # type: ignore[explicit-any]
         self, rwa_indices: list[int] | numpy.ndarray, rwa_energy: float | None = None
-    ) -> None:  # type: ignore[explicit-any]
+    ) -> None:
         """Set the block indices for the Rotating Wave Approximation (RWA).
 
         Parameters

--- a/quantarhei/qm/hilbertspace/operators.py
+++ b/quantarhei/qm/hilbertspace/operators.py
@@ -35,11 +35,11 @@ class Operator(MatrixData, BasisManaged, Saveable):
         Human-readable label for the operator. Default is ``''``.
     """
 
-    _data: numpy.ndarray
+    _data: numpy.ndarray  # type: ignore[explicit-any]
     dim: int
     data = BasisManagedComplexArray("data")
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         dim: int | None = None,
         data: Any = None,
@@ -85,7 +85,7 @@ class Operator(MatrixData, BasisManaged, Saveable):
         """Addition of two operators. Returns a new Operator."""
         return Operator(data=self.data + other.data)
 
-    def apply(self, obj: Any) -> Any:
+    def apply(self, obj: Any) -> Any:  # type: ignore[explicit-any]
         """Apply the operator to vector or operator on the right"""
         if isinstance(obj, Operator):
             return Operator(data=numpy.dot(self.data, obj.data))
@@ -95,7 +95,7 @@ class Operator(MatrixData, BasisManaged, Saveable):
 
         raise QuantarheiError("Cannot apply operator to the object")
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """Transformation of the operator by a given matrix
 
 
@@ -122,7 +122,7 @@ class Operator(MatrixData, BasisManaged, Saveable):
         # S1 = scipy.linalg.inv(SS)
         self._data = numpy.dot(S1, numpy.dot(self._data, SS))
 
-    def assert_square_matrix(A: Any) -> bool:
+    def assert_square_matrix(A: Any) -> bool:  # type: ignore[explicit-any]
         if isinstance(A, numpy.ndarray):
             if A.ndim == 2:
                 if A.shape[0] == A.shape[1]:
@@ -167,7 +167,7 @@ class SelfAdjointOperator(Operator):
         If ``data`` is not self-adjoint.
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, dim: int | None = None, data: Any = None, name: str = ""
     ) -> None:
 
@@ -184,7 +184,7 @@ class SelfAdjointOperator(Operator):
             (numpy.isclose(numpy.transpose(numpy.conj(self.data)), self.data)).all()
         )
 
-    def diagonalize(self) -> numpy.ndarray:
+    def diagonalize(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         # first use is of "data", the rest of "_data"
         dd, SS = numpy.linalg.eigh(self.data)
         self._data = numpy.zeros(self._data.shape)
@@ -192,7 +192,7 @@ class SelfAdjointOperator(Operator):
             self._data[ii, ii] = dd[ii]
         return SS
 
-    def get_diagonalization_matrix(self) -> numpy.ndarray:
+    def get_diagonalization_matrix(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         dd, SS = numpy.linalg.eigh(self._data)
         return SS
 
@@ -208,7 +208,7 @@ class UnityOperator(SelfAdjointOperator):
     def __init__(self, dim: int | None = None, name: str = "") -> None:
         if dim is None:
             raise QuantarheiError("Dimension parameters 'dim' has to be specified")
-        series: numpy.ndarray = numpy.array([1 for i in range(dim)], dtype=COMPLEX)
+        series: numpy.ndarray = numpy.array([1 for i in range(dim)], dtype=COMPLEX)  # type: ignore[explicit-any]
         data = numpy.diag(series)
         super().__init__(dim=dim, data=data, name=name)
 
@@ -217,7 +217,7 @@ class BasisReferenceOperator(SelfAdjointOperator):
     def __init__(self, dim: int | None = None, name: str = "") -> None:
         if dim is None:
             raise QuantarheiError("Dimension parameters 'dim' has to be specified")
-        series: numpy.ndarray = numpy.array([i for i in range(dim)], dtype=REAL)
+        series: numpy.ndarray = numpy.array([i for i in range(dim)], dtype=REAL)  # type: ignore[explicit-any]
         data = numpy.diag(series)
         super().__init__(dim=dim, data=data, name=name)
 
@@ -254,7 +254,7 @@ class ProjectionOperator(Operator):
         else:
             raise QuantarheiError("Wrong operator dimension")
 
-    def __mult__(self, other: Any) -> numpy.ndarray:
+    def __mult__(self, other: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Multiplication of operator by scalar"""
         if isinstance(other, numbers.Number):
             self._data = self._data * other
@@ -262,7 +262,7 @@ class ProjectionOperator(Operator):
             raise QuantarheiError("Only multiplication by scalar is allowed")
         return self._data
 
-    def __rmult__(self, other: Any) -> numpy.ndarray:
+    def __rmult__(self, other: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Multiplication from right"""
         return self.__mult__(other)
 
@@ -289,7 +289,7 @@ class DensityMatrix(SelfAdjointOperator, Saveable):
         # using data because any transformation needed was already done
         self._data = self._data * (norm / tr)
 
-    def get_populations(self) -> numpy.ndarray:
+    def get_populations(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns a vector of diagonal elements of the density matrix"""
         # using self.data to allow transformation of the basis
         pvec = numpy.zeros(self.data.shape[0], dtype=REAL)
@@ -301,7 +301,7 @@ class DensityMatrix(SelfAdjointOperator, Saveable):
 
         return pvec
 
-    def excite_delta(
+    def excite_delta(  # type: ignore[explicit-any]
         self, dmoment: Any, epolarization: Any = None
     ) -> ReducedDensityMatrix:
         """Returns a density matrix obtained by delta-pulse excitation"""

--- a/quantarhei/qm/hilbertspace/operators.py
+++ b/quantarhei/qm/hilbertspace/operators.py
@@ -42,7 +42,7 @@ class Operator(MatrixData, BasisManaged, Saveable):
     def __init__(  # type: ignore[explicit-any]
         self,
         dim: int | None = None,
-        data: Any = None,
+        data: numpy.ndarray | None = None,
         real: bool = False,
         name: str = "",
     ) -> None:

--- a/quantarhei/qm/hilbertspace/oqsstatevector.py
+++ b/quantarhei/qm/hilbertspace/oqsstatevector.py
@@ -38,7 +38,7 @@ class OQSStateVector:
 
     """
 
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:
+    def __init__(self, dim: int | None = None, data: Any = None) -> None:  # type: ignore[explicit-any]
 
         self._initialized = False
 
@@ -61,11 +61,11 @@ class OQSStateVector:
             self.data = numpy.zeros(self.dim, dtype=REAL)
             self._initialized = True
 
-    def norm(self) -> Any:
+    def norm(self) -> Any:  # type: ignore[explicit-any]
         """Norm of the state vector"""
         return numpy.sqrt(numpy.dot(self.data, self.data))
 
-    def puredot(self, psi: OQSStateVector) -> Any:
+    def puredot(self, psi: OQSStateVector) -> Any:  # type: ignore[explicit-any]
         """Dot product concerning only the system part"""
         return numpy.dot(self.data, psi.data)
 
@@ -85,7 +85,7 @@ class OQSStateVector:
         Effectively it is in interaction picture.
 
         """
-        data: numpy.ndarray = numpy.zeros((self.dim, self.dim), dtype=REAL)
+        data: numpy.ndarray = numpy.zeros((self.dim, self.dim), dtype=REAL)  # type: ignore[explicit-any]
         rho = ReducedDensityMatrix(data=data)
         for ii in range(self.dim):
             for jj in range(self.dim):

--- a/quantarhei/qm/hilbertspace/statevector.py
+++ b/quantarhei/qm/hilbertspace/statevector.py
@@ -45,9 +45,9 @@ class StateVector(BasisManaged):
     data = BasisManagedComplexArray("data")
     _data: numpy.ndarray  # type: ignore[explicit-any]
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, dim: int | None = None, data: numpy.ndarray | None = None
-    ) -> None:  # type: ignore[explicit-any]
+    ) -> None:
 
         self._initialized = False
 

--- a/quantarhei/qm/hilbertspace/statevector.py
+++ b/quantarhei/qm/hilbertspace/statevector.py
@@ -45,7 +45,9 @@ class StateVector(BasisManaged):
     data = BasisManagedComplexArray("data")
     _data: numpy.ndarray  # type: ignore[explicit-any]
 
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:  # type: ignore[explicit-any]
+    def __init__(
+        self, dim: int | None = None, data: numpy.ndarray | None = None
+    ) -> None:  # type: ignore[explicit-any]
 
         self._initialized = False
 

--- a/quantarhei/qm/hilbertspace/statevector.py
+++ b/quantarhei/qm/hilbertspace/statevector.py
@@ -43,9 +43,9 @@ class StateVector(BasisManaged):
     """
 
     data = BasisManagedComplexArray("data")
-    _data: numpy.ndarray
+    _data: numpy.ndarray  # type: ignore[explicit-any]
 
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:
+    def __init__(self, dim: int | None = None, data: Any = None) -> None:  # type: ignore[explicit-any]
 
         self._initialized = False
 
@@ -73,16 +73,16 @@ class StateVector(BasisManaged):
                 self.data = numpy.zeros(dim, dtype=COMPLEX)
                 self._initialized = True
 
-    def dot(self, vec: StateVector) -> Any:
+    def dot(self, vec: StateVector) -> Any:  # type: ignore[explicit-any]
         """Scalar product of two StateVectors"""
         return numpy.dot(self.data, vec.data)
 
-    def norm(self) -> Any:
+    def norm(self) -> Any:  # type: ignore[explicit-any]
         """Returns the norm of the StateVector"""
         # vdot conjugates its first argument: <data|data> = ||data||^2
         return numpy.sqrt(numpy.vdot(self.data, self.data).real)
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """Transformation of the operator by a given matrix
 
 
@@ -105,7 +105,7 @@ class StateVector(BasisManaged):
 
         self._data = numpy.dot(S1, self._data)
 
-    def get_DensityMatrix(self) -> Any:
+    def get_DensityMatrix(self) -> Any:  # type: ignore[explicit-any]
         """Constructs DensityMatrix from the present StateVector"""
         from .operators import DensityMatrix
 

--- a/quantarhei/qm/liouvillespace/Mockevolutionsuperoperator.py
+++ b/quantarhei/qm/liouvillespace/Mockevolutionsuperoperator.py
@@ -209,14 +209,14 @@ from .superoperator import SuperOperator
 
 
 class MockSuperOperator:
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, data_pop: Any = None, data_coh: Any = None, ham: Any = None
     ) -> None:
         self.data_pop = data_pop
         self.data_coh = data_coh
         self.ham = ham
 
-    def data(self, i: int, j: int, k: int, l: int) -> Any:
+    def data(self, i: int, j: int, k: int, l: int) -> Any:  # type: ignore[explicit-any]
         if i == j and k == l:  # population
             return self.data_pop[i, k]
         if i == k and j == l:
@@ -250,7 +250,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
 
     dense_time: TimeAxis | None
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         time: Any = None,
         ham: Any = None,
@@ -308,7 +308,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
 
         self.now = 0
 
-    def get_Hamiltonian(self) -> Any:
+    def get_Hamiltonian(self) -> Any:  # type: ignore[explicit-any]
         """Returns the Hamiltonian associated with thise evolution"""
         return self.ham
 
@@ -333,7 +333,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
             self.dense_time.start, self.dense_time.length, self.dense_time.step
         )
 
-    def set_PureDephasing(self, pdeph: Any) -> None:
+    def set_PureDephasing(self, pdeph: Any) -> None:  # type: ignore[explicit-any]
         """Sets the PureDephasing object for the dynamic calculation"""
         self.pdeph = pdeph
 
@@ -380,7 +380,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
                 for j in range(dim):
                     self.data_coh[i, j] = 1.0
 
-    def data(self, ti: int, i: int, j: int, k: int, l: int) -> Any:  # type: ignore[override,no-redef]
+    def data(self, ti: int, i: int, j: int, k: int, l: int) -> Any:  # type: ignore[explicit-any, override,no-redef]
         if i == j and k == l:  # population
             return self.data_pop[ti, i, k]
         if i == k and j == l:
@@ -485,7 +485,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
         if show_progress:
             print("...done")
 
-    def _elemental_step_TimeIndep(
+    def _elemental_step_TimeIndep(  # type: ignore[explicit-any]
         self, t0: float, dens_dt: float, Nt: int, show_progress: bool = False
     ) -> numpy.ndarray:
         """Single elemental step of propagation with the dense time step"""
@@ -507,7 +507,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
                 rhonm0.data[n, m] = 0.0
         return Ut1
 
-    def _elemental_step_TimeDependent(self, t0: float) -> numpy.ndarray:
+    def _elemental_step_TimeDependent(self, t0: float) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Single step of propagation with the dense time step
 
         assuming time dependent relaxation tensor
@@ -521,7 +521,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
             one_step_time, self.ham, RTensor=self.relt, PDeph=self.pdeph
         )
         rhonm0 = ReducedDensityMatrix(dim=dim)
-        Ut1: numpy.ndarray = numpy.zeros((dim, dim, dim, dim), dtype=COMPLEX)
+        Ut1: numpy.ndarray = numpy.zeros((dim, dim, dim, dim), dtype=COMPLEX)  # type: ignore[explicit-any]
         for n in range(dim):
             for m in range(dim):
                 rhonm0.data[n, m] = 1.0
@@ -531,7 +531,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
                 # self.now += 1
         return Ut1
 
-    def _one_step_with_dense_TimeIndep(
+    def _one_step_with_dense_TimeIndep(  # type: ignore[explicit-any]
         self,
         t0: float,
         Ndense: int,
@@ -673,7 +673,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
             )
         return None
 
-    def apply(self, time: Any, target: Any = None, copy: bool = True) -> Any:
+    def apply(self, time: Any, target: Any = None, copy: bool = True) -> Any:  # type: ignore[explicit-any]
         """Applies the evolution superoperator at a given time
 
 
@@ -758,7 +758,7 @@ class MockEvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
 
         raise QuantarheiError("Invalid argument: time")
 
-    def plot_element(self, elem: Any, show: bool = True) -> None:
+    def plot_element(self, elem: Any, show: bool = True) -> None:  # type: ignore[explicit-any]
         """Plots a selected element of the evolution superoperator
 
 

--- a/quantarhei/qm/liouvillespace/evolutionsuperoperator.py
+++ b/quantarhei/qm/liouvillespace/evolutionsuperoperator.py
@@ -239,7 +239,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         time: Any = None,
         ham: Any = None,
@@ -309,7 +309,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
 
         self.now = 0
 
-    def get_Hamiltonian(self) -> Any:
+    def get_Hamiltonian(self) -> Any:  # type: ignore[explicit-any]
         """Returns the Hamiltonian associated with thise evolution"""
         return self.ham
 
@@ -334,7 +334,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
             self.dense_time.start, self.dense_time.length, self.dense_time.step
         )
 
-    def set_PureDephasing(self, pdeph: Any) -> None:
+    def set_PureDephasing(self, pdeph: Any) -> None:  # type: ignore[explicit-any]
         """Sets the PureDephasing object for the dynamic calculation"""
         self.pdeph = pdeph
 
@@ -449,7 +449,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
             # evolution was calculated in RWA
             self.is_in_rwa = True
 
-    def _elemental_step_TimeIndep(
+    def _elemental_step_TimeIndep(  # type: ignore[explicit-any]
         self, t0: float, dens_dt: float, Nt: int
     ) -> numpy.ndarray:
         """Single elemental step of propagation with the dense time step"""
@@ -469,7 +469,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
 
         return Ut1
 
-    def _elemental_step_TimeDependent(self, t0: float) -> numpy.ndarray:
+    def _elemental_step_TimeDependent(self, t0: float) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Single step of propagation with the dense time step
 
         assuming time dependent relaxation tensor
@@ -482,7 +482,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
             one_step_time, self.ham, RTensor=self.relt, PDeph=self.pdeph
         )
         rhonm0 = ReducedDensityMatrix(dim=dim)
-        Ut1: numpy.ndarray = numpy.zeros((dim, dim, dim, dim), dtype=COMPLEX)
+        Ut1: numpy.ndarray = numpy.zeros((dim, dim, dim, dim), dtype=COMPLEX)  # type: ignore[explicit-any]
         for n in range(dim):
             for m in range(dim):
                 rhonm0.data[n, m] = 1.0
@@ -542,7 +542,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
                 #    self.data[:,:,:,m,n] = numpy.conj()
                 rhonm0.data[n, m] = 0.0
 
-    def _one_step_with_dense_TimeIndep(
+    def _one_step_with_dense_TimeIndep(  # type: ignore[explicit-any]
         self, t0: float, Ndense: int, dens_dt: float, Nt: int
     ) -> numpy.ndarray:
         """One step of propagation over the standard time step
@@ -554,7 +554,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
         #
         # propagation to the end of the first interval
         #
-        Udt: numpy.ndarray = numpy.zeros(Ut1.shape, dtype=COMPLEX)
+        Udt: numpy.ndarray = numpy.zeros(Ut1.shape, dtype=COMPLEX)  # type: ignore[explicit-any]
         Udt[:, :, :, :] = Ut1[:, :, :, :]
         for ti in range(2, self.dense_time.length):
             Udt = numpy.tensordot(Ut1, Udt)
@@ -661,7 +661,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
             return SuperOperator(data=self.data[ti, :, :, :, :])
         return SuperOperator(data=self.data)
 
-    def apply(self, oper: Any, target: Any = None, copy: bool = True) -> Any:
+    def apply(self, oper: Any, target: Any = None, copy: bool = True) -> Any:  # type: ignore[explicit-any]
         """Applies the evolution superoperator at a given time
 
 
@@ -746,7 +746,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
 
         raise QuantarheiError("Invalid argument: time")
 
-    def plot_element(self, elem: Any, part: str = "REAL", show: bool = True) -> None:
+    def plot_element(self, elem: Any, part: str = "REAL", show: bool = True) -> None:  # type: ignore[explicit-any]
         """Plots a selected element of the evolution superoperator
 
 
@@ -782,7 +782,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
         else:
             print("Nothing to plot")
 
-    def get_element_fft(self, elem: Any, window: Any = None) -> Any:
+    def get_element_fft(self, elem: Any, window: Any = None) -> Any:  # type: ignore[explicit-any]
         """Returns a DFunction with the FFT of the element evolution"""
         if window is None:
             winfce = DFunction(self.time, numpy.ones(self.time.length, dtype=REAL))
@@ -802,7 +802,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
         return ffce
 
     # FIXME: In principle, we can define Greens function and return it
-    def get_fft(self, window: Any = None, subtract_last: bool = True) -> tuple:
+    def get_fft(self, window: Any = None, subtract_last: bool = True) -> tuple:  # type: ignore[explicit-any]
         """Returns Fourier transform of the whole evolution superoperator
 
 
@@ -834,7 +834,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
 
         return fdat, freq
 
-    def convert_from_RWA(self, ham: Any = None, sgn: int = 1) -> None:
+    def convert_from_RWA(self, ham: Any = None, sgn: int = 1) -> None:  # type: ignore[explicit-any]
         """Converts evolution superoperator from RWA to standard repre
 
 
@@ -872,7 +872,7 @@ class EvolutionSuperOperator(SuperOperator, TimeDependent, Saveable):
         if sgn == 1:
             self.is_in_rwa = False
 
-    def convert_to_RWA(self, ham: Any) -> None:
+    def convert_to_RWA(self, ham: Any) -> None:  # type: ignore[explicit-any]
         """Converts evolution superoperator from standard repre to RWA
 
 

--- a/quantarhei/qm/liouvillespace/foerstertensor.py
+++ b/quantarhei/qm/liouvillespace/foerstertensor.py
@@ -17,7 +17,7 @@ class FoersterRelaxationTensor(RelaxationTensor):
     """Weak resonance coupling relaxation tensor by Foerster theory"""
 
     dim: int
-    data: numpy.ndarray
+    data: numpy.ndarray  # type: ignore[explicit-any]
     _has_cutoff_time: bool
     cutoff_time: float | None
     _is_initialized: bool

--- a/quantarhei/qm/liouvillespace/heom.py
+++ b/quantarhei/qm/liouvillespace/heom.py
@@ -98,7 +98,7 @@ class KTHierarchy:
 
     """
 
-    def __init__(self, ham: Any, sbi: Any, depth: int = 2) -> None:
+    def __init__(self, ham: Any, sbi: Any, depth: int = 2) -> None:  # type: ignore[explicit-any]
 
         self.ham = ham
         self.sbi = sbi
@@ -160,7 +160,7 @@ class KTHierarchy:
         #                                                 dtype=COMPLEX))
 
         # This needs to be basis controlled
-        self.ado: numpy.ndarray | None = None
+        self.ado: numpy.ndarray | None = None  # type: ignore[explicit-any]
         self.reset_ados()
 
         #
@@ -178,7 +178,7 @@ class KTHierarchy:
         self.np1 = numpy.zeros((self.hsize, self.nbath), dtype=int)
         self._make_nmp1()
 
-        self.Gamma: numpy.ndarray = numpy.zeros(self.hsize, dtype=REAL)
+        self.Gamma: numpy.ndarray = numpy.zeros(self.hsize, dtype=REAL)  # type: ignore[explicit-any]
         self._make_Gamma()
 
         self.hpop = None
@@ -265,7 +265,7 @@ class KTHierarchy:
         lret.append(level4)
         return lret
 
-    def _convert_2_matrix(self, indxs: list) -> numpy.ndarray:
+    def _convert_2_matrix(self, indxs: list) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Convert the list of levels of the hierarchy into an numpy array"""
         hsize = 0
         lvl = 0
@@ -326,7 +326,7 @@ class KTHierarchy:
         """Creates memory of ADOs and sets them to zero"""
         self.ado = numpy.zeros((self.hsize, self.dim, self.dim), dtype=COMPLEX)
 
-    def get_kernel(self, timeaxis: Any) -> numpy.ndarray:
+    def get_kernel(self, timeaxis: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns integration kernel for the time-non-local equation"""
         N = self.dim
         Nt = timeaxis.length
@@ -354,7 +354,7 @@ class KTHierarchy:
 
         return kernel
 
-    def _QHPsop(self) -> numpy.ndarray:
+    def _QHPsop(self) -> numpy.ndarray:  # type: ignore[explicit-any]
 
         N = self.dim
         delta = UnityOperator(dim=N).data
@@ -400,7 +400,7 @@ class KTHierarchy:
 
         return qhp
 
-    def _PHQsop(self) -> numpy.ndarray:
+    def _PHQsop(self) -> numpy.ndarray:  # type: ignore[explicit-any]
 
         N = self.dim
         delta = UnityOperator(dim=N).data
@@ -471,7 +471,7 @@ class KTHierarchyPropagator:
 
     """
 
-    def __init__(self, timeaxis: Any, hierarchy: Any) -> None:
+    def __init__(self, timeaxis: Any, hierarchy: Any) -> None:  # type: ignore[explicit-any]
 
         self.timeaxis = timeaxis
         self.Nt = timeaxis.length
@@ -496,7 +496,7 @@ class KTHierarchyPropagator:
         else:
             raise QuantarheiError("Hamiltonian does not have RWA.")
 
-    def propagate(
+    def propagate(  # type: ignore[explicit-any]
         self,
         rhoi: Any,
         L: int = 4,
@@ -563,7 +563,7 @@ class KTHierarchyPropagator:
 
         return rhot
 
-    def _ado_self_rhs(
+    def _ado_self_rhs(  # type: ignore[explicit-any]
         self, ado1: numpy.ndarray, dt: float, slevel: int = 0
     ) -> numpy.ndarray:
         """Self contribution of the equation for the hierarchy ADOs"""
@@ -583,7 +583,7 @@ class KTHierarchyPropagator:
 
         return ado3
 
-    def _ado_cros_rhs(
+    def _ado_cros_rhs(  # type: ignore[explicit-any]
         self, ado1: numpy.ndarray, dt: float, slevel: int = 0
     ) -> numpy.ndarray:
         """All cross-terms of the Hierarchy"""
@@ -659,12 +659,12 @@ class QuTip_KTHierarchyPropagator(KTHierarchyPropagator):
         indices.
     """
 
-    def __init__(self, timeaxis: Any, hierarchy: Any) -> None:
+    def __init__(self, timeaxis: Any, hierarchy: Any) -> None:  # type: ignore[explicit-any]
 
         super().__init__(timeaxis, hierarchy)
         self._is_prepared = False
 
-    def propagate(
+    def propagate(  # type: ignore[explicit-any]
         self,
         rhoi: Any,
         L: int = 4,

--- a/quantarhei/qm/liouvillespace/integrodiff/integrodiff.py
+++ b/quantarhei/qm/liouvillespace/integrodiff/integrodiff.py
@@ -56,7 +56,7 @@ class IntegrodiffPropagator:
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any,
         ham: Any,
@@ -74,7 +74,7 @@ class IntegrodiffPropagator:
         self.timeaxis = timeaxis
         self.ham = ham
         self.kernel = kernel
-        self.last_int: numpy.ndarray
+        self.last_int: numpy.ndarray  # type: ignore[explicit-any]
         self.last_tn: int = -1
 
         self.kernel_is_tdependent = False
@@ -107,7 +107,7 @@ class IntegrodiffPropagator:
             self.fft = fft
 
         if self.fft:
-            self.resolv: numpy.ndarray | None = None
+            self.resolv: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
             # FFT on timeaxis twice as long as defines (we add negative times)
             tlen = timefac * self.timeaxis.length
@@ -122,7 +122,7 @@ class IntegrodiffPropagator:
             # FFT of the kernel
             N1 = self.ham.dim
 
-            self.om: numpy.ndarray = numpy.zeros(len(tt), REAL)
+            self.om: numpy.ndarray = numpy.zeros(len(tt), REAL)  # type: ignore[explicit-any]
             # calculate frequencies
             self.om[:] = (2.0 * numpy.pi) * numpy.fft.fftfreq(tlen, self.timeaxis.step)
             om = self.om
@@ -140,7 +140,7 @@ class IntegrodiffPropagator:
 
             if with_kernel:
                 # if kernel is present, we use it for calculation
-                MM: numpy.ndarray = numpy.zeros((tlen, N1, N1, N1, N1), dtype=COMPLEX)
+                MM: numpy.ndarray = numpy.zeros((tlen, N1, N1, N1, N1), dtype=COMPLEX)  # type: ignore[explicit-any]
                 MM[: self.timeaxis.length, :, :, :, :] = self._kernel
 
                 # we renormalize the kernel by a e^{-gam*t} decay
@@ -176,7 +176,7 @@ class IntegrodiffPropagator:
             # prepare propagation in time domain
             pass
 
-    def propagate(self, rhoi: Any) -> Any:
+    def propagate(self, rhoi: Any) -> Any:  # type: ignore[explicit-any]
         """Propagates initial condition of an integro-differential eq."""
         N1 = rhoi.data.shape[0]
         rhot = ReducedDensityMatrixEvolution(self.timeaxis, rhoi)
@@ -188,7 +188,7 @@ class IntegrodiffPropagator:
 
             Nt = len(self.om)
 
-            rhOm: numpy.ndarray = numpy.zeros((Nt, N1, N1), dtype=COMPLEX)
+            rhOm: numpy.ndarray = numpy.zeros((Nt, N1, N1), dtype=COMPLEX)  # type: ignore[explicit-any]
 
             rho0 = rhoi.data  # .reshape(N1**2)
 
@@ -260,7 +260,7 @@ class IntegrodiffPropagator:
 
         return rhot
 
-    def _convolution_with_kernel(
+    def _convolution_with_kernel(  # type: ignore[explicit-any]
         self, tn: int, rho_in: numpy.ndarray, rhot: Any
     ) -> numpy.ndarray:
         """Convolution of the density matrix with integration kernel"""
@@ -293,7 +293,7 @@ class IntegrodiffPropagator:
 
         return rho
 
-    def _right_hand_side(self, tn: int, rho: numpy.ndarray, rhot: Any) -> numpy.ndarray:
+    def _right_hand_side(self, tn: int, rho: numpy.ndarray, rhot: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Right-hand side of the master equation"""
         ham = self.ham.data
         drho = -1j * (numpy.dot(ham, rho) - numpy.dot(rho, ham))
@@ -301,7 +301,7 @@ class IntegrodiffPropagator:
 
         return drho
 
-    def _no_kernel_rhs(self, tn: int, rho: numpy.ndarray, rhot: Any) -> numpy.ndarray:
+    def _no_kernel_rhs(self, tn: int, rho: numpy.ndarray, rhot: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Right-hand side of the master equation without the kernel"""
         # M0 = self.kernel
 
@@ -311,13 +311,13 @@ class IntegrodiffPropagator:
 
         return drho
 
-    def check_solution(self, rhot: Any) -> numpy.ndarray:
+    def check_solution(self, rhot: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Masures the difference between the right- and left-hand-side
         of the equation
 
         """
         N1 = self.ham.dim
-        diff: numpy.ndarray = numpy.zeros((self.timeaxis.length, N1, N1), dtype=COMPLEX)
+        diff: numpy.ndarray = numpy.zeros((self.timeaxis.length, N1, N1), dtype=COMPLEX)  # type: ignore[explicit-any]
         for tn in range(self.timeaxis.length):
             # time derivative
             if tn == 0:

--- a/quantarhei/qm/liouvillespace/lindbladform.py
+++ b/quantarhei/qm/liouvillespace/lindbladform.py
@@ -20,7 +20,7 @@ class LindbladForm(RedfieldRelaxationTensor):
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         ham: Any,
         sbi: Any,
@@ -32,7 +32,7 @@ class LindbladForm(RedfieldRelaxationTensor):
             ham, sbi, initialize=initialize, as_operators=as_operators, name=name
         )
 
-    def _implementation(self, ham: Any, sbi: Any) -> None:
+    def _implementation(self, ham: Any, sbi: Any) -> None:  # type: ignore[explicit-any]
         """Very simple implementation of Lindblad form"""
         # dimension of the operators
         Na = ham.dim
@@ -91,7 +91,7 @@ class ElectronicLindbladForm(LindbladForm):
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         ham: Any,
         sbi: Any,
@@ -171,7 +171,7 @@ class ElectronicLindbladForm(LindbladForm):
                 " attribute set to an Aggregate"
             )
 
-    def cast_to_vibronic(agg: Any, KK: Any) -> numpy.ndarray:
+    def cast_to_vibronic(agg: Any, KK: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         newkk = numpy.zeros((agg.Ntot, agg.Ntot), dtype=numpy.float64)
 
         # populate the operator
@@ -227,7 +227,7 @@ class VibrationalDecayLindbladForm(LindbladForm):
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         ham: Any,
         sbi: Any,
@@ -247,7 +247,7 @@ class VibrationalDecayLindbladForm(LindbladForm):
             ops = []
             rts = []
 
-            zero: numpy.ndarray = numpy.zeros((Ntot, Ntot), dtype=REAL)
+            zero: numpy.ndarray = numpy.zeros((Ntot, Ntot), dtype=REAL)  # type: ignore[explicit-any]
             zrs = 0
 
             # we loop over sites in which we want to introduce relaxation
@@ -314,7 +314,7 @@ class VibrationalDecayLindbladForm(LindbladForm):
             ham, newsbi, initialize=initialize, as_operators=as_operators, name=name
         )
 
-    def _same_regardless_of_one(self, a: Any, b: Any, k: int) -> bool | None:
+    def _same_regardless_of_one(self, a: Any, b: Any, k: int) -> bool | None:  # type: ignore[explicit-any]
 
         if (a[:k] == b[:k]) and (a[k + 1 :] == b[k + 1 :]):
             return True

--- a/quantarhei/qm/liouvillespace/liouvillian.py
+++ b/quantarhei/qm/liouvillespace/liouvillian.py
@@ -41,7 +41,7 @@ class Liouvillian(SuperOperator):
 
     """
 
-    def __init__(self, ham: Any) -> None:
+    def __init__(self, ham: Any) -> None:  # type: ignore[explicit-any]
         super().__init__(dim=ham.dim)
         dim = ham.dim
         H = ham.data

--- a/quantarhei/qm/liouvillespace/modredfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/modredfieldtensor.py
@@ -24,7 +24,7 @@ class ModRedfieldRelaxationTensor(RelaxationTensor):
     """
 
     dim: int
-    data: numpy.ndarray
+    data: numpy.ndarray  # type: ignore[explicit-any]
 
     @prevent_basis_context
     def __init__(

--- a/quantarhei/qm/liouvillespace/nefoerstertensor.py
+++ b/quantarhei/qm/liouvillespace/nefoerstertensor.py
@@ -24,7 +24,7 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         ham: Any,
         sbi: Any,
@@ -107,7 +107,7 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
                 self.updateStructure()
                 self.add_dephasing()
 
-    def td_reference_implementation(
+    def td_reference_implementation(  # type: ignore[explicit-any]
         self,
         Na: int,
         Nt: int,
@@ -156,7 +156,7 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
         #
         return _td_reference_implementation(Na, Nt, HH, tt, gt, ll, _ne_fintegral)
 
-    def _initial_term_pre(
+    def _initial_term_pre(  # type: ignore[explicit-any]
         self,
         Na: int,
         Nt: int,
@@ -169,7 +169,7 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
         condition
 
         """
-        II: numpy.ndarray = numpy.zeros((Nt, Na, Na), dtype=COMPLEX)
+        II: numpy.ndarray = numpy.zeros((Nt, Na, Na), dtype=COMPLEX)  # type: ignore[explicit-any]
 
         JJ = HH.data
 
@@ -188,7 +188,7 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
         self.II = II
         self.has_Iterm = True
 
-    def initial_term(self, rhoi: Any) -> None:
+    def initial_term(self, rhoi: Any) -> None:  # type: ignore[explicit-any]
         """Inhomogeneous (initial condition) term
         of the non-equilibrium Foerster theory
 
@@ -197,7 +197,7 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
             self.initial_term_nsc(rhoi)
             return
 
-        II: numpy.ndarray = numpy.zeros(self.II.shape, dtype=COMPLEX)
+        II: numpy.ndarray = numpy.zeros(self.II.shape, dtype=COMPLEX)  # type: ignore[explicit-any]
         Na = self.II.shape[1]
 
         for aa in range(Na):
@@ -207,7 +207,7 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
         self.Iterm = II
         self.has_Iterm = True
 
-    def _initial_term_pre_nsc(
+    def _initial_term_pre_nsc(  # type: ignore[explicit-any]
         self,
         Na: int,
         Nt: int,
@@ -220,7 +220,7 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
         with known initial condition
 
         """
-        II: numpy.ndarray = numpy.zeros((Nt, Na, Na, Na, Na), dtype=COMPLEX)
+        II: numpy.ndarray = numpy.zeros((Nt, Na, Na, Na, Na), dtype=COMPLEX)  # type: ignore[explicit-any]
         JJ = HH.data
         EE = numpy.eye(Na, Na)
 
@@ -246,14 +246,14 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
         self.II = II
         self.has_Iterm = True
 
-    def initial_term_nsc(self, rhoi: Any) -> None:
+    def initial_term_nsc(self, rhoi: Any) -> None:  # type: ignore[explicit-any]
         """Inhomogeneous (initial condition) term
         of the effective non-secular non-equilibrium Foerster theory
 
         """
         Na = self.II.shape[1]
         Nt = self.II.shape[0]
-        II: numpy.ndarray = numpy.zeros((Nt, Na, Na), dtype=COMPLEX)
+        II: numpy.ndarray = numpy.zeros((Nt, Na, Na), dtype=COMPLEX)  # type: ignore[explicit-any]
 
         for aa in range(Na):
             for bb in range(Na):
@@ -267,7 +267,7 @@ class NEFoersterRelaxationTensor(TDFoersterRelaxationTensor):
         self.has_Iterm = True
 
 
-def _kernel_at_t(
+def _kernel_at_t(  # type: ignore[explicit-any]
     ti: int,
     tt: numpy.ndarray,
     gtd: numpy.ndarray,
@@ -279,7 +279,7 @@ def _kernel_at_t(
     """Two-time kernel to be integrated"""
     Nt = tt.shape[0]
     gtd_i = gtd[0 : ti + 1]
-    gtd_m: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+    gtd_m: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
     gtd_m[0 : ti + 1] = numpy.flip(gtd_i)
 
     prod = (
@@ -291,7 +291,7 @@ def _kernel_at_t(
     return prod
 
 
-def _nsc_kernel_at_t(
+def _nsc_kernel_at_t(  # type: ignore[explicit-any]
     ti: int,
     tt: numpy.ndarray,
     aa: int,
@@ -309,8 +309,8 @@ def _nsc_kernel_at_t(
     # expressions for t-tau
     gtb_i = gt[bb, 0 : ti + 1]
     gta_i = gt[aa, 0 : ti + 1]
-    gtb_m: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
-    gta_m: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+    gtb_m: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
+    gta_m: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
     gtb_m[0 : ti + 1] = numpy.flip(gtb_i)
     gta_m[0 : ti + 1] = numpy.flip(gta_i)
 
@@ -321,7 +321,7 @@ def _nsc_kernel_at_t(
 
     # general expression for all indices
 
-    dl: numpy.ndarray = numpy.eye(HH.shape[0], dtype=REAL)
+    dl: numpy.ndarray = numpy.eye(HH.shape[0], dtype=REAL)  # type: ignore[explicit-any]
 
     tt_i = tt[ti]
     prod = exp(
@@ -341,7 +341,7 @@ def _nsc_kernel_at_t(
     return prod
 
 
-def _integrate_kernel(tt: numpy.ndarray, fce: numpy.ndarray) -> numpy.ndarray:
+def _integrate_kernel(tt: numpy.ndarray, fce: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Spline integration of a complex function"""
     preal = numpy.real(fce)
     pimag = numpy.imag(fce)
@@ -351,7 +351,7 @@ def _integrate_kernel(tt: numpy.ndarray, fce: numpy.ndarray) -> numpy.ndarray:
     return inte
 
 
-def _integrate_kernel_to_t(
+def _integrate_kernel_to_t(  # type: ignore[explicit-any]
     ti: int, tt: numpy.ndarray, fce: numpy.ndarray, margin: int = 10
 ) -> Any:
     """Spline partial integration of a complex function
@@ -377,7 +377,7 @@ def _integrate_kernel_to_t(
     return numpy.sum(fce_ti) * (tt_ti[1] - tt_ti[0])
 
 
-def _integrate_three_to_t(
+def _integrate_three_to_t(  # type: ignore[explicit-any]
     ti: int,
     tt: numpy.ndarray,
     fce_t: numpy.ndarray,
@@ -401,7 +401,7 @@ def _integrate_three_to_t(
     import numpy
 
     # convert the function of t-tau into a function of tau
-    fce_flip: numpy.ndarray = numpy.zeros(fce_ttau.shape, dtype=COMPLEX)
+    fce_flip: numpy.ndarray = numpy.zeros(fce_ttau.shape, dtype=COMPLEX)  # type: ignore[explicit-any]
     fce_flip[0 : ti + 1] = numpy.flip(fce_ttau[0 : ti + 1])
 
     # construct the function to be integrated
@@ -411,7 +411,7 @@ def _integrate_three_to_t(
     return _integrate_kernel_to_t(ti, tt, fce)[ti]
 
 
-def _ne_fintegral(
+def _ne_fintegral(  # type: ignore[explicit-any]
     tt: numpy.ndarray,
     gtd: numpy.ndarray,
     gta: numpy.ndarray,
@@ -449,7 +449,7 @@ def _ne_fintegral(
 
     """
     Nt = tt.shape[0]
-    hoft: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+    hoft: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
 
     for ti in range(Nt):
         #
@@ -471,7 +471,7 @@ def _ne_fintegral(
     return ret
 
 
-def _nsc_reference_implementation(
+def _nsc_reference_implementation(  # type: ignore[explicit-any]
     Na: int,
     Nt: int,
     HH: numpy.ndarray,
@@ -484,12 +484,12 @@ def _nsc_reference_implementation(
     #
     # Rates between states a and b
     #
-    KK: numpy.ndarray = numpy.zeros((Nt, Na, Na, Na, Na), dtype=COMPLEX)
-    fKK: numpy.ndarray = numpy.zeros((Nt, Na, Na, Na, Na), dtype=COMPLEX)
-    RR: numpy.ndarray = numpy.zeros((Nt, Na, Na), dtype=COMPLEX)
+    KK: numpy.ndarray = numpy.zeros((Nt, Na, Na, Na, Na), dtype=COMPLEX)  # type: ignore[explicit-any]
+    fKK: numpy.ndarray = numpy.zeros((Nt, Na, Na, Na, Na), dtype=COMPLEX)  # type: ignore[explicit-any]
+    RR: numpy.ndarray = numpy.zeros((Nt, Na, Na), dtype=COMPLEX)  # type: ignore[explicit-any]
 
     # resonance coupling matrix
-    JJ: numpy.ndarray = numpy.zeros(HH.shape, dtype=REAL)
+    JJ: numpy.ndarray = numpy.zeros(HH.shape, dtype=REAL)  # type: ignore[explicit-any]
     JJ[:, :] = HH[:, :]
     for ii in range(Na):
         JJ[ii, ii] = 0.0
@@ -538,7 +538,7 @@ def _nsc_reference_implementation(
     # return numpy.zeros((Nt,Na,Na,Na,Na), dtype=COMPLEX)
 
 
-def _nsc_kernel_implementation(
+def _nsc_kernel_implementation(  # type: ignore[explicit-any]
     Na: int,
     Nt: int,
     HH: numpy.ndarray,
@@ -556,9 +556,9 @@ def _nsc_kernel_implementation(
 
     """
 
-    def fkernel(ti: int) -> numpy.ndarray:
+    def fkernel(ti: int) -> numpy.ndarray:  # type: ignore[explicit-any]
 
-        def fce2(
+        def fce2(  # type: ignore[explicit-any]
             tt: numpy.ndarray,
             aa: int,
             bb: int,
@@ -576,7 +576,7 @@ def _nsc_kernel_implementation(
     return fkernel
 
 
-def _nsc_fintegral(
+def _nsc_fintegral(  # type: ignore[explicit-any]
     tt: numpy.ndarray,
     a: int,
     b: int,
@@ -615,7 +615,7 @@ def _nsc_fintegral(
 
     """
     Nt = tt.shape[0]
-    hoft: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+    hoft: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
 
     for ti in range(Nt):
         #

--- a/quantarhei/qm/liouvillespace/puredephasing.py
+++ b/quantarhei/qm/liouvillespace/puredephasing.py
@@ -87,15 +87,15 @@ from ...qm.hilbertspace.operators import Operator
 from ..liouvillespace.superoperator import SuperOperator
 
 
-def _eigenb() -> Any:
+def _eigenb() -> Any:  # type: ignore[explicit-any]
     """Pointer to eigenbasis property"""
 
     @property  # type: ignore[misc]
-    def prop(self: Any) -> Any:
+    def prop(self: Any) -> Any:  # type: ignore[explicit-any]
         return self._eigenbasis()
 
     @prop.setter  # type: ignore[misc]
-    def prop(self: Any, value: Any) -> None:
+    def prop(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         raise BasisError("The property 'eigenbasis' is protected and cannot be set.")
 
     return prop
@@ -106,7 +106,7 @@ class PureDephasing:  # (BasisManaged):
 
     eigenbasis = _eigenb()
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         drates: Any = None,
         dtype: str = "Lorentzian",
@@ -118,7 +118,7 @@ class PureDephasing:  # (BasisManaged):
         if drates is None:
             raise QuantarheiError("Dephasing rates must be specified.")
 
-        self.data: numpy.ndarray = numpy.array(drates, dtype=REAL)
+        self.data: numpy.ndarray = numpy.array(drates, dtype=REAL)  # type: ignore[explicit-any]
 
         if system is not None:
             self.system = system
@@ -137,7 +137,7 @@ class PureDephasing:  # (BasisManaged):
             else:
                 raise ImplementationError("Non-Aggregate systems not implemented yet.")
 
-            HH: Any = self.system.get_Hamiltonian()
+            HH: Any = self.system.get_Hamiltonian()  # type: ignore[explicit-any]
             if HH.dim != self.data.shape[0]:
                 raise QuantarheiError(
                     "Incompatible dimension of the rate matrix:"
@@ -197,7 +197,7 @@ class PureDephasing:  # (BasisManaged):
         else:
             raise QuantarheiError("Unknown dephasing type")
 
-    def _eigenbasis(self) -> Any:
+    def _eigenbasis(self) -> Any:  # type: ignore[explicit-any]
         """Returns the context for the eigenbasis in which pure dephasing
         is defined
 
@@ -220,7 +220,7 @@ class PureDephasing:  # (BasisManaged):
 class ElectronicPureDephasing(PureDephasing):
     """Electronic pure dephasing for one-exciton states"""
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         system: Any,
         drates: Any = None,

--- a/quantarhei/qm/liouvillespace/rates/foersterrates.py
+++ b/quantarhei/qm/liouvillespace/rates/foersterrates.py
@@ -85,7 +85,7 @@ class FoersterRateMatrix:
         self.data = _reference_implementation(Na, HH, tt, gt, ll)
 
 
-def _reference_implementation(
+def _reference_implementation(  # type: ignore[explicit-any]
     Na: int, HH: numpy.ndarray, tt: numpy.ndarray, gt: numpy.ndarray, ll: numpy.ndarray
 ) -> numpy.ndarray:
     """Reference implementation of Foerster rates
@@ -144,7 +144,7 @@ def _reference_implementation(
     return KK
 
 
-def _fintegral(
+def _fintegral(  # type: ignore[explicit-any]
     tt: numpy.ndarray,
     gtd: numpy.ndarray,
     gta: numpy.ndarray,

--- a/quantarhei/qm/liouvillespace/rates/modifiedredfieldrates.py
+++ b/quantarhei/qm/liouvillespace/rates/modifiedredfieldrates.py
@@ -54,7 +54,7 @@ class ModifiedRedfieldRateMatrix:
     """
 
     dim: int
-    _data: numpy.ndarray
+    _data: numpy.ndarray  # type: ignore[explicit-any]
 
     def __init__(
         self,
@@ -229,7 +229,7 @@ class ModifiedRedfieldRateMatrix:
         #
         # HIDE THIS INTO: get_reorganization_energy_matrix()
         #
-        lam4: numpy.ndarray = numpy.zeros((Na, Na, Na, Na), dtype=REAL)
+        lam4: numpy.ndarray = numpy.zeros((Na, Na, Na, Na), dtype=REAL)  # type: ignore[explicit-any]
         for a in range(Na):
             for b in range(Na):
                 for c in range(Na):
@@ -270,7 +270,7 @@ class ModifiedRedfieldRateMatrix:
         self.data = rates
 
 
-def ssModifiedRedfieldRateMatrix(
+def ssModifiedRedfieldRateMatrix(  # type: ignore[explicit-any]
     Na: int,
     Nc: int,
     Nt: int,
@@ -337,13 +337,13 @@ def ssModifiedRedfieldRateMatrix(
     warnings and errors
 
     """
-    E_0k: numpy.ndarray = numpy.zeros(Na, dtype=REAL)
-    F_k_t: numpy.ndarray = numpy.zeros((Na, Nt), dtype=COMPLEX)
-    A_k_t: numpy.ndarray = numpy.zeros((Na, Nt), dtype=COMPLEX)
-    N_kl_t: numpy.ndarray = numpy.zeros((Na, Na, Nt), dtype=COMPLEX)
-    f: numpy.ndarray = numpy.zeros((Na, Na, Nt), dtype=COMPLEX)
-    RR: numpy.ndarray = numpy.zeros((Na, Na), dtype=COMPLEX)
-    RR1: numpy.ndarray = numpy.zeros((Na, Na), dtype=COMPLEX)
+    E_0k: numpy.ndarray = numpy.zeros(Na, dtype=REAL)  # type: ignore[explicit-any]
+    F_k_t: numpy.ndarray = numpy.zeros((Na, Nt), dtype=COMPLEX)  # type: ignore[explicit-any]
+    A_k_t: numpy.ndarray = numpy.zeros((Na, Nt), dtype=COMPLEX)  # type: ignore[explicit-any]
+    N_kl_t: numpy.ndarray = numpy.zeros((Na, Na, Nt), dtype=COMPLEX)  # type: ignore[explicit-any]
+    f: numpy.ndarray = numpy.zeros((Na, Na, Nt), dtype=COMPLEX)  # type: ignore[explicit-any]
+    RR: numpy.ndarray = numpy.zeros((Na, Na), dtype=COMPLEX)  # type: ignore[explicit-any]
+    RR1: numpy.ndarray = numpy.zeros((Na, Na), dtype=COMPLEX)  # type: ignore[explicit-any]
 
     # lam1 = (convert(numpy.imag(-h4[2,1,1,2,Nt-1]),"int","1/cm"))
     # lam2 = convert(lam4[2,1,1,2],"int","1/cm")
@@ -396,7 +396,7 @@ def ssModifiedRedfieldRateMatrix(
 
         """
 
-    f1: numpy.ndarray = numpy.zeros((Na, Na, Nt), dtype=COMPLEX)
+    f1: numpy.ndarray = numpy.zeros((Na, Na, Nt), dtype=COMPLEX)  # type: ignore[explicit-any]
     for a in range(Na):
         for b in range(Na):
             f1[a, b, :] = numpy.conjugate(F_k_t[b, :]) * A_k_t[a, :] * N_kl_t[a, b, :]
@@ -415,7 +415,7 @@ def ssModifiedRedfieldRateMatrix(
     # qr.stop()
 
 
-def _c2g(timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
+def _c2g(timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Converts correlation function to lineshape function
 
     Explicit numerical double integration of the correlation
@@ -443,7 +443,7 @@ def _c2g(timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
     return gt
 
 
-def _c2h(timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
+def _c2h(timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Converts correlation function to derivative of lineshape function
 
     Explicit numerical single integration of the correlation
@@ -469,7 +469,7 @@ def _c2h(timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
     return ht
 
 
-def ssModifiedRRM(
+def ssModifiedRRM(  # type: ignore[explicit-any]
     Na: int,
     Nt: int,
     en: numpy.ndarray,
@@ -504,11 +504,11 @@ def ssModifiedRRM(
 
 
     """
-    RR: numpy.ndarray = numpy.zeros((Na, Na), dtype=REAL)
-    f: numpy.ndarray = numpy.zeros((Na, Na, Nt), dtype=COMPLEX)
-    Ab: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
-    Fl: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
-    Nn: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+    RR: numpy.ndarray = numpy.zeros((Na, Na), dtype=REAL)  # type: ignore[explicit-any]
+    f: numpy.ndarray = numpy.zeros((Na, Na, Nt), dtype=COMPLEX)  # type: ignore[explicit-any]
+    Ab: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
+    Fl: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
+    Nn: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
 
     if method == "ModifiedRedfield":
         for a in range(Na):

--- a/quantarhei/qm/liouvillespace/rates/ratematrix.py
+++ b/quantarhei/qm/liouvillespace/rates/ratematrix.py
@@ -11,7 +11,7 @@ from ....exceptions import QuantarheiError
 class RateMatrix(MatrixData):
     """Represents a population transfer rate matrix"""
 
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:
+    def __init__(self, dim: int | None = None, data: Any = None) -> None:  # type: ignore[explicit-any]
 
         self.N = 0
 
@@ -38,7 +38,7 @@ class RateMatrix(MatrixData):
             else:
                 self.data = numpy.zeros((self.N, self.N), dtype=numpy.float64)
 
-    def set_rate(self, pos: Any, value: float) -> None:
+    def set_rate(self, pos: Any, value: float) -> None:  # type: ignore[explicit-any]
         """Sets a value of a rate between two states
 
         Diagonal depopulation rates are automatically updated

--- a/quantarhei/qm/liouvillespace/rates/redfieldrates.py
+++ b/quantarhei/qm/liouvillespace/rates/redfieldrates.py
@@ -46,9 +46,9 @@ class RedfieldRateMatrix:
 
     """
 
-    _data: numpy.ndarray
+    _data: numpy.ndarray  # type: ignore[explicit-any]
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         ham: Hamiltonian,
         sbi: SystemBathInteraction,
@@ -118,7 +118,7 @@ class RedfieldRateMatrix:
                 Om[a, b] = hD[a] - hD[b]
 
         # calculate values of the spectral density at frequencies
-        cc: numpy.ndarray = numpy.zeros((Nk, Na, Na), dtype=REAL)
+        cc: numpy.ndarray = numpy.zeros((Nk, Na, Na), dtype=REAL)  # type: ignore[explicit-any]
 
         # loop over components
         for k in range(Nk):
@@ -146,7 +146,7 @@ class RedfieldRateMatrix:
                                 )
 
         # create storage for the rates
-        self.data: numpy.ndarray = numpy.zeros((Na, Na), dtype=REAL)
+        self.data: numpy.ndarray = numpy.zeros((Na, Na), dtype=REAL)  # type: ignore[explicit-any]
 
         # calculate rate matrix
         #
@@ -178,7 +178,7 @@ class RedfieldRateMatrix:
     fallback_local=False,
     always_local=False,
 )
-def ssRedfieldRateMatrix(
+def ssRedfieldRateMatrix(  # type: ignore[explicit-any]
     Na: int,
     Nk: int,
     KI: numpy.ndarray,

--- a/quantarhei/qm/liouvillespace/rates/tdfoersterrates.py
+++ b/quantarhei/qm/liouvillespace/rates/tdfoersterrates.py
@@ -77,7 +77,7 @@ class TDFoersterRateMatrix(TimeDependent):
         self._is_initialized = True
 
 
-def _td_reference_implementation(
+def _td_reference_implementation(  # type: ignore[explicit-any]
     Na: int,
     Nt: int,
     HH: numpy.ndarray,
@@ -103,7 +103,7 @@ def _td_reference_implementation(
     return KK
 
 
-def _td_fintegral(
+def _td_fintegral(  # type: ignore[explicit-any]
     tt: numpy.ndarray,
     gtd: numpy.ndarray,
     gta: numpy.ndarray,

--- a/quantarhei/qm/liouvillespace/rates/tdredfieldrates.py
+++ b/quantarhei/qm/liouvillespace/rates/tdredfieldrates.py
@@ -171,7 +171,7 @@ class TDRedfieldRateMatrix(TimeDependent):
     fallback_local=True,
     always_local=True,
 )
-def ssTDRedfieldRateMatrix(
+def ssTDRedfieldRateMatrix(  # type: ignore[explicit-any]
     Na: int,
     Nk: int,
     Nt: int,
@@ -183,7 +183,7 @@ def ssTDRedfieldRateMatrix(
 ) -> numpy.ndarray:
 
     # output relaxatio rate matrix
-    RR: numpy.ndarray = numpy.zeros((Nt, Na, Na), dtype=REAL)
+    RR: numpy.ndarray = numpy.zeros((Nt, Na, Na), dtype=REAL)  # type: ignore[explicit-any]
 
     # real part of FT correlation function = 2Re of the half FT of
     # the correlation function - no factor of 2 here!

--- a/quantarhei/qm/liouvillespace/redfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/redfieldtensor.py
@@ -79,9 +79,9 @@ class RedfieldRelaxationTensor(RelaxationTensor):
     cutoff_time: float | None
     _is_initialized: bool
     dim: int
-    _Km: numpy.ndarray
-    _Lm: numpy.ndarray
-    _Ld: numpy.ndarray
+    _Km: numpy.ndarray  # type: ignore[explicit-any]
+    _Lm: numpy.ndarray  # type: ignore[explicit-any]
+    _Ld: numpy.ndarray  # type: ignore[explicit-any]
 
     def __init__(
         self,
@@ -149,7 +149,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
         self.Iterm = None
         self.has_Iterm = False
 
-    def apply(self, oper: Any, target: Any = None, copy: bool = True) -> Any:
+    def apply(self, oper: Any, target: Any = None, copy: bool = True) -> Any:  # type: ignore[explicit-any]
         """Applies the relaxation tensor on a superoperator"""
         if self.as_operators:
             print("Applying Relaxation tensor")
@@ -186,7 +186,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
 
         return super().apply(oper, copy=copy)
 
-    def get_population_rate(self, N: int, M: int) -> Any:
+    def get_population_rate(self, N: int, M: int) -> Any:  # type: ignore[explicit-any]
         """Returns the relaxation rate between states N -> M"""
         if self.as_operators:
             rt = 0.0
@@ -197,7 +197,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
 
         return super().get_population_rate(N, M)
 
-    def get_dephasing_rate(self, N: int, M: int) -> Any:
+    def get_dephasing_rate(self, N: int, M: int) -> Any:  # type: ignore[explicit-any]
         """Returns the dephasing rate of a coherence between states N and M"""
         if self.as_operators:
             rt = 0.0
@@ -212,7 +212,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
 
         return super().get_dephasing_rate(N, M)
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """Transformation of the tensor by a given matrix
 
 
@@ -240,9 +240,9 @@ class RedfieldRelaxationTensor(RelaxationTensor):
             else:
                 S1 = inv
 
-            _Lm: numpy.ndarray = numpy.zeros_like(self._Lm, dtype=COMPLEX)
-            _Ld: numpy.ndarray = numpy.zeros_like(self._Ld, dtype=COMPLEX)
-            _Km: numpy.ndarray = numpy.zeros_like(self._Km, dtype=COMPLEX)
+            _Lm: numpy.ndarray = numpy.zeros_like(self._Lm, dtype=COMPLEX)  # type: ignore[explicit-any]
+            _Ld: numpy.ndarray = numpy.zeros_like(self._Ld, dtype=COMPLEX)  # type: ignore[explicit-any]
+            _Km: numpy.ndarray = numpy.zeros_like(self._Km, dtype=COMPLEX)  # type: ignore[explicit-any]
             for m in range(self._Km.shape[0]):
                 _Lm[:, :, m] = numpy.dot(S1, numpy.dot(self._Lm[:, :, m], SS))
                 _Ld[:, :, m] = numpy.dot(S1, numpy.dot(self._Ld[:, :, m], SS))
@@ -352,7 +352,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
             Km[ns, :, :] = numpy.dot(S1, numpy.dot(sbi.KK[ns, :, :], SS))
 
         if multi_ex:
-            system_any: Any = sbi.system
+            system_any: Any = sbi.system  # type: ignore[explicit-any]
             try:
                 ii = system_any.twoex_state[0, 0]
                 # print(ii)
@@ -366,7 +366,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
             Nb2 = sbi.N
 
             # projectors to two-exciton states
-            K2: numpy.ndarray = numpy.zeros((Nb2, Na, Na), dtype=REAL)
+            K2: numpy.ndarray = numpy.zeros((Nb2, Na, Na), dtype=REAL)  # type: ignore[explicit-any]
             i_start = ham.rwa_indices[2]  # here the two-exciton bands starts
             ii = 0
             for ms in range(i_start, ham.dim):
@@ -441,7 +441,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
 
         log_detail("... Redfield done")
 
-    def _post_implementation(
+    def _post_implementation(  # type: ignore[explicit-any]
         self, Km: numpy.ndarray, Lm: numpy.ndarray, Ld: numpy.ndarray
     ) -> None:
         """When components of the tensor are calculated, should they be
@@ -463,7 +463,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
 
         self._is_initialized = True
 
-    def _guts_Cmplx_Splines(
+    def _guts_Cmplx_Splines(  # type: ignore[explicit-any]
         self,
         ms: int,
         Lm: numpy.ndarray,
@@ -497,7 +497,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
                 # \Lambda_m operators
                 Lm[a, b, ms] += cc_mnab * Km[ms, a, b]
 
-    def _guts_Cmplx_Sum(
+    def _guts_Cmplx_Sum(  # type: ignore[explicit-any]
         self,
         ms: int,
         Lm: numpy.ndarray,
@@ -525,7 +525,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
                 # \Lambda_m operators
                 Lm[a, b, ms] += cc_mnab * Km[ms, a, b]
 
-    def _guts_Cmplx_FFT(
+    def _guts_Cmplx_FFT(  # type: ignore[explicit-any]
         self,
         ms: int,
         Lm: numpy.ndarray,
@@ -559,7 +559,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
                 # \Lambda_m operators
                 Lm[a, b, ms] += cc_mnab * Km[ms, a, b]
 
-    def _convert_operators_2_tensor(
+    def _convert_operators_2_tensor(  # type: ignore[explicit-any]
         self, Km: numpy.ndarray, Lm: numpy.ndarray, Ld: numpy.ndarray
     ) -> numpy.ndarray:
         r"""Converts operator representation to the tensor one
@@ -631,7 +631,7 @@ class RedfieldRelaxationTensor(RelaxationTensor):
             self.as_operators = False
 
 
-def _loopit(
+def _loopit(  # type: ignore[explicit-any]
     Km: numpy.ndarray,
     Kd: numpy.ndarray,
     Lm: numpy.ndarray,
@@ -654,7 +654,7 @@ def _loopit(
                         RR[a, b, c, d] -= LdKm[d, b]
 
 
-def _integrate_last_axis(f: numpy.ndarray, dt: float) -> numpy.ndarray:
+def _integrate_last_axis(f: numpy.ndarray, dt: float) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Cumulative Simpson integration over the last axis of a 2D or higher NumPy array.
 
     Parameters:

--- a/quantarhei/qm/liouvillespace/relaxationtensor.py
+++ b/quantarhei/qm/liouvillespace/relaxationtensor.py
@@ -26,10 +26,10 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
         self.name = ""
         self.as_operators = False
 
-        self.Iterm: Any = None
+        self.Iterm: Any = None  # type: ignore[explicit-any]
         self.has_Iterm = False
 
-        self.Hamiltonian: Any = None
+        self.Hamiltonian: Any = None  # type: ignore[explicit-any]
 
     def _initialize_basis(self) -> None:
 
@@ -108,19 +108,19 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
             for ii in range(N):
                 self.secular_GG[:, ii, ii] = 0.0
 
-    def get_population_rate(self, N: int, M: int) -> Any:
+    def get_population_rate(self, N: int, M: int) -> Any:  # type: ignore[explicit-any]
         """Returns the relaxation rate from state M -> N"""
         return self.data[N, N, M, M]
 
-    def set_population_rate(self, N: int, M: int, val: Any) -> None:
+    def set_population_rate(self, N: int, M: int, val: Any) -> None:  # type: ignore[explicit-any]
         """Sets the relaxation rate from state M -> N"""
         self.data[N, N, M, M] = val
 
-    def get_dephasing_rate(self, N: int, M: int) -> Any:
+    def get_dephasing_rate(self, N: int, M: int) -> Any:  # type: ignore[explicit-any]
         """Returns the dephasing rate of a coherence between states N and M"""
         return -self.data[N, M, N, M]
 
-    def set_dephasing_rate(self, N: int, M: int, val: Any) -> None:
+    def set_dephasing_rate(self, N: int, M: int, val: Any) -> None:  # type: ignore[explicit-any]
         """Sets the dephasing rate of a coherence between states N and M"""
         self.data[N, M, N, M] = -val
 
@@ -197,7 +197,7 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
                         if ii != jj:
                             self.data[ii, jj, ii, jj] += Rdep[ii, jj]
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """Transformation of the tensor by a given matrix
 
 
@@ -291,7 +291,7 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
                     ) / 2.0
                     self._data[:, mm, nn, mm, nn] = self._data[:, nn, mm, nn, mm]
 
-    def __mult__(self, scalar: Any) -> RelaxationTensor:
+    def __mult__(self, scalar: Any) -> RelaxationTensor:  # type: ignore[explicit-any]
         """Multiplication of the Tensor by a scalar"""
         import numbers
 
@@ -304,7 +304,7 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
         self._data = self._data * scalar
         return self
 
-    def __rmult__(self, scalar: Any) -> RelaxationTensor:
+    def __rmult__(self, scalar: Any) -> RelaxationTensor:  # type: ignore[explicit-any]
         return self.__mult__(scalar)
 
     def __add__(self, other: RelaxationTensor) -> RelaxationTensor:
@@ -316,14 +316,14 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
         self._data += other._data
         return self
 
-    def _rhs(self, rho: Any) -> Any:
+    def _rhs(self, rho: Any) -> Any:  # type: ignore[explicit-any]
         """Applies the tensor to a given matrix"""
         if self.as_operators:
             return self._rhs_as_operators(rho)
 
         return self._rhs_as_tensor(rho)
 
-    def _rhs_as_operators(self, rho: Any) -> Any:
+    def _rhs_as_operators(self, rho: Any) -> Any:  # type: ignore[explicit-any]
         """Applies the tensor in form of a set of operators to a given matrix
 
         Parameters
@@ -340,7 +340,7 @@ class RelaxationTensor(SuperOperator, Secular, Saveable):
         """
         pass
 
-    def _rhs_as_tensor(self, rho: Any) -> Any:
+    def _rhs_as_tensor(self, rho: Any) -> Any:  # type: ignore[explicit-any]
         """Applies the tensor to a given matrix
 
         Parameters

--- a/quantarhei/qm/liouvillespace/secular.py
+++ b/quantarhei/qm/liouvillespace/secular.py
@@ -96,10 +96,10 @@ class Secular:
     secular_reversible = False
 
     # operator whose eigenstates for the basis in which this object is secular
-    secular_basis_op: Any = None
+    secular_basis_op: Any = None  # type: ignore[explicit-any]
 
     # These attributes are expected to be defined by concrete subclasses
-    data: Any
+    data: Any  # type: ignore[explicit-any]
     as_operators: bool
     _has_rates: bool
 
@@ -108,10 +108,10 @@ class Secular:
     #
 
     # coherence decay rates
-    secular_GG: ndarray | None = None
+    secular_GG: ndarray | None = None  # type: ignore[explicit-any]
 
     # population tranfer rates
-    secular_KK: Any = None
+    secular_KK: Any = None  # type: ignore[explicit-any]
 
     ###########################################################################
     #
@@ -177,7 +177,7 @@ class Secular:
                     " secularization was performed irreversibly"
                 )
 
-    def get_secular_basis_operator(self) -> Any:
+    def get_secular_basis_operator(self) -> Any:  # type: ignore[explicit-any]
         """Returns the operator to ensure the correct basis context"""
         return self.secular_basis_op
 
@@ -248,7 +248,7 @@ class Secular:
                             ):
                                 self.data[:, ii, jj, kk, ll] = 0
 
-    def apply(self, rho: Any) -> Any:
+    def apply(self, rho: Any) -> Any:  # type: ignore[explicit-any]
         """Application of the secular tensor on the statistical operator"""
         #        rhoret = -self.secular_GG*rho.data
         #        if self._has_rates:
@@ -258,7 +258,7 @@ class Secular:
         # FIXME: time this to find out how bad is to call additional function
         return self._apply(rho.data)
 
-    def _apply(self, rho: Any) -> Any:
+    def _apply(self, rho: Any) -> Any:  # type: ignore[explicit-any]
         """Application of the tensor directly to an array"""
         rhoret = -self.secular_GG * rho
         if self._has_rates:
@@ -270,6 +270,6 @@ class Secular:
     #
     ###########################################################################
 
-    def _get_current_basis_op(self) -> Any:
+    def _get_current_basis_op(self) -> Any:  # type: ignore[explicit-any]
         """Returns the operator which defines the currently used basis"""
         return Manager().current_basis_operator

--- a/quantarhei/qm/liouvillespace/superoperator.py
+++ b/quantarhei/qm/liouvillespace/superoperator.py
@@ -83,11 +83,11 @@ class SuperOperator(BasisManaged):
 
     """
 
-    data: numpy.ndarray = BasisManagedComplexArray("data")  # type: ignore[assignment]
-    _data: numpy.ndarray
+    data: numpy.ndarray = BasisManagedComplexArray("data")  # type: ignore[assignment, explicit-any]
+    _data: numpy.ndarray  # type: ignore[explicit-any]
     name: str = ""
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, dim: int | None = None, data: Any = None, real: bool = False
     ) -> None:
 
@@ -117,7 +117,7 @@ class SuperOperator(BasisManaged):
                 )
             self.dim = data.shape[0]
 
-    def apply(self, oper: Any, target: Any = None, copy: bool = True) -> Any:
+    def apply(self, oper: Any, target: Any = None, copy: bool = True) -> Any:  # type: ignore[explicit-any]
         """Applies superoperator to an operator
 
 
@@ -196,7 +196,7 @@ class SuperOperator(BasisManaged):
         oper.data = numpy.tensordot(self.data, oper.data)
         return oper
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """Transforms the superoperator to a new basis
 
 

--- a/quantarhei/qm/liouvillespace/superoperator_test.py
+++ b/quantarhei/qm/liouvillespace/superoperator_test.py
@@ -72,9 +72,9 @@ class TestSuperOperator(SuperOperator):
         else:
             raise QuantarheiError("Unknown test name")
 
-    def _def_A(self, dim: int) -> numpy.ndarray:
+    def _def_A(self, dim: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Defines the matrix A for constuction of a super operator"""
-        A: numpy.ndarray = numpy.zeros((dim, dim), dtype=qr.COMPLEX)
+        A: numpy.ndarray = numpy.zeros((dim, dim), dtype=qr.COMPLEX)  # type: ignore[explicit-any]
 
         for k_i in range(dim):
             A[k_i, k_i] = k_i

--- a/quantarhei/qm/liouvillespace/supopunity.py
+++ b/quantarhei/qm/liouvillespace/supopunity.py
@@ -68,7 +68,7 @@ class SOpUnity(SuperOperator):
 
     """
 
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:
+    def __init__(self, dim: int | None = None, data: Any = None) -> None:  # type: ignore[explicit-any]
 
         if data is not None:
             dim = data.shape[0]

--- a/quantarhei/qm/liouvillespace/systembathinteraction.py
+++ b/quantarhei/qm/liouvillespace/systembathinteraction.py
@@ -79,7 +79,7 @@ class SystemBathInteraction(Saveable):
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         sys_operators: Any = None,
         bath_correlation_matrix: Any = None,
@@ -96,15 +96,15 @@ class SystemBathInteraction(Saveable):
         self.aggregate: Aggregate | None = None
         self.molecule: Molecule | None = None
         self.system: Aggregate | Molecule | OpenSystem | None = None
-        self.rates: Any = None
-        self.KK: numpy.ndarray | None = None
+        self.rates: Any = None  # type: ignore[explicit-any]
+        self.KK: numpy.ndarray | None = None  # type: ignore[explicit-any]
         self.CC: CorrelationFunctionMatrix | None = None  # correlation function matrix
         self.GG: FunctionStorage | None = None  # lineshape function storage
         self.TimeAxis: TimeAxis | None = None
-        self.drates: Any = None
+        self.drates: Any = None  # type: ignore[explicit-any]
         self.N = 0
-        self.osites: Any = None
-        self.orates: Any = None
+        self.osites: Any = None  # type: ignore[explicit-any]
+        self.orates: Any = None  # type: ignore[explicit-any]
         self.sbitype = "Linear_Coupling"
 
         self._has_gg_storage = False
@@ -207,7 +207,7 @@ class SystemBathInteraction(Saveable):
             self.orates = orates
             self.osites = osites
 
-    def set_system(self, system: Any) -> None:
+    def set_system(self, system: Any) -> None:  # type: ignore[explicit-any]
         """Sets the system attribute"""
         from ...builders.aggregates import Aggregate
         from ...builders.molecules import Molecule
@@ -232,7 +232,7 @@ class SystemBathInteraction(Saveable):
             else:
                 raise QuantarheiError("Unknown system type")
 
-    def _set_operators(self, sys_operators: Any) -> None:
+    def _set_operators(self, sys_operators: Any) -> None:  # type: ignore[explicit-any]
         """Sets the system part of the interaction"""
         # First of the operators
         KK = sys_operators[0]
@@ -254,15 +254,15 @@ class SystemBathInteraction(Saveable):
                     "Operators in the list are not of the same dimension"
                 )
 
-    def get_time_axis(self) -> Any:
+    def get_time_axis(self) -> Any:  # type: ignore[explicit-any]
         """Returns the time axis of the storred correlation functions"""
         return self.TimeAxis
 
-    def get_correlation_function(self, where: Any) -> Any:
+    def get_correlation_function(self, where: Any) -> Any:  # type: ignore[explicit-any]
         """Returns the bath correlation function object defined by a pair of sites (tuple)"""
         return self.CC.get_correlation_function(where[0], where[1])
 
-    def get_coft(self, n: int, m: int) -> Any:
+    def get_coft(self, n: int, m: int) -> Any:  # type: ignore[explicit-any]
         """Returns bath correlation function corresponding to sites n and m"""
         if self.sbitype != "Linear_Coupling":
             raise QuantarheiError(
@@ -303,7 +303,7 @@ class SystemBathInteraction(Saveable):
         assert self.CC is not None
         return self.CC._cofts[0, :]
 
-    def get_coft_elsig(self, n_sig: Any, m_sig: Any) -> Any:
+    def get_coft_elsig(self, n_sig: Any, m_sig: Any) -> Any:  # type: ignore[explicit-any]
         """Returns bath correlation based on electronic signatures"""
         if self.sbitype != "Linear_Coupling":
             raise QuantarheiError(
@@ -335,7 +335,7 @@ class SystemBathInteraction(Saveable):
         assert self.CC is not None
         return self.CC._cofts[0, :]
 
-    def get_goft_storage(
+    def get_goft_storage(  # type: ignore[explicit-any]
         self, config: dict | int | None = None, timeaxis: Any = None
     ) -> Any:
         """Returns a lineshape function storage based on correlation functions
@@ -421,7 +421,7 @@ class SystemBathInteraction(Saveable):
         """Returns temperature associated with the bath"""
         return self.CC.get_temperature()
 
-    def get_reorganization_energy(self, i: int, j: int | None = None) -> Any:
+    def get_reorganization_energy(self, i: int, j: int | None = None) -> Any:  # type: ignore[explicit-any]
         """Returns reorganization energy associated with a given site
 
         If one index `i` is specified, the function returns reorganization
@@ -439,7 +439,7 @@ class SystemBathInteraction(Saveable):
             j = i
         return self.CC.get_reorganization_energy(i, j)
 
-    def get_correlation_time(self, i: int, j: int | None = None) -> Any:
+    def get_correlation_time(self, i: int, j: int | None = None) -> Any:  # type: ignore[explicit-any]
 
         if (
             self.sbitype == "Lindblad_Form"

--- a/quantarhei/qm/liouvillespace/systembathinteraction.py
+++ b/quantarhei/qm/liouvillespace/systembathinteraction.py
@@ -16,7 +16,7 @@ from ...core.saveable import Saveable
 from ...core.time import TimeAxis
 from ...exceptions import QuantarheiError
 from ...qm.corfunctions.cfmatrix import CorrelationFunctionMatrix
-from ...qm.corfunctions.correlationfunctions import c2g
+from ...qm.corfunctions.correlationfunctions import CorrelationFunction, c2g
 from ...qm.corfunctions.functionstorage import FunctionStorage
 
 if TYPE_CHECKING:
@@ -207,7 +207,7 @@ class SystemBathInteraction(Saveable):
             self.orates = orates
             self.osites = osites
 
-    def set_system(self, system: Any) -> None:  # type: ignore[explicit-any]
+    def set_system(self, system: Aggregate | Molecule | OpenSystem | None) -> None:
         """Sets the system attribute"""
         from ...builders.aggregates import Aggregate
         from ...builders.molecules import Molecule
@@ -254,15 +254,15 @@ class SystemBathInteraction(Saveable):
                     "Operators in the list are not of the same dimension"
                 )
 
-    def get_time_axis(self) -> Any:  # type: ignore[explicit-any]
+    def get_time_axis(self) -> TimeAxis:
         """Returns the time axis of the storred correlation functions"""
         return self.TimeAxis
 
-    def get_correlation_function(self, where: Any) -> Any:  # type: ignore[explicit-any]
+    def get_correlation_function(self, where: tuple[int, int]) -> CorrelationFunction:  # type: ignore[explicit-any]
         """Returns the bath correlation function object defined by a pair of sites (tuple)"""
         return self.CC.get_correlation_function(where[0], where[1])
 
-    def get_coft(self, n: int, m: int) -> Any:  # type: ignore[explicit-any]
+    def get_coft(self, n: int, m: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns bath correlation function corresponding to sites n and m"""
         if self.sbitype != "Linear_Coupling":
             raise QuantarheiError(
@@ -421,7 +421,9 @@ class SystemBathInteraction(Saveable):
         """Returns temperature associated with the bath"""
         return self.CC.get_temperature()
 
-    def get_reorganization_energy(self, i: int, j: int | None = None) -> Any:  # type: ignore[explicit-any]
+    def get_reorganization_energy(  # type: ignore[explicit-any]
+        self, i: int, j: int | None = None
+    ) -> float | numpy.ndarray | None:
         """Returns reorganization energy associated with a given site
 
         If one index `i` is specified, the function returns reorganization
@@ -439,7 +441,9 @@ class SystemBathInteraction(Saveable):
             j = i
         return self.CC.get_reorganization_energy(i, j)
 
-    def get_correlation_time(self, i: int, j: int | None = None) -> Any:  # type: ignore[explicit-any]
+    def get_correlation_time(  # type: ignore[explicit-any]
+        self, i: int, j: int | None = None
+    ) -> float | numpy.ndarray | None:
 
         if (
             self.sbitype == "Lindblad_Form"

--- a/quantarhei/qm/liouvillespace/systembathinteraction_test.py
+++ b/quantarhei/qm/liouvillespace/systembathinteraction_test.py
@@ -67,7 +67,7 @@ class TestSystemBathInteraction(SystemBathInteraction):
             agg = TestAggregate(name="dimer-2")
             agg.build()
 
-            _ham: Any = agg.get_Hamiltonian()
+            _ham: Any = agg.get_Hamiltonian()  # type: ignore[explicit-any]
             N = _ham.dim
 
             P1 = ProjectionOperator(1, 2, dim=N)
@@ -115,6 +115,6 @@ class TestSystemBathInteraction(SystemBathInteraction):
 
             sys_ops = [P1, P2]
             rates = [1.0 / 100.0, 1.0 / 200]
-            ctimes: list[Any] = []
+            ctimes: list[Any] = []  # type: ignore[explicit-any]
 
             super().__init__(sys_operators=sys_ops, rates=rates)

--- a/quantarhei/qm/liouvillespace/tdfoerstertensor.py
+++ b/quantarhei/qm/liouvillespace/tdfoerstertensor.py
@@ -110,7 +110,7 @@ class TDFoersterRelaxationTensor(FoersterRelaxationTensor, TimeDependent):
                 if aa != bb:
                     self.data[:, aa, bb, aa, bb] -= ht[aa, :] + ht[bb, :]
 
-    def td_reference_implementation(
+    def td_reference_implementation(  # type: ignore[explicit-any]
         self,
         Na: int,
         Nt: int,

--- a/quantarhei/qm/liouvillespace/tdmodredfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/tdmodredfieldtensor.py
@@ -162,7 +162,7 @@ class TDModRedfieldRelaxationTensor(RelaxationTensor, TimeDependent):
                         self.data[:, mm, nn, mm, nn] = self.data[:, nn, mm, nn, mm]
 
 
-def intfull(F: numpy.ndarray, dt: float, omega: float) -> Any:
+def intfull(F: numpy.ndarray, dt: float, omega: float) -> Any:  # type: ignore[explicit-any]
     """Discrete integration of an oscillating function"""
     Nt = F.shape[0]
     x = (1.0 - numpy.exp(-1j * omega * dt)) / (1j * omega * dt)
@@ -172,10 +172,10 @@ def intfull(F: numpy.ndarray, dt: float, omega: float) -> Any:
     return I
 
 
-def intrun(F: numpy.ndarray, dt: float, omega: float) -> numpy.ndarray:
+def intrun(F: numpy.ndarray, dt: float, omega: float) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Running intergration of an oscillating function of one parameter"""
     Nt = F.shape[0]
-    I: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+    I: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
     x = (1.0 - numpy.exp(-1j * omega * dt)) / (1j * omega * dt)
     y = (1.0 - x) / (1j * omega)
 
@@ -187,16 +187,16 @@ def intrun(F: numpy.ndarray, dt: float, omega: float) -> numpy.ndarray:
     return I
 
 
-def intruntrap(F: numpy.ndarray, dt: float) -> numpy.ndarray:
+def intruntrap(F: numpy.ndarray, dt: float) -> numpy.ndarray:  # type: ignore[explicit-any]
     Nt = F.shape[0]
-    I: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+    I: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
     for ii in range(1, Nt):
         I[ii] = I[ii - 1] + F[ii] * dt / 2.0 + F[ii - 1] * dt / 2.0
 
     return I
 
 
-def intfullsec(F: numpy.ndarray, dt: float, omega: float, Nt: int) -> Any:
+def intfullsec(F: numpy.ndarray, dt: float, omega: float, Nt: int) -> Any:  # type: ignore[explicit-any]
     """Integrate only a section of a give function F
 
     This is used when the function depends explicitely on time (the upper limit)
@@ -215,7 +215,7 @@ def intfullsec(F: numpy.ndarray, dt: float, omega: float, Nt: int) -> Any:
     return I
 
 
-def ssmodr(
+def ssmodr(  # type: ignore[explicit-any]
     Na: int,
     ee: numpy.ndarray,
     ll: numpy.ndarray,
@@ -287,15 +287,15 @@ def ssmodr(
 
     # Relaxation rate matrix (may be time-dependent)
     if tdep:
-        RR: numpy.ndarray = numpy.zeros((Na + 1, Na + 1, Nt), dtype=REAL)
-        Iterm: numpy.ndarray = numpy.zeros((Na + 1, Na + 1, Nt), dtype=COMPLEX)
+        RR: numpy.ndarray = numpy.zeros((Na + 1, Na + 1, Nt), dtype=REAL)  # type: ignore[explicit-any]
+        Iterm: numpy.ndarray = numpy.zeros((Na + 1, Na + 1, Nt), dtype=COMPLEX)  # type: ignore[explicit-any]
     else:
         RR = numpy.zeros((Na + 1, Na + 1), dtype=REAL)
         Iterm = numpy.zeros((Na + 1, Na + 1), dtype=REAL)
 
     # Various storage variables
-    cbaab: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
-    Nab: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+    cbaab: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
+    Nab: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
 
     # time step
     dt = tt[1] - tt[0]
@@ -372,7 +372,7 @@ def ssmodr(
         # Modified Redfield theory (equilibrium version)
         #
         #
-        mm: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+        mm: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
 
         for a in range(Na + 1):
             aa = -1j * ee[a] * tt
@@ -500,7 +500,7 @@ def ssmodr(
         #
         #
         mm = numpy.zeros(Nt, dtype=COMPLEX)
-        mr: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)
+        mr: numpy.ndarray = numpy.zeros(Nt, dtype=COMPLEX)  # type: ignore[explicit-any]
         fb = numpy.zeros(Nt, dtype=COMPLEX)
 
         for a in range(Na + 1):

--- a/quantarhei/qm/liouvillespace/tdredfieldfoerster.py
+++ b/quantarhei/qm/liouvillespace/tdredfieldfoerster.py
@@ -183,7 +183,7 @@ class TDRedfieldFoersterRelaxationTensor(
             # Add the rates to the Redfield
             #
             for b in range(Na):
-                gg: numpy.ndarray = numpy.zeros(Nt, dtype=numpy.float64)
+                gg: numpy.ndarray = numpy.zeros(Nt, dtype=numpy.float64)  # type: ignore[explicit-any]
                 for a in range(Na):
                     self.data[:, a, a, b, b] += KF[:, a, b]
                     gg += KF[:, a, b]

--- a/quantarhei/qm/liouvillespace/tdredfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/tdredfieldtensor.py
@@ -13,9 +13,9 @@ from .redfieldtensor import RedfieldRelaxationTensor
 
 class TDRedfieldRelaxationTensor(RedfieldRelaxationTensor, TimeDependent):
     # Shadow parent descriptors with plain ndarray attrs (time-dependent case stores full trajectories)
-    Lm: numpy.ndarray | None = None
-    Ld: numpy.ndarray | None = None
-    Km: numpy.ndarray | None = None
+    Lm: numpy.ndarray | None = None  # type: ignore[explicit-any]
+    Ld: numpy.ndarray | None = None  # type: ignore[explicit-any]
+    Km: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
     def _implementation(self, ham: Hamiltonian, sbi: SystemBathInteraction) -> None:
         r"""Reference implementation, completely in Python
@@ -125,7 +125,7 @@ class TDRedfieldRelaxationTensor(RedfieldRelaxationTensor, TimeDependent):
             Nb2 = sbi.N
 
             # projectors to two-exciton states
-            K2: numpy.ndarray = numpy.zeros((Nb2, Na, Na), dtype=REAL)
+            K2: numpy.ndarray = numpy.zeros((Nb2, Na, Na), dtype=REAL)  # type: ignore[explicit-any]
             assert ham.rwa_indices is not None, (
                 "Hamiltonian must have rwa_indices set for multi-exciton"
             )
@@ -216,7 +216,7 @@ class TDRedfieldRelaxationTensor(RedfieldRelaxationTensor, TimeDependent):
         self._is_initialized = True
         self.is_time_dependent = True
 
-    def _convert_operators_2_tensor(
+    def _convert_operators_2_tensor(  # type: ignore[explicit-any]
         self, Km: numpy.ndarray, Lm: numpy.ndarray, Ld: numpy.ndarray
     ) -> numpy.ndarray:
         r"""Converts operator representation to the tensor one
@@ -289,7 +289,7 @@ class TDRedfieldRelaxationTensor(RedfieldRelaxationTensor, TimeDependent):
 
         return RR
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """Transformation of the tensor by a given matrix
 
 
@@ -360,7 +360,7 @@ class TDRedfieldRelaxationTensor(RedfieldRelaxationTensor, TimeDependent):
                                 self.data[:, ii, jj, kk, ll] = 0
 
 
-def _integrate(f: numpy.ndarray, dt: float) -> numpy.ndarray:
+def _integrate(f: numpy.ndarray, dt: float) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Cummulative simpson rule for integration (even number of points also handled)"""
     N = len(f)
     if N < 2:
@@ -382,7 +382,7 @@ def _integrate(f: numpy.ndarray, dt: float) -> numpy.ndarray:
     return F
 
 
-def _integrate_last_axis(f: numpy.ndarray, dt: float) -> numpy.ndarray:
+def _integrate_last_axis(f: numpy.ndarray, dt: float) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Cumulative Simpson integration over the last axis of a 2D or higher NumPy array.
 
     Parameters:

--- a/quantarhei/qm/oscillators/ho.py
+++ b/quantarhei/qm/oscillators/ho.py
@@ -30,7 +30,7 @@ class fcstorage(Saveable):
     def __init__(self) -> None:
         """Constructor"""
         self._shifts: list[float] = []
-        self._fcs: list[numpy.ndarray] = []
+        self._fcs: list[numpy.ndarray] = []  # type: ignore[explicit-any]
 
     def lookup(self, shift: float) -> bool:
         """Returns true if the FC factors for a given shift are available"""
@@ -42,12 +42,12 @@ class fcstorage(Saveable):
         """Returns an index of the FC factors with a given shift"""
         return self._shifts.index(shift)
 
-    def add(self, shift: float, fcmatrix: numpy.ndarray) -> None:
+    def add(self, shift: float, fcmatrix: numpy.ndarray) -> None:  # type: ignore[explicit-any]
         """Adds the matrix of FC factors to the storage"""
         self._shifts.append(shift)
         self._fcs.append(fcmatrix)
 
-    def get(self, ii: int) -> numpy.ndarray:
+    def get(self, ii: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns a stored FC matrix"""
         return self._fcs[ii]
 
@@ -65,9 +65,9 @@ class operator_factory(Saveable):
         # to represent all operators
         self.N = N
 
-    def anihilation_operator(self) -> numpy.ndarray:
+    def anihilation_operator(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         N = self.N
-        aa: numpy.ndarray = numpy.zeros(
+        aa: numpy.ndarray = numpy.zeros(  # type: ignore[explicit-any]
             (N, N), dtype=REAL
         )  # matrix N x N full of zeros
 
@@ -78,9 +78,9 @@ class operator_factory(Saveable):
 
         return aa
 
-    def creation_operator(self) -> numpy.ndarray:
+    def creation_operator(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         N = self.N
-        ad: numpy.ndarray = numpy.zeros((N, N), dtype=REAL)
+        ad: numpy.ndarray = numpy.zeros((N, N), dtype=REAL)  # type: ignore[explicit-any]
 
         for ng in range(N):
             for mg in range(N):
@@ -89,7 +89,7 @@ class operator_factory(Saveable):
 
         return ad
 
-    def shift_operator(self, dd_: Any) -> numpy.ndarray:
+    def shift_operator(self, dd_: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates the Shift Operator based on the size N_ of the basis
         of states and the shift dd_.
 
@@ -181,7 +181,7 @@ class operator_factory(Saveable):
         ad = self.creation_operator()
 
         # construct the Shift Operator
-        Dd_large: numpy.ndarray = numpy.zeros((N_, N_), dtype=COMPLEX)
+        Dd_large: numpy.ndarray = numpy.zeros((N_, N_), dtype=COMPLEX)  # type: ignore[explicit-any]
         Dd_large = (dd_ * ad - numpy.conj(dd_) * aa) / numpy.sqrt(2.0)
 
         # Diagonalize and obtain transformation matrix
@@ -194,9 +194,9 @@ class operator_factory(Saveable):
         # Transform back and reduce to the lower number of states
         return numpy.dot(S, numpy.dot(Dd_large, S1))
 
-    def unity_operator(self) -> numpy.ndarray:
+    def unity_operator(self) -> numpy.ndarray:  # type: ignore[explicit-any]
 
-        ones: numpy.ndarray = numpy.ones(self.N, dtype=REAL)
+        ones: numpy.ndarray = numpy.ones(self.N, dtype=REAL)  # type: ignore[explicit-any]
         ret = numpy.diag(ones)
         return ret
 
@@ -204,7 +204,7 @@ class operator_factory(Saveable):
 class qrepresentation:
     """Coordinate representation of the HO wavefunctions"""
 
-    def __init__(self, qaxis: Any) -> None:
+    def __init__(self, qaxis: Any) -> None:  # type: ignore[explicit-any]
 
         self.qaxis = qaxis
         self.ho_eigenfce_generated = False
@@ -227,7 +227,7 @@ class qrepresentation:
 
         return psi0
 
-    def get_coherent_state(self, alpha: Any) -> DFunction:
+    def get_coherent_state(self, alpha: Any) -> DFunction:  # type: ignore[explicit-any]
         """Returns q-representation of a coherent state with a given alpha"""
         ar = numpy.real(alpha)
         ai = numpy.imag(alpha)
@@ -243,6 +243,6 @@ class qrepresentation:
 
         return psi_alpha
 
-    def get_probability_distribution(self, wfce: Any) -> DFunction:
+    def get_probability_distribution(self, wfce: Any) -> DFunction:  # type: ignore[explicit-any]
         """Returns probability distribution for a given wavefunction"""
         return DFunction(x=wfce.axis, y=numpy.abs(wfce.data) ** 2)

--- a/quantarhei/qm/propagators/dmevolution.py
+++ b/quantarhei/qm/propagators/dmevolution.py
@@ -8,10 +8,10 @@ import numpy
 from ...core.managers import BasisManaged
 from ...core.matrixdata import MatrixData
 from ...core.saveable import Saveable
+from ...core.time import TimeAxis
 from ...exceptions import QuantarheiError
-
-# from ...core.time import TimeAxis
 from ...utils.types import BasisManagedComplexArray
+from ..hilbertspace.hamiltonian import Hamiltonian
 from ..hilbertspace.operators import DensityMatrix, ReducedDensityMatrix
 
 
@@ -43,7 +43,9 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
 
         self.is_in_rwa = is_in_rwa
 
-    def set_initial_condition(self, rhoi: Any) -> None:  # type: ignore[explicit-any]
+    def set_initial_condition(
+        self, rhoi: ReducedDensityMatrix | DensityMatrix | numpy.ndarray
+    ) -> None:  # type: ignore[explicit-any]
         """ """
         self.dim = rhoi.data.shape[1]
         self._data = numpy.zeros(
@@ -99,11 +101,11 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
         tr = numpy.trace(self.data[0, :, :])
         self.data = self.data / tr
 
-    def get_TimeAxis(self) -> Any:  # type: ignore[explicit-any]
+    def get_TimeAxis(self) -> TimeAxis:
         """Returns the TimeAxis of the present evolution"""
         return self.TimeAxis
 
-    def convert_from_RWA(self, ham: Any, sgn: int = 1) -> None:  # type: ignore[explicit-any]
+    def convert_from_RWA(self, ham: Hamiltonian, sgn: int = 1) -> None:
         """Converts density matrix evolution from RWA to standard repre
 
 
@@ -130,7 +132,7 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
         if sgn == 1:
             self.is_in_rwa = False
 
-    def convert_to_RWA(self, ham: Any) -> None:  # type: ignore[explicit-any]
+    def convert_to_RWA(self, ham: Hamiltonian) -> None:
         """Converts density matrix evolution from standard repre to RWA
 
 

--- a/quantarhei/qm/propagators/dmevolution.py
+++ b/quantarhei/qm/propagators/dmevolution.py
@@ -18,7 +18,7 @@ from ..hilbertspace.operators import DensityMatrix, ReducedDensityMatrix
 class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
     data = BasisManagedComplexArray("data")
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any = None,
         rhoi: Any = None,
@@ -43,7 +43,7 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
 
         self.is_in_rwa = is_in_rwa
 
-    def set_initial_condition(self, rhoi: Any) -> None:
+    def set_initial_condition(self, rhoi: Any) -> None:  # type: ignore[explicit-any]
         """ """
         self.dim = rhoi.data.shape[1]
         self._data = numpy.zeros(
@@ -66,7 +66,7 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
 
         return DensityMatrix(data=self.data[ti, :, :])
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """Transformation of the operator by a given matrix
 
 
@@ -99,11 +99,11 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
         tr = numpy.trace(self.data[0, :, :])
         self.data = self.data / tr
 
-    def get_TimeAxis(self) -> Any:
+    def get_TimeAxis(self) -> Any:  # type: ignore[explicit-any]
         """Returns the TimeAxis of the present evolution"""
         return self.TimeAxis
 
-    def convert_from_RWA(self, ham: Any, sgn: int = 1) -> None:
+    def convert_from_RWA(self, ham: Any, sgn: int = 1) -> None:  # type: ignore[explicit-any]
         """Converts density matrix evolution from RWA to standard repre
 
 
@@ -130,7 +130,7 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
         if sgn == 1:
             self.is_in_rwa = False
 
-    def convert_to_RWA(self, ham: Any) -> None:
+    def convert_to_RWA(self, ham: Any) -> None:  # type: ignore[explicit-any]
         """Converts density matrix evolution from standard repre to RWA
 
 
@@ -144,7 +144,7 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
             self.convert_from_RWA(ham, sgn=-1)
             self.is_in_rwa = True
 
-    def plot(
+    def plot(  # type: ignore[explicit-any]
         self,
         populations: bool = True,
         popselection: str = "All",
@@ -164,7 +164,7 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
         population_sum = False
         # populations=False
 
-        howi: Any = ["-k", "-r", "-b", "-g", "-m", "-y", "-c"]
+        howi: Any = ["-k", "-r", "-b", "-g", "-m", "-y", "-c"]  # type: ignore[explicit-any]
         if how == "-":
             howi = ["-k", "-r", "-b", "-g", "-m", "-y", "-c"]
         if how == "--":
@@ -238,7 +238,7 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
         if show:
             plt.show()
 
-    def _exportDataToText(self, file: Any) -> None:
+    def _exportDataToText(self, file: Any) -> None:  # type: ignore[explicit-any]
         """Saves textual data to a file"""
         Nt = self.data.shape[0]
         N = self.data.shape[1]

--- a/quantarhei/qm/propagators/oqssvevolution.py
+++ b/quantarhei/qm/propagators/oqssvevolution.py
@@ -26,7 +26,7 @@ class OQSStateVectorEvolution:
         Default is ``None``.
     """
 
-    def __init__(self, timeaxis: Any = None, psii: Any = None) -> None:
+    def __init__(self, timeaxis: Any = None, psii: Any = None) -> None:  # type: ignore[explicit-any]
 
         if timeaxis is not None:
             self.TimeAxis = timeaxis
@@ -38,13 +38,13 @@ class OQSStateVectorEvolution:
             else:
                 self.dim = 0
 
-    def set_initial_condition(self, psii: Any) -> None:
+    def set_initial_condition(self, psii: Any) -> None:  # type: ignore[explicit-any]
         """ """
         self.dim = psii.data.shape[0]
         self.data = numpy.zeros((self.TimeAxis.length, self.dim), dtype=numpy.float64)
         self.data[0, :] = psii.data
 
-    def get_norm(self) -> numpy.ndarray:
+    def get_norm(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Time dependent norm of the state vector"""
         return numpy.sum(self.data * self.data, axis=1)
 

--- a/quantarhei/qm/propagators/oqssvevolution.py
+++ b/quantarhei/qm/propagators/oqssvevolution.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
-
 import numpy
 
 from ... import REAL
+from ...core.time import TimeAxis
 from ...exceptions import ImplementationError
+from ..hilbertspace.oqsstatevector import OQSStateVector
 from ..propagators.dmevolution import ReducedDensityMatrixEvolution
 
 
@@ -26,7 +26,9 @@ class OQSStateVectorEvolution:
         Default is ``None``.
     """
 
-    def __init__(self, timeaxis: Any = None, psii: Any = None) -> None:  # type: ignore[explicit-any]
+    def __init__(
+        self, timeaxis: TimeAxis | None = None, psii: OQSStateVector | None = None
+    ) -> None:
 
         if timeaxis is not None:
             self.TimeAxis = timeaxis
@@ -38,7 +40,7 @@ class OQSStateVectorEvolution:
             else:
                 self.dim = 0
 
-    def set_initial_condition(self, psii: Any) -> None:  # type: ignore[explicit-any]
+    def set_initial_condition(self, psii: OQSStateVector) -> None:
         """ """
         self.dim = psii.data.shape[0]
         self.data = numpy.zeros((self.TimeAxis.length, self.dim), dtype=numpy.float64)

--- a/quantarhei/qm/propagators/oqssvpropagator.py
+++ b/quantarhei/qm/propagators/oqssvpropagator.py
@@ -33,7 +33,7 @@ class OQSStateVectorPropagator:
         ``"Redfield"`` is supported. Default is ``"Redfield"``.
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any = None,
         current_matrix: Any = None,
@@ -70,7 +70,7 @@ class OQSStateVectorPropagator:
         self.Nref = Nref
         self.dt = self.Odt / self.Nref
 
-    def propagate(self, psii: Any, L: int = 4) -> Any:
+    def propagate(self, psii: Any, L: int = 4) -> Any:  # type: ignore[explicit-any]
         """Short expansion of an exponention to integrate equations of motion
 
 
@@ -84,7 +84,7 @@ class OQSStateVectorPropagator:
 
         return pr
 
-    def get_secular_dynamics(self, psii: Any, L: int = 4) -> Any:
+    def get_secular_dynamics(self, psii: Any, L: int = 4) -> Any:  # type: ignore[explicit-any]
         """Here we obtain the secular dynamics for self-consistent methodology"""
         pr = OQSStateVectorEvolution(self.TimeAxis, psii)
 
@@ -112,13 +112,13 @@ class OQSStateVectorPropagator:
 
             return pr
 
-    def get_c0(self, psii: Any, L: int = 4) -> Any:
+    def get_c0(self, psii: Any, L: int = 4) -> Any:  # type: ignore[explicit-any]
         """Returns the zero's order solution to the iterative problem"""
         return self.get_secular_dynamics(psii, L)
 
 
 # @njit(cache=True)
-def _CALC(
+def _CALC(  # type: ignore[explicit-any]
     KK: numpy.ndarray,
     psii: numpy.ndarray,
     Nt: int,

--- a/quantarhei/qm/propagators/poppropagator.py
+++ b/quantarhei/qm/propagators/poppropagator.py
@@ -29,7 +29,7 @@ class PopulationPropagator:
 
     """
 
-    def __init__(self, timeaxis: Any, rate_matrix: Any = None) -> None:
+    def __init__(self, timeaxis: Any, rate_matrix: Any = None) -> None:  # type: ignore[explicit-any]
 
         self.timeAxis = timeaxis
         self.Nref = 1
@@ -46,14 +46,14 @@ class PopulationPropagator:
                 self.KK = rate_matrix
             self.KK = numpy.asarray(self.KK)
 
-    def propagate(self, pini: Any) -> numpy.ndarray:
+    def propagate(self, pini: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Propagates a given initional population vector"""
         if not isinstance(pini, numpy.ndarray):
             pini = numpy.array(pini)
 
         return self._propagate_short_exp(pini)
 
-    def _propagate_short_exp(self, pini: numpy.ndarray, L: int = 4) -> numpy.ndarray:
+    def _propagate_short_exp(self, pini: numpy.ndarray, L: int = 4) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Propagation of the initial pop vector by short time expansion
 
         Propagates initial population vector by a give rate matrix with
@@ -94,7 +94,7 @@ class PopulationPropagator:
         KKT = self.KK + numpy.diag(KKD)
         return KKD, KKT
 
-    def _integrateK0(
+    def _integrateK0(  # type: ignore[explicit-any]
         self, timeaxis: Any, Kab: float, Ka: float, Kb: float
     ) -> numpy.ndarray:
         """Returns an integral of transfer matrix element"""
@@ -104,7 +104,7 @@ class PopulationPropagator:
             integ[i] = numpy.sum(expK[0:i])
         return Kab * integ * timeaxis.step
 
-    def _integrateKn(
+    def _integrateKn(  # type: ignore[explicit-any]
         self, timeaxis: Any, Kab: float, Ka: float, Kb: float, Kbc: numpy.ndarray
     ) -> numpy.ndarray:
         """Returns an integral of transfer matrix element multiplied by
@@ -118,7 +118,7 @@ class PopulationPropagator:
             integ[i] = numpy.sum(expK[0:i] * Kbc[0:i])
         return Kab * integ * timeaxis.step
 
-    def _time_indices(self, timeaxis: Any) -> numpy.ndarray:
+    def _time_indices(self, timeaxis: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns indices of ``timeaxis`` points on the internal time axis"""
         if not timeaxis.is_subset_of(self.timeAxis):
             raise Exception(
@@ -136,7 +136,7 @@ class PopulationPropagator:
 
         return indices
 
-    def _rate_matrix_time_series(self) -> numpy.ndarray:
+    def _rate_matrix_time_series(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns rate matrices as an array with shape ``(Nt, N, N)``"""
         KK = numpy.asarray(self.KK)
 
@@ -161,11 +161,11 @@ class PopulationPropagator:
 
         raise Exception("Rate matrix has to be an array of rank 2 or 3")
 
-    def _to_matrix_time_order(self, matrix_time: numpy.ndarray) -> numpy.ndarray:
+    def _to_matrix_time_order(self, matrix_time: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Converts ``(Nt, N, N)`` arrays to the historical ``(N, N, Nt)`` order"""
         return numpy.transpose(matrix_time, (1, 2, 0))
 
-    def _integrate_matrix_time_series(
+    def _integrate_matrix_time_series(  # type: ignore[explicit-any]
         self, matrix_time: numpy.ndarray
     ) -> numpy.ndarray:
         """Integrates a matrix-valued time series by the trapezoidal rule"""
@@ -180,7 +180,7 @@ class PopulationPropagator:
 
         return integral
 
-    def _no_jump_propagator(self, rates: numpy.ndarray) -> numpy.ndarray:
+    def _no_jump_propagator(self, rates: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates the diagonal no-jump propagator U0(t)"""
         Nt = self.timeAxis.length
         N = rates.shape[1]
@@ -198,7 +198,7 @@ class PopulationPropagator:
 
         return U0
 
-    def _interaction_picture_rates(
+    def _interaction_picture_rates(  # type: ignore[explicit-any]
         self, rates: numpy.ndarray
     ) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Returns U0(t) and interaction-picture transfer rates"""
@@ -222,7 +222,7 @@ class PopulationPropagator:
 
         return U0, KI
 
-    def _propagation_matrix_time_dependent(self, timeaxis: Any) -> numpy.ndarray:
+    def _propagation_matrix_time_dependent(self, timeaxis: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns propagation matrix for time-dependent rates by RK4."""
         indices = self._time_indices(timeaxis)
         rates = self._rate_matrix_time_series()
@@ -247,7 +247,7 @@ class PopulationPropagator:
 
         return self._to_matrix_time_order(U[indices])
 
-    def get_JumpExpansion(self, timeaxis: Any = None, max_order: int = 3) -> tuple:
+    def get_JumpExpansion(self, timeaxis: Any = None, max_order: int = 3) -> tuple:  # type: ignore[explicit-any]
         """Returns jump-expansion terms of the population propagator.
 
         The returned tuple contains matrices ``(U0, U1, ..., Un)`` in the
@@ -289,13 +289,13 @@ class PopulationPropagator:
 
         return tuple(propagators)
 
-    def get_KineticDecomposition(
+    def get_KineticDecomposition(  # type: ignore[explicit-any]
         self, timeaxis: Any = None, max_order: int = 3
     ) -> tuple:
         """Alias for :meth:`get_JumpExpansion`."""
         return self.get_JumpExpansion(timeaxis=timeaxis, max_order=max_order)
 
-    def get_PropagationMatrix(
+    def get_PropagationMatrix(  # type: ignore[explicit-any]
         self, timeaxis: Any, corrections: int = -1, exact: bool = False
     ) -> Any:
         """Returns propagation matrix corresponding to the present propagator

--- a/quantarhei/qm/propagators/poppropagator.py
+++ b/quantarhei/qm/propagators/poppropagator.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy
 
+from ...core.time import TimeAxis
 from ...exceptions import QuantarheiError
 from ..liouvillespace.rates.ratematrix import RateMatrix
 
@@ -29,7 +30,7 @@ class PopulationPropagator:
 
     """
 
-    def __init__(self, timeaxis: Any, rate_matrix: Any = None) -> None:  # type: ignore[explicit-any]
+    def __init__(self, timeaxis: TimeAxis, rate_matrix: Any = None) -> None:  # type: ignore[explicit-any]
 
         self.timeAxis = timeaxis
         self.Nref = 1
@@ -95,7 +96,7 @@ class PopulationPropagator:
         return KKD, KKT
 
     def _integrateK0(  # type: ignore[explicit-any]
-        self, timeaxis: Any, Kab: float, Ka: float, Kb: float
+        self, timeaxis: TimeAxis, Kab: float, Ka: float, Kb: float
     ) -> numpy.ndarray:
         """Returns an integral of transfer matrix element"""
         expK = numpy.exp((Ka - Kb) * timeaxis.data)
@@ -105,7 +106,7 @@ class PopulationPropagator:
         return Kab * integ * timeaxis.step
 
     def _integrateKn(  # type: ignore[explicit-any]
-        self, timeaxis: Any, Kab: float, Ka: float, Kb: float, Kbc: numpy.ndarray
+        self, timeaxis: TimeAxis, Kab: float, Ka: float, Kb: float, Kbc: numpy.ndarray
     ) -> numpy.ndarray:
         """Returns an integral of transfer matrix element multiplied by
         a result of previous order of expansion
@@ -118,7 +119,7 @@ class PopulationPropagator:
             integ[i] = numpy.sum(expK[0:i] * Kbc[0:i])
         return Kab * integ * timeaxis.step
 
-    def _time_indices(self, timeaxis: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
+    def _time_indices(self, timeaxis: TimeAxis) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns indices of ``timeaxis`` points on the internal time axis"""
         if not timeaxis.is_subset_of(self.timeAxis):
             raise Exception(
@@ -222,7 +223,7 @@ class PopulationPropagator:
 
         return U0, KI
 
-    def _propagation_matrix_time_dependent(self, timeaxis: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
+    def _propagation_matrix_time_dependent(self, timeaxis: TimeAxis) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns propagation matrix for time-dependent rates by RK4."""
         indices = self._time_indices(timeaxis)
         rates = self._rate_matrix_time_series()
@@ -247,7 +248,7 @@ class PopulationPropagator:
 
         return self._to_matrix_time_order(U[indices])
 
-    def get_JumpExpansion(self, timeaxis: Any = None, max_order: int = 3) -> tuple:  # type: ignore[explicit-any]
+    def get_JumpExpansion(self, timeaxis: TimeAxis = None, max_order: int = 3) -> tuple:  # type: ignore[explicit-any]
         """Returns jump-expansion terms of the population propagator.
 
         The returned tuple contains matrices ``(U0, U1, ..., Un)`` in the
@@ -290,13 +291,13 @@ class PopulationPropagator:
         return tuple(propagators)
 
     def get_KineticDecomposition(  # type: ignore[explicit-any]
-        self, timeaxis: Any = None, max_order: int = 3
+        self, timeaxis: TimeAxis = None, max_order: int = 3
     ) -> tuple:
         """Alias for :meth:`get_JumpExpansion`."""
         return self.get_JumpExpansion(timeaxis=timeaxis, max_order=max_order)
 
     def get_PropagationMatrix(  # type: ignore[explicit-any]
-        self, timeaxis: Any, corrections: int = -1, exact: bool = False
+        self, timeaxis: TimeAxis, corrections: int = -1, exact: bool = False
     ) -> Any:
         """Returns propagation matrix corresponding to the present propagator
 

--- a/quantarhei/qm/propagators/rdmpropagator.py
+++ b/quantarhei/qm/propagators/rdmpropagator.py
@@ -75,11 +75,11 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         If ``timeaxis`` is not a :class:`TimeAxis` or ``Ham`` is missing.
     """
 
-    Efield: Any
-    EField: Any
-    RelaxationTensor: Any
+    Efield: Any  # type: ignore[explicit-any]
+    EField: Any  # type: ignore[explicit-any]
+    RelaxationTensor: Any  # type: ignore[explicit-any]
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any = None,
         Ham: Any = None,
@@ -244,7 +244,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         self.Nref = Nref
         self.dt = self.Odt / self.Nref
 
-    def propagate(
+    def propagate(  # type: ignore[explicit-any]
         self, rhoi: Any, method: str = "short-exp", mdata: Any = None, Nref: int = 1
     ) -> Any:
         """Propagate the density matrix forward in time.
@@ -509,7 +509,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
                 raise QuantarheiError("Unknown propagation method: " + method)
 
-    def __propagate_short_exp(
+    def __propagate_short_exp(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
         """Short expansion of an exponention to integrate equations of motion
@@ -541,7 +541,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def _INIT_EXP(self, rhoi: Any) -> tuple:
+    def _INIT_EXP(self, rhoi: Any) -> tuple:  # type: ignore[explicit-any]
         """Parameters
         ----------
         rhoi : TYPE
@@ -563,7 +563,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return (pr, rho1, rho2)
 
-    def _INIT_RWA(self) -> numpy.ndarray:
+    def _INIT_RWA(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Create Hamiltonian matrix respecting RWA settings
 
         Parameters
@@ -587,7 +587,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return HH
 
-    def _CLOSE_RWA(self, pr: Any) -> None:
+    def _CLOSE_RWA(self, pr: Any) -> None:  # type: ignore[explicit-any]
         """Closes the RWA treatment
 
         Parameters
@@ -605,19 +605,19 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         if self.Hamiltonian.has_rwa:
             pr.is_in_rwa = True
 
-    def __propagate_short_exp_efield(
+    def __propagate_short_exp_efield(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
 
         raise ImplementationError("NOT IMPLEMENTED")
 
-    def __propagate_short_exp_EField(
+    def __propagate_short_exp_EField(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
 
         raise ImplementationError("NOT IMPLEMENTED")
 
-    def __propagate_short_exp_with_relaxation(
+    def __propagate_short_exp_with_relaxation(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
         """Integration by short exponentional expansion
@@ -696,7 +696,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def _GET_IR(self, indx: int) -> Any:
+    def _GET_IR(self, indx: int) -> Any:  # type: ignore[explicit-any]
         """Returns in value of the initial term at a give time
 
         Parameters
@@ -729,7 +729,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
             self.expo = numpy.exp(-self.PDeph.data * (self.dt**2) / 2.0)
             self.t0 = self.PDeph.data * self.dt
 
-    def _APPLY_DEPH(self, tt: float, rho2: numpy.ndarray) -> numpy.ndarray:
+    def _APPLY_DEPH(self, tt: float, rho2: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Parameters
         ----------
         tt : TYPE
@@ -745,7 +745,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         """
         return rho2 * self.expo * numpy.exp(-self.t0 * tt)
 
-    def __propagate_short_exp_with_rel_operators(
+    def __propagate_short_exp_with_rel_operators(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
         """Integration by short exponentional expansion
@@ -887,7 +887,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_with_TD_relaxation(
+    def __propagate_short_exp_with_TD_relaxation(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
         """Short exp integration
@@ -999,7 +999,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_with_TDrel_operators(
+    def __propagate_short_exp_with_TDrel_operators(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
         """Short exp integration with time-dependent relaxation tensor
@@ -1076,7 +1076,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_with_TD_relaxation_field(
+    def __propagate_short_exp_with_TD_relaxation_field(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
         """Short exp integration of the density matrix with external driving"""
@@ -1192,12 +1192,12 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_TDrelax_field_oper(self, rhoi: Any, L: int = 4) -> Any:
+    def __propagate_short_exp_TDrelax_field_oper(self, rhoi: Any, L: int = 4) -> Any:  # type: ignore[explicit-any]
         """ """
         debug("(7)")
         return None
 
-    def __propagate_short_exp_with_TD_relaxation_EField(
+    def __propagate_short_exp_with_TD_relaxation_EField(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
         """Short exp integration of the density matrix with external driving"""
@@ -1312,7 +1312,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_TDrelax_EField_oper(self, rhoi: Any, L: int = 4) -> Any:
+    def __propagate_short_exp_TDrelax_EField_oper(self, rhoi: Any, L: int = 4) -> Any:  # type: ignore[explicit-any]
         """ """
         debug("(9)")
         return None
@@ -1331,7 +1331,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         """Switch off the single frequency RWA"""
         self._has_field_RWA = False
 
-    def __propagate_short_exp_with_relaxation_field(
+    def __propagate_short_exp_with_relaxation_field(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
         """Short exponential integration with relaxation and array field
@@ -1380,7 +1380,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         X = 0
 
         Nst = self.Hamiltonian.dim
-        MU_raw: numpy.ndarray = numpy.zeros((Nst, Nst), dtype=COMPLEX)
+        MU_raw: numpy.ndarray = numpy.zeros((Nst, Nst), dtype=COMPLEX)  # type: ignore[explicit-any]
         MU_raw[:, :] = self.Trdip.data[:, :, X]
 
         if self._has_field_RWA:
@@ -1462,14 +1462,14 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_with_relaxation_field_oper(
+    def __propagate_short_exp_with_relaxation_field_oper(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> Any:
 
         debug("(12)")
         return None
 
-    def __propagate_short_exp_with_relaxation_EField(
+    def __propagate_short_exp_with_relaxation_EField(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> ReducedDensityMatrixEvolution:
         """Short exponential integration with relaxation and EField like object
@@ -1538,7 +1538,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
             # upper and lower triagle
             N = self.Hamiltonian.dim
-            Mu: numpy.ndarray = numpy.zeros((N, N), dtype=REAL)
+            Mu: numpy.ndarray = numpy.zeros((N, N), dtype=REAL)  # type: ignore[explicit-any]
             for ii in range(N):
                 for jj in range(ii + 1, N):
                     Mu[ii, jj] = 1.0
@@ -1607,7 +1607,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_with_relaxation_EField_oper(
+    def __propagate_short_exp_with_relaxation_EField_oper(  # type: ignore[explicit-any]
         self, rhoi: Any, L: int = 4
     ) -> Any:
 
@@ -1615,7 +1615,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
         return None
 
 
-def _OTI(
+def _OTI(  # type: ignore[explicit-any]
     rhoY: numpy.ndarray,
     Km: numpy.ndarray,
     Kd: numpy.ndarray,
@@ -1662,7 +1662,7 @@ def _OTI(
         )
 
 
-def _COM(
+def _COM(  # type: ignore[explicit-any]
     HH: numpy.ndarray,
     ll: int,
     dt: float,
@@ -1699,7 +1699,7 @@ def _COM(
     return ret
 
 
-def _TTI(
+def _TTI(  # type: ignore[explicit-any]
     rhoY: numpy.ndarray,
     RR: numpy.ndarray,
     IR: Any,

--- a/quantarhei/qm/propagators/rdmpropagator.py
+++ b/quantarhei/qm/propagators/rdmpropagator.py
@@ -82,9 +82,9 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
     def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any = None,
-        Ham: Any = None,
-        RTensor: Any = None,
-        Iterm: Any = None,
+        Ham: Hamiltonian | None = None,
+        RTensor: RelaxationTensor | None = None,
+        Iterm: numpy.ndarray | None = None,
         Efield: Any = None,
         Trdip: Any = None,
         PDeph: Any = None,
@@ -541,7 +541,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def _INIT_EXP(self, rhoi: Any) -> tuple:  # type: ignore[explicit-any]
+    def _INIT_EXP(self, rhoi: ReducedDensityMatrix) -> tuple:  # type: ignore[explicit-any]
         """Parameters
         ----------
         rhoi : TYPE
@@ -587,7 +587,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return HH
 
-    def _CLOSE_RWA(self, pr: Any) -> None:  # type: ignore[explicit-any]
+    def _CLOSE_RWA(self, pr: ReducedDensityMatrixEvolution) -> None:
         """Closes the RWA treatment
 
         Parameters
@@ -1192,7 +1192,9 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_TDrelax_field_oper(self, rhoi: Any, L: int = 4) -> Any:  # type: ignore[explicit-any]
+    def __propagate_short_exp_TDrelax_field_oper(
+        self, rhoi: ReducedDensityMatrix, L: int = 4
+    ) -> ReducedDensityMatrixEvolution:  # type: ignore[explicit-any]
         """ """
         debug("(7)")
         return None
@@ -1312,7 +1314,9 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_TDrelax_EField_oper(self, rhoi: Any, L: int = 4) -> Any:  # type: ignore[explicit-any]
+    def __propagate_short_exp_TDrelax_EField_oper(
+        self, rhoi: ReducedDensityMatrix, L: int = 4
+    ) -> ReducedDensityMatrixEvolution:  # type: ignore[explicit-any]
         """ """
         debug("(9)")
         return None

--- a/quantarhei/qm/propagators/statevectorevolution.py
+++ b/quantarhei/qm/propagators/statevectorevolution.py
@@ -10,7 +10,9 @@ from ...core.matrixdata import MatrixData
 from ...core.time import TimeAxis
 from ...exceptions import QuantarheiError
 from ...utils.types import BasisManagedComplexArray
+from ..hilbertspace.hamiltonian import Hamiltonian
 from ..hilbertspace.operators import DensityMatrix
+from ..hilbertspace.statevector import StateVector
 from .dmevolution import DensityMatrixEvolution
 
 
@@ -19,7 +21,7 @@ class StateVectorEvolution(MatrixData, BasisManaged):
     _data: numpy.ndarray  # type: ignore[explicit-any]
     is_in_rwa: bool = False
 
-    def __init__(self, timeaxis: Any, psii: Any) -> None:  # type: ignore[explicit-any]
+    def __init__(self, timeaxis: TimeAxis, psii: StateVector) -> None:
 
         if not isinstance(timeaxis, TimeAxis):
             raise QuantarheiError
@@ -32,7 +34,7 @@ class StateVectorEvolution(MatrixData, BasisManaged):
         self.dim = psii.data.shape[0]
         self.data[0, :] = psii.data
 
-    def convert_from_RWA(self, ham: Any, sgn: int = 1) -> None:  # type: ignore[explicit-any]
+    def convert_from_RWA(self, ham: Hamiltonian, sgn: int = 1) -> None:
         """Converts density matrix evolution from RWA to standard repre
 
 

--- a/quantarhei/qm/propagators/statevectorevolution.py
+++ b/quantarhei/qm/propagators/statevectorevolution.py
@@ -16,10 +16,10 @@ from .dmevolution import DensityMatrixEvolution
 
 class StateVectorEvolution(MatrixData, BasisManaged):
     data = BasisManagedComplexArray("data")
-    _data: numpy.ndarray
+    _data: numpy.ndarray  # type: ignore[explicit-any]
     is_in_rwa: bool = False
 
-    def __init__(self, timeaxis: Any, psii: Any) -> None:
+    def __init__(self, timeaxis: Any, psii: Any) -> None:  # type: ignore[explicit-any]
 
         if not isinstance(timeaxis, TimeAxis):
             raise QuantarheiError
@@ -32,7 +32,7 @@ class StateVectorEvolution(MatrixData, BasisManaged):
         self.dim = psii.data.shape[0]
         self.data[0, :] = psii.data
 
-    def convert_from_RWA(self, ham: Any, sgn: int = 1) -> None:
+    def convert_from_RWA(self, ham: Any, sgn: int = 1) -> None:  # type: ignore[explicit-any]
         """Converts density matrix evolution from RWA to standard repre
 
 
@@ -59,7 +59,7 @@ class StateVectorEvolution(MatrixData, BasisManaged):
         if sgn == 1:
             self.is_in_rwa = False
 
-    def convert_to_RWA(self, ham: Any) -> None:
+    def convert_to_RWA(self, ham: Any) -> None:  # type: ignore[explicit-any]
         """Converts density matrix evolution from standard repre to RWA
 
 
@@ -91,7 +91,7 @@ class StateVectorEvolution(MatrixData, BasisManaged):
         if show:
             plt.show()
 
-    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:
+    def transform(self, SS: numpy.ndarray, inv: numpy.ndarray | None = None) -> None:  # type: ignore[explicit-any]
         """Transformation of the operator by a given matrix
 
 

--- a/quantarhei/qm/propagators/svpropagator.py
+++ b/quantarhei/qm/propagators/svpropagator.py
@@ -28,7 +28,7 @@ class StateVectorPropagator:
         rotating-wave approximation (RWA) frame.
     """
 
-    def __init__(self, timeaxis: Any, ham: Any) -> None:
+    def __init__(self, timeaxis: Any, ham: Any) -> None:  # type: ignore[explicit-any]
         self.timeaxis = timeaxis
         self.ham = ham
 
@@ -61,7 +61,7 @@ class StateVectorPropagator:
         self.Nref = Nref
         self.dt = self.Odt / self.Nref
 
-    def propagate(
+    def propagate(  # type: ignore[explicit-any]
         self, psii: Any, L: int = 4, hfce: Any = None, nonlinear: bool = False
     ) -> Any:
         """Propagates the state vector
@@ -96,13 +96,13 @@ class StateVectorPropagator:
         # standard propagation with time independent Hamiltonian
         return self._propagate_short_exp(psii, L=L)
 
-    def get_evolution_operator(self) -> Any:
+    def get_evolution_operator(self) -> Any:  # type: ignore[explicit-any]
         """Returns the evolution operator corresponding to the propagator"""
         # FIXME: not yet implemented
         eop = 0.0
         return EvolutionOperator(self.timeaxis, data=eop)
 
-    def _propagate_short_exp(self, psii: Any, L: int = 4) -> StateVectorEvolution:
+    def _propagate_short_exp(self, psii: Any, L: int = 4) -> StateVectorEvolution:  # type: ignore[explicit-any]
         """Short exp integration"""
         pr = StateVectorEvolution(self.timeaxis, psii)
 
@@ -135,7 +135,7 @@ class StateVectorPropagator:
 
         return pr
 
-    def _propagate_short_exp_nonlin(
+    def _propagate_short_exp_nonlin(  # type: ignore[explicit-any]
         self, psii: Any, hfce: Any, L: int = 4
     ) -> StateVectorEvolution:
         """Short exp integration with non-linear Hamiltonian"""
@@ -182,7 +182,7 @@ class StateVectorPropagator:
 
         return pr
 
-    def _propagate_short_exp_tdep(
+    def _propagate_short_exp_tdep(  # type: ignore[explicit-any]
         self, psii: Any, hfce: Any, L: int = 4
     ) -> StateVectorEvolution:
         """Short exp integration with time-dependent Hamiltonian"""

--- a/quantarhei/scripts/ghenerate.py
+++ b/quantarhei/scripts/ghenerate.py
@@ -27,7 +27,7 @@ import quantarhei as qr
 from ..exceptions import QuantarheiError
 
 
-def parsing() -> dict[str, Any] | int:
+def parsing() -> dict[str, Any] | int:  # type: ignore[explicit-any]
     """This function handles parsing command line arguments"""
     descr = "Ghenerate, the Gherkin Python Step Generator from Quantarhei"
     parser = argparse.ArgumentParser(description=descr + " ...")
@@ -157,7 +157,7 @@ def parsing() -> dict[str, Any] | int:
     )
 
 
-def analyze_children(children: list[Any]) -> None:
+def analyze_children(children: list[Any]) -> None:  # type: ignore[explicit-any]
     """Analyzes children of the feature and prints info"""
     test_strings = []
     for scenario in children:
@@ -204,7 +204,7 @@ def check_outputfile_exists(ddir: str, filename: str) -> str | int:
     return ofile
 
 
-def write_func_def(
+def write_func_def(  # type: ignore[explicit-any]
     myfile: IO[str],
     step: dict[str, Any],
     textrep: str,

--- a/quantarhei/scripts/qrhei.py
+++ b/quantarhei/scripts/qrhei.py
@@ -21,11 +21,11 @@ import quantarhei as qr
 from ..exceptions import QuantarheiError
 
 # Module-level parser globals used across command functions
-parser_list: Any = None
-parser_fetch: Any = None
+parser_list: Any = None  # type: ignore[explicit-any]
+parser_fetch: Any = None  # type: ignore[explicit-any]
 
 
-def do_command_run(args: Any) -> None:
+def do_command_run(args: Any) -> None:  # type: ignore[explicit-any]
     """Runs a script"""
     m = qr.Manager().log_conf
 
@@ -178,7 +178,7 @@ def do_command_run(args: Any) -> None:
         )
 
 
-def do_command_test(args: Any) -> None:
+def do_command_test(args: Any) -> None:  # type: ignore[explicit-any]
     """Runs Quantarhei tests"""
     qr.printlog("--- Running tests ---", loglevel=qr.LOG_URGENT)
     qr.printlog("No built-in qrhei tests are currently defined.")
@@ -197,7 +197,7 @@ def _match_filenames(
     return fnmatch.filter(filenames, pattern)
 
 
-def do_command_list(args: Any) -> None:
+def do_command_list(args: Any) -> None:  # type: ignore[explicit-any]
     """Lists files for Quantarhei"""
     global parser_list
 
@@ -221,7 +221,7 @@ def do_command_list(args: Any) -> None:
         parser_list.print_help()
 
 
-def do_command_fetch(args: Any) -> None:
+def do_command_fetch(args: Any) -> None:  # type: ignore[explicit-any]
     """Fetches files for Quantarhei"""
     global parser_fetch
 
@@ -289,17 +289,17 @@ def do_command_fetch(args: Any) -> None:
         parser_fetch.print_help()
 
 
-def do_command_config(args: Any) -> None:
+def do_command_config(args: Any) -> None:  # type: ignore[explicit-any]
     """Configures Quantarhei"""
     qr.printlog("Setting configuration", loglevel=1)
 
 
-def do_command_report(args: Any) -> None:
+def do_command_report(args: Any) -> None:  # type: ignore[explicit-any]
     """Reports on Quantarhei and the system"""
     qr.printlog("Probing system configuration", loglevel=1)
 
 
-def do_command_file(args: Any) -> None:
+def do_command_file(args: Any) -> None:  # type: ignore[explicit-any]
     """Report on the content of a file"""
     qr.printlog("Checking file info", loglevel=1)
 
@@ -330,7 +330,7 @@ def do_command_file(args: Any) -> None:
         # print(traceback.format_exc())
 
 
-def do_command_script(args: Any) -> None:
+def do_command_script(args: Any) -> None:  # type: ignore[explicit-any]
     """Provides script management functionality
 
 

--- a/quantarhei/scripts/qtask.py
+++ b/quantarhei/scripts/qtask.py
@@ -7,16 +7,16 @@ from typing import Any
 import quantarhei as qr
 
 
-def code_hamiltonian(INP: Any, status: Any) -> str:
+def code_hamiltonian(INP: Any, status: Any) -> str:  # type: ignore[explicit-any]
 
     code = "# Ahoj"
 
     return code
 
 
-def tasks(tlist: Any, INP: Any) -> str:
+def tasks(tlist: Any, INP: Any) -> str:  # type: ignore[explicit-any]
     """Go through the list of tasks"""
-    status: list[Any] = []
+    status: list[Any] = []  # type: ignore[explicit-any]
     code = ""
 
     if isinstance(tlist, str):
@@ -31,7 +31,7 @@ def tasks(tlist: Any, INP: Any) -> str:
     return code
 
 
-def do_process(args: Any) -> None:
+def do_process(args: Any) -> None:  # type: ignore[explicit-any]
     """Process arguments of the script"""
     if args.filename:
         fname = args.filename[0]

--- a/quantarhei/scripts/qview.py
+++ b/quantarhei/scripts/qview.py
@@ -38,7 +38,7 @@ class Viewer(Frame):
         Frame.__init__(self, parent)
         self.pack(expand=YES, fill=BOTH)
         self.makeWidgets()
-        master: Any = self.master
+        master: Any = self.master  # type: ignore[explicit-any]
         master.title("Quantarhei File Viewer")
 
     def makeWidgets(self) -> None:
@@ -50,7 +50,7 @@ class Viewer(Frame):
 
     def makeMenuBar(self) -> None:
         self.menubar = Menu(self.master)
-        master: Any = self.master
+        master: Any = self.master  # type: ignore[explicit-any]
         master.config(menu=self.menubar)
         self.fileMenu()
 
@@ -78,7 +78,7 @@ class Viewer(Frame):
         obj = qr.load_parcel(file)
         self.figure(obj)
 
-    def figure(self, obj: Any) -> None:
+    def figure(self, obj: Any) -> None:  # type: ignore[explicit-any]
         from tkinter import TOP
 
         import matplotlib.pyplot as plt

--- a/quantarhei/spectroscopy/absbase.py
+++ b/quantarhei/spectroscopy/absbase.py
@@ -24,12 +24,12 @@ class AbsSpectrumBase(DFunction, EnergyUnitsManaged, DataSaveable):
 
     """
 
-    def __init__(self, axis: Any = None, data: Any = None) -> None:
+    def __init__(self, axis: Any = None, data: Any = None) -> None:  # type: ignore[explicit-any]
         super().__init__()
         self.axis = axis
         self.data = data
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Sets axis atribute
 
         Parameters
@@ -40,7 +40,7 @@ class AbsSpectrumBase(DFunction, EnergyUnitsManaged, DataSaveable):
         """
         self.axis = axis
 
-    def set_data(self, data: Any) -> None:
+    def set_data(self, data: Any) -> None:  # type: ignore[explicit-any]
         """Sets data atribute
 
         Parameters
@@ -54,7 +54,7 @@ class AbsSpectrumBase(DFunction, EnergyUnitsManaged, DataSaveable):
     # def add_data(self, data):
     #    self.data += data
 
-    def set_by_interpolation(self, x: Any, y: Any, xaxis: str = "frequency") -> None:
+    def set_by_interpolation(self, x: Any, y: Any, xaxis: str = "frequency") -> None:  # type: ignore[explicit-any]
         """Sets the data by interpolation with splines
 
         When the spectrum is defined in wavelength, it is converted to
@@ -125,11 +125,11 @@ class AbsSpectrumBase(DFunction, EnergyUnitsManaged, DataSaveable):
         """Normalization to one"""
         self.normalize2(norm=1.0)
 
-    def subtract(self, val: Any) -> None:
+    def subtract(self, val: Any) -> None:  # type: ignore[explicit-any]
         """Subtracts a value from the spectrum to shift its base line"""
         self.data -= val
 
-    def add_to_data(self, spect: Any) -> None:
+    def add_to_data(self, spect: Any) -> None:  # type: ignore[explicit-any]
         """Performs addition on the data.
 
         Expects a compatible object holding absorption spectrum
@@ -191,13 +191,13 @@ class AbsSpectrumBase(DFunction, EnergyUnitsManaged, DataSaveable):
 
     # save method is inherited from DFunction
 
-    def save_data(
+    def save_data(  # type: ignore[explicit-any]
         self, name: str, with_axis: ValueAxis | None = None, **kwargs: Any
     ) -> None:
         """Saves the data of this absorption spectrum"""
         super().save_data(name, with_axis=self.axis)
 
-    def load_data(
+    def load_data(  # type: ignore[explicit-any]
         self, name: str, with_axis: ValueAxis | None = None, **kwargs: Any
     ) -> None:
         """Loads data from file into this absorption spectrum"""
@@ -205,7 +205,7 @@ class AbsSpectrumBase(DFunction, EnergyUnitsManaged, DataSaveable):
             raise QuantarheiError("The property `axis` has to be defined")
         super().load_data(name, with_axis=self.axis)
 
-    def plot(self, **kwargs: Any) -> None:  # type: ignore[override]
+    def plot(self, **kwargs: Any) -> None:  # type: ignore[explicit-any, override]
         """Plotting absorption spectrum using the DFunction plot method"""
         if "ylabel" not in kwargs:
             kwargs["ylabel"] = r"$\alpha(\omega)$ [a.u.]"

--- a/quantarhei/spectroscopy/abscalculator.py
+++ b/quantarhei/spectroscopy/abscalculator.py
@@ -99,7 +99,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
     TimeAxis = derived_type("TimeAxis", TimeAxis)
     system = derived_type("system", [Molecule, Aggregate, OpenSystem])
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any,
         system: Any = None,
@@ -138,12 +138,12 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
 
         self._pop_fluor = "vertical"
 
-        self.rwa: float | numpy.ndarray = 0.0
+        self.rwa: float | numpy.ndarray = 0.0  # type: ignore[explicit-any]
         self.prop_has_rwa = False
 
         self.bootstrapped = False
 
-    def bootstrap(
+    def bootstrap(  # type: ignore[explicit-any]
         self,
         rwa: float = 0.0,
         prop: Any = None,
@@ -238,7 +238,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
         self.bootstrapped = True
 
     @prevent_basis_context
-    def calculate(
+    def calculate(  # type: ignore[explicit-any]
         self, raw: bool = False, from_dynamics: bool = False, alt: bool = False
     ) -> Any:
         """Calculates the absorption spectrum"""
@@ -280,7 +280,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
 
             stick_width = 1.0 / 0.1
 
-    def _equilibrium_excit_populations(
+    def _equilibrium_excit_populations(  # type: ignore[explicit-any]
         self, AG: Any, temperature: float = 300, relaxation_hamiltonian: Any = None
     ) -> Any:
         if relaxation_hamiltonian:
@@ -296,7 +296,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
             )
         return rho0
 
-    def one_transition_spectrum_abs(self, tr: dict[str, Any]) -> numpy.ndarray:
+    def one_transition_spectrum_abs(self, tr: dict[str, Any]) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates spectrum of one transition"""
         ta = tr["ta"]  # TimeAxis
         dd = tr["dd"]  # transition dipole strength
@@ -349,7 +349,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
         Nt = ta.length  # len(ta.data)
         return ft[Nt // 2 : Nt + Nt // 2]
 
-    def one_transition_spectrum_ld(self, tr: dict[str, Any]) -> numpy.ndarray:
+    def one_transition_spectrum_ld(self, tr: dict[str, Any]) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates spectrum of one transition"""
         ta = tr["ta"]  # TimeAxis
         ld = tr["ld"]  # linear dichroism strength
@@ -393,7 +393,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
         Nt = ta.length  # len(ta.data)
         return ft[Nt // 2 : Nt + Nt // 2]
 
-    def one_transition_spectrum_gauss(
+    def one_transition_spectrum_gauss(  # type: ignore[explicit-any]
         self, tr: dict[str, Any]
     ) -> tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]:
         """Calculates spectrum of one transition using gaussian broadening
@@ -425,7 +425,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
 
         return data_abs, data_CD, data_LD
 
-    def one_transition_spectrum_fluor(self, tr: dict[str, Any]) -> numpy.ndarray:
+    def one_transition_spectrum_fluor(self, tr: dict[str, Any]) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates spectrum of one transition"""
         ta = tr["ta"]  # TimeAxis
         dd = tr["dd"]  # transition dipole strength
@@ -478,7 +478,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
         Nt = ta.length  # len(ta.data)
         return ft[Nt // 2 : Nt + Nt // 2]
 
-    def one_transition_spectrum_cd(self, tr: dict[str, Any]) -> numpy.ndarray:
+    def one_transition_spectrum_cd(self, tr: dict[str, Any]) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates spectrum of one transition"""
         ta = tr["ta"]  # TimeAxis
         rr = tr["rr"]  # transition dipole strength
@@ -530,7 +530,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
         Nt = ta.length  # len(ta.data)
         return ft[Nt // 2 : Nt + Nt // 2]
 
-    def _excitonic_coft_old(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:
+    def _excitonic_coft_old(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns energy gap correlation function data of an exciton state"""
         # FIXME: works only for 2 level molecules
 
@@ -564,7 +564,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
 
         return ct
 
-    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:
+    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns energy gap correlation function data of an exciton state n"""
         # SystemBathInteraction
         sbi = AG.get_SystemBathInteraction()
@@ -588,7 +588,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
                         ct += (SS[kk, n] ** 2) * (SS[ll, n] ** 2) * coft
         return ct
 
-    def _excitonic_coft_all(self, SS: numpy.ndarray, AG: Any) -> numpy.ndarray:
+    def _excitonic_coft_all(self, SS: numpy.ndarray, AG: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns energy gap correlation function data of an exciton state n"""
         # SystemBathInteraction
         sbi = AG.get_SystemBathInteraction()
@@ -625,7 +625,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
         print(stop - start, stop - start - timecount)
         return ct
 
-    def _excitonic_reorg_energy(self, SS: numpy.ndarray, AG: Any, n: int) -> float:
+    def _excitonic_reorg_energy(self, SS: numpy.ndarray, AG: Any, n: int) -> float:  # type: ignore[explicit-any]
         """Returns the reorganisation energy of an exciton state"""
         # SystemBathInteraction
         sbi = AG.get_SystemBathInteraction()
@@ -642,7 +642,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
                 rg += (SS[kk, n] ** 2) * (SS[kk, n] ** 2) * reorg
         return rg
 
-    def _excitonic_rotatory_strength(
+    def _excitonic_rotatory_strength(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, AG: Any, energy: numpy.ndarray, n: int
     ) -> float:
         # Initialize rotatory strength
@@ -677,7 +677,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
         #        print(Rot_n,energy,n)
         return Rot_n
 
-    def _excitonic_rotatory_strength_fullv(
+    def _excitonic_rotatory_strength_fullv(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, AG: Any, energy: numpy.ndarray, n: int
     ) -> Any:
         # Initialize rotatory strength
@@ -709,7 +709,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
 
         return Rot_n  # ,Rot_nm
 
-    def _subtract_site_reorg(
+    def _subtract_site_reorg(  # type: ignore[explicit-any]
         self, AG: Any, Hin: Any, subtract_bath: bool = True
     ) -> tuple[Any, numpy.ndarray]:
         # Subtract the reorganisation energy from the sites
@@ -741,7 +741,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
 
         return HH, reorg_site
 
-    def _site2excit_reorg(
+    def _site2excit_reorg(  # type: ignore[explicit-any]
         self, reorg_site: numpy.ndarray, SS: numpy.ndarray
     ) -> numpy.ndarray:
         # Get exciton reorganization energy from the site one
@@ -753,7 +753,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
 
         return reorg_exct
 
-    def _calculate_monomer(self, raw: bool = False) -> Any:
+    def _calculate_monomer(self, raw: bool = False) -> Any:  # type: ignore[explicit-any]
         """Calculates the absorption spectrum of a monomer"""
         ta = self.TimeAxis
         # transition frequency
@@ -845,7 +845,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
 
         return spect
 
-    def _calculate_abs_from_dynamics(self, raw: bool = False, alt: bool = False) -> Any:
+    def _calculate_abs_from_dynamics(self, raw: bool = False, alt: bool = False) -> Any:  # type: ignore[explicit-any]
         """Calculates the absorption spectrum of a molecule from its dynamics"""
         #
         # Frequency axis
@@ -915,7 +915,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
         return {"abs": spect_abs, "fluor": fluor_spect}
         # return spect
 
-    def _calculate_aggregate(
+    def _calculate_aggregate(  # type: ignore[explicit-any]
         self,
         relaxation_tensor: Any = None,
         relaxation_hamiltonian: Any = None,
@@ -974,10 +974,10 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
             tr["fwhm"] = self.gauss
 
         if relaxation_tensor is not None:
-            RR: Any = relaxation_tensor
+            RR: Any = relaxation_tensor  # type: ignore[explicit-any]
             RR.transform(SS)
             gg = []
-            RR_any: Any = RR
+            RR_any: Any = RR  # type: ignore[explicit-any]
             if isinstance(RR, TimeDependent):
                 for ii in range(HH.dim):
                     gg.append(RR_any.data[:, ii, ii, ii, ii])
@@ -1163,7 +1163,7 @@ class LinSpectrumCalculator(EnergyUnitsManaged):
 
 
 class AbsSpectrumCalculator(LinSpectrumCalculator):
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any,
         system: Any = None,
@@ -1183,7 +1183,7 @@ class AbsSpectrumCalculator(LinSpectrumCalculator):
         )
 
     @prevent_basis_context
-    def calculate(
+    def calculate(  # type: ignore[explicit-any]
         self, raw: bool = False, from_dynamics: bool = False, alt: bool = False
     ) -> Any:
 
@@ -1193,7 +1193,7 @@ class AbsSpectrumCalculator(LinSpectrumCalculator):
                 "call bootstrap() method of this object."
             )
 
-        spect: Any = None
+        spect: Any = None  # type: ignore[explicit-any]
         with energy_units("int"):
             if self.system is not None:
                 if from_dynamics:
@@ -1216,7 +1216,7 @@ class AbsSpectrumCalculator(LinSpectrumCalculator):
         return spect
 
 
-def _spect_from_dyn(
+def _spect_from_dyn(  # type: ignore[explicit-any]
     time: Any, HH: Any, DD: Any, prop: Any, rhoeq: Any, secular: bool = False
 ) -> numpy.ndarray:
     """Calculation of the first order signal field.
@@ -1279,7 +1279,7 @@ def _spect_from_dyn(
     return at
 
 
-def _spect_from_dyn_single(
+def _spect_from_dyn_single(  # type: ignore[explicit-any]
     time: Any, HH: Any, DD: Any, prop: Any, rhoeq: Any, secular: bool = False
 ) -> numpy.ndarray:
     """Calculation of the first order signal field.
@@ -1341,7 +1341,7 @@ def _spect_from_dyn_single(
     return at
 
 
-def _c2g(timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
+def _c2g(timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Converts correlation function to lineshape function
 
     Explicit numerical double integration of the correlation

--- a/quantarhei/spectroscopy/abscontainer.py
+++ b/quantarhei/spectroscopy/abscontainer.py
@@ -16,16 +16,16 @@ class AbsSpectrumContainer(Saveable):
         ``set_axis``.
     """
 
-    def __init__(self, axis: Any = None) -> None:
+    def __init__(self, axis: Any = None) -> None:  # type: ignore[explicit-any]
 
         self.axis = axis
         self.count = 0
-        self.spectra: dict[str, Any] = {}
+        self.spectra: dict[str, Any] = {}  # type: ignore[explicit-any]
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         self.axis = axis
 
-    def set_spectrum(self, spect: Any, tag: Any = None) -> None:
+    def set_spectrum(self, spect: Any, tag: Any = None) -> None:  # type: ignore[explicit-any]
         """Store an absorption spectrum, checking axis compatibility.
 
         Parameters
@@ -58,7 +58,7 @@ class AbsSpectrumContainer(Saveable):
         else:
             raise QuantarheiError("Incompatible time axis (equal axis required)")
 
-    def get_spectrum(self, tag: Any) -> Any:
+    def get_spectrum(self, tag: Any) -> Any:  # type: ignore[explicit-any]
         """Return the spectrum identified by tag.
 
         Parameters
@@ -84,7 +84,7 @@ class AbsSpectrumContainer(Saveable):
             return self.spectra[tag]
         raise QuantarheiError("Unknown spectrum")
 
-    def get_spectra(self) -> list[Any]:
+    def get_spectra(self) -> list[Any]:  # type: ignore[explicit-any]
         """Return all stored spectra sorted by their string tags.
 
         Returns

--- a/quantarhei/spectroscopy/circular_dichroism.py
+++ b/quantarhei/spectroscopy/circular_dichroism.py
@@ -32,12 +32,12 @@ from ..utils import derived_type
 class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
     """Provides basic container for circular dichroism spectrum."""
 
-    def __init__(self, axis: Any = None, data: Any = None) -> None:
+    def __init__(self, axis: Any = None, data: Any = None) -> None:  # type: ignore[explicit-any]
         super().__init__()
         self.axis = axis
         self.data = data
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Set the frequency axis of the spectrum.
 
         Parameters
@@ -47,7 +47,7 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
         """
         self.axis = axis
 
-    def set_data(self, data: Any) -> None:
+    def set_data(self, data: Any) -> None:  # type: ignore[explicit-any]
         """Set the spectral data array.
 
         Parameters
@@ -57,11 +57,11 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
         """
         self.data = data
 
-    def set_by_interpolation(self, x: Any, y: Any, xaxis: str = "frequency") -> None:
+    def set_by_interpolation(self, x: Any, y: Any, xaxis: str = "frequency") -> None:  # type: ignore[explicit-any]
 
         from scipy import interpolate
 
-        om: numpy.ndarray
+        om: numpy.ndarray  # type: ignore[explicit-any]
         if xaxis == "frequency":
             om = numpy.asarray(self.convert_2_internal_u(x))
 
@@ -116,7 +116,7 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
         """Subtracts a value from the spectrum to shift its base line"""
         self.data -= val
 
-    def add_to_data(self, spect: Any) -> None:
+    def add_to_data(self, spect: Any) -> None:  # type: ignore[explicit-any]
         """Add data from a compatible spectrum to this spectrum.
 
         Parameters
@@ -143,7 +143,7 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
 
         self.data += spect.data
 
-    def load_data(
+    def load_data(  # type: ignore[explicit-any]
         self,
         name: str,
         with_axis: Any = None,
@@ -173,7 +173,7 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
 
     # save method is inherited from DFunction
 
-    def plot(
+    def plot(  # type: ignore[explicit-any]
         self,
         fig: Any = None,
         title: str | None = None,
@@ -219,7 +219,7 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
             **kwargs,
         )
 
-    def gaussian_fit(
+    def gaussian_fit(  # type: ignore[explicit-any]
         self, N: int = 1, guess: Any = None, plot: bool = False, Nsvf: int = 251
     ) -> Any:
         """Performs a Gaussian fit of the spectrum based on an initial guess
@@ -238,7 +238,7 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
         if guess is None:
             raise QuantarheiError("Guess is required at this time")
 
-        def funcf(x: Any, *p: Any) -> Any:
+        def funcf(x: Any, *p: Any) -> Any:  # type: ignore[explicit-any]
             return _n_gaussians(x, N, *p)
 
         # minimize, leastsq,
@@ -292,7 +292,7 @@ class CircDichSpectrumBase(DFunction, EnergyUnitsManaged):
 #
 
 
-def _gaussian(
+def _gaussian(  # type: ignore[explicit-any]
     x: Any, height: float, center: float, fwhm: float, offset: float = 0.0
 ) -> numpy.ndarray:
     """Gaussian function with a possible offset
@@ -323,7 +323,7 @@ def _gaussian(
     )
 
 
-def _n_gaussians(x: Any, N: int, *params: float) -> Any:
+def _n_gaussians(x: Any, N: int, *params: float) -> Any:  # type: ignore[explicit-any]
     """Sum of N Gaussian functions plus an offset from zero
 
     Parameters
@@ -343,7 +343,7 @@ def _n_gaussians(x: Any, N: int, *params: float) -> Any:
     k = n // 3
 
     if (k * 3 == n) and (k == N):
-        res: float | numpy.ndarray = 0.0
+        res: float | numpy.ndarray = 0.0  # type: ignore[explicit-any]
         pp = numpy.zeros(3)
         for i in range(k):
             pp[0:3] = params[3 * i : 3 * i + 3]
@@ -430,16 +430,16 @@ class CircDichSpectrumContainer(Saveable):
         the axis is set automatically when the first spectrum is added.
     """
 
-    def __init__(self, axis: Any = None) -> None:
+    def __init__(self, axis: Any = None) -> None:  # type: ignore[explicit-any]
 
         self.axis = axis
         self.count = 0
-        self.spectra: dict[str, Any] = {}
+        self.spectra: dict[str, Any] = {}  # type: ignore[explicit-any]
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         self.axis = axis
 
-    def set_spectrum(self, spect: Any, tag: Any = None) -> None:
+    def set_spectrum(self, spect: Any, tag: Any = None) -> None:  # type: ignore[explicit-any]
         """Store a circular dichroism spectrum, checking axis compatibility.
 
         Parameters
@@ -472,7 +472,7 @@ class CircDichSpectrumContainer(Saveable):
         else:
             raise QuantarheiError("Incompatible time axis (equal axis required)")
 
-    def get_spectrum(self, tag: Any) -> Any:
+    def get_spectrum(self, tag: Any) -> Any:  # type: ignore[explicit-any]
         """Return the spectrum identified by tag.
 
         Parameters
@@ -498,7 +498,7 @@ class CircDichSpectrumContainer(Saveable):
             return self.spectra[tag]
         raise QuantarheiError("Unknown spectrum")
 
-    def get_spectra(self) -> list[Any]:
+    def get_spectra(self) -> list[Any]:  # type: ignore[explicit-any]
         """Return all stored spectra sorted by their string tags.
 
         Returns
@@ -593,7 +593,7 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
     TimeAxis = derived_type("TimeAxis", TimeAxis)
     system = derived_type("system", [Molecule, Aggregate])
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any,
         system: Any = None,
@@ -626,7 +626,7 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
             self._rate_matrix = rate_matrix
             self._has_rate_matrix = True
 
-        self.rwa: float | numpy.ndarray = 0.0
+        self.rwa: float | numpy.ndarray = 0.0  # type: ignore[explicit-any]
 
     def bootstrap(self, rwa: float = 0.0) -> None:
         """ """
@@ -636,7 +636,7 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
             self.frequencyAxis = self.TimeAxis.get_FrequencyAxis()
             self.frequencyAxis.data += self.rwa
 
-    def calculate(self) -> Any:
+    def calculate(self) -> Any:  # type: ignore[explicit-any]
         """Calculates the circular dichroism spectrum"""
         with energy_units("int"):
             if self.system is not None:
@@ -663,7 +663,7 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
 
             stick_width = 1.0 / 0.1
 
-    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
+    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Converts correlation function to lineshape function
 
         Explicit numerical double integration of the correlation
@@ -698,7 +698,7 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
         gt = sr + 1j * si
         return gt
 
-    def one_transition_spectrum(self, tr: dict[str, Any]) -> numpy.ndarray:
+    def one_transition_spectrum(self, tr: dict[str, Any]) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates spectrum of one transition"""
         ta = tr["ta"]  # TimeAxis
         dd = tr["dd"]  # transition dipole moment
@@ -735,7 +735,7 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
         Nt = ta.length  # len(ta.data)
         return ft[Nt // 2 : Nt + Nt // 2]
 
-    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:
+    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns energy gap correlation function data of an exciton state"""
         # FIXME: works only for 2 level molecules
 
@@ -764,7 +764,7 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
 
         return ct
 
-    def _excitonic_rot_dip(self, SS: numpy.ndarray, AG: Any, n: int) -> Any:
+    def _excitonic_rot_dip(self, SS: numpy.ndarray, AG: Any, n: int) -> Any:  # type: ignore[explicit-any]
         Na = AG.nmono
         rr = 0
         for kk in range(Na):
@@ -781,14 +781,14 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
 
         return rr
 
-    def _calculate_monomer(self) -> Any:
+    def _calculate_monomer(self) -> Any:  # type: ignore[explicit-any]
         """Calculates the circular dichroism spectrum of a monomer"""
         raise QuantarheiError(
             "Not yet implemented. Usually, CD is calculated\
                         for aggregates"
         )
 
-    def _calculate_aggregate(
+    def _calculate_aggregate(  # type: ignore[explicit-any]
         self,
         relaxation_tensor: Any = None,
         relaxation_hamiltonian: Any = None,
@@ -818,7 +818,7 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
             RR.transform(SS)
             gg = []
             if isinstance(RR, TimeDependent):
-                RR_any: Any = RR
+                RR_any: Any = RR  # type: ignore[explicit-any]
                 for ii in range(HH.dim):
                     gg.append(RR_any.data[:, ii, ii, ii, ii])
             else:
@@ -829,7 +829,7 @@ class CircDichSpectrumCalculator(EnergyUnitsManaged):
             RR = rate_matrix  # rate matrix is in excitonic basis
             gg = []
             if isinstance(RR, TimeDependent):
-                RR_any2: Any = RR
+                RR_any2: Any = RR  # type: ignore[explicit-any]
                 for ii in range(HH.dim):
                     gg.append(RR_any2.data[:, ii, ii])
             else:

--- a/quantarhei/spectroscopy/diagramatics.py
+++ b/quantarhei/spectroscopy/diagramatics.py
@@ -16,7 +16,7 @@ class liouville_pathway(UnitsManaged):
     order = Integer("order")
     nint = Integer("nint")
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         ptype: str,
         sinit: int,
@@ -65,7 +65,7 @@ class liouville_pathway(UnitsManaged):
         self.relax_order = relax_order
 
         # list events associated with relaxations and light interations
-        self.event: list[Any] = [None] * (1 + order + relax_order)
+        self.event: list[Any] = [None] * (1 + order + relax_order)  # type: ignore[explicit-any]
 
         # type of the pathway (rephasing, non-rephasing, double-coherence)
         self.pathway_type = ptype
@@ -94,7 +94,7 @@ class liouville_pathway(UnitsManaged):
         self.transitions = numpy.zeros((order + 1, 2), dtype=int)
 
         # relaxation induced transitions
-        self.relaxations: list[Any] = [None] * relax_order
+        self.relaxations: list[Any] = [None] * relax_order  # type: ignore[explicit-any]
 
         # sides from which the transitions occurred
         self.sides = numpy.zeros(order + 1, dtype=int)
@@ -118,10 +118,10 @@ class liouville_pathway(UnitsManaged):
         self.evolfac: float | complex = 1.0
 
         # transition widths
-        self.widths: Any = None
+        self.widths: Any = None  # type: ignore[explicit-any]
 
         # transition dephasings
-        self.dephs: Any = None
+        self.dephs: Any = None  # type: ignore[explicit-any]
 
         # band through which the pathway travels at population time
         self.popt_band = popt_band
@@ -132,7 +132,7 @@ class liouville_pathway(UnitsManaged):
         # was the pathway already built?
         self.built = False
 
-    def _chars(self, lx: Any, rx: Any, char: str = " ") -> str:
+    def _chars(self, lx: Any, rx: Any, char: str = " ") -> str:  # type: ignore[explicit-any]
         nsp = 10
         if isinstance(lx, str):
             ln = 0
@@ -420,15 +420,15 @@ class liouville_pathway(UnitsManaged):
 
         self.built = True
 
-    def get_current_state(self) -> numpy.ndarray:
+    def get_current_state(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """ """
         return self.current
 
-    def get_transition(self, n: int) -> Any:
+    def get_transition(self, n: int) -> Any:  # type: ignore[explicit-any]
         """Returns info on the transition occuring on the n-th interaction"""
         return self.sides[n], self.transitions[n]
 
-    def orientational_averaging(self, lab: Any) -> None:
+    def orientational_averaging(self, lab: Any) -> None:  # type: ignore[explicit-any]
         """Orientational averaging
 
         Orientational averaging and temperature dependence of the
@@ -458,7 +458,7 @@ class liouville_pathway(UnitsManaged):
         """Returns frequency corresponding to a given response interval"""
         return self.frequency[n]
 
-    def get_dmoment(self, n: int) -> numpy.ndarray:
+    def get_dmoment(self, n: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Transition dipole moment of a given interaction with light"""
         return self.dmoments[n]
 
@@ -466,7 +466,7 @@ class liouville_pathway(UnitsManaged):
         """Dipole and temperature dependent prefactor"""
         return self.pref
 
-    def get_states(self) -> tuple[Any, ...]:
+    def get_states(self) -> tuple[Any, ...]:  # type: ignore[explicit-any]
         """Returns a tuple of states through which the pathway passes"""
         states = []
         self.current[0] = self.sinit[0]

--- a/quantarhei/spectroscopy/dsfeynman.py
+++ b/quantarhei/spectroscopy/dsfeynman.py
@@ -40,7 +40,7 @@ class DSFeynmanDiagram:
         self._pic_rep = "\n"
         self.finished = False
 
-        self.light_transitions: dict[int, Any] = {}
+        self.light_transitions: dict[int, Any] = {}  # type: ignore[explicit-any]
         self.ltcount = 0
 
         if ptype in ptype_simple + ptype_relax:
@@ -166,7 +166,7 @@ class DSFeynmanDiagram:
 
         return fact
 
-    def evolution_operators(self, operators: bool = False) -> Any:
+    def evolution_operators(self, operators: bool = False) -> Any:  # type: ignore[explicit-any]
         """Returns evolution operators corresponding to the diagram
 
         It can return a string representation or a list of operator objects.
@@ -223,7 +223,7 @@ class DSFeynmanDiagram:
 
         kk = 0
         rUop = ""
-        rUops_list: list[Any] = []
+        rUops_list: list[Any] = []  # type: ignore[explicit-any]
 
         for key in self.states:
             if kk > 0 and kk < self.count + 1:
@@ -268,7 +268,7 @@ class DSFeynmanDiagram:
 
         return Uops
 
-    def coherence_GF(self) -> Any:
+    def coherence_GF(self) -> Any:  # type: ignore[explicit-any]
         """Returns coherence Green's function product for this diagram"""
         from ..symbolic.cumulant import UopEater
 
@@ -277,7 +277,7 @@ class DSFeynmanDiagram:
         out_list = eater.eat(evs)
         return eater.spit_coherence_GF()
 
-    def get_cumulant_expression(self, verbose: bool = False) -> Any:
+    def get_cumulant_expression(self, verbose: bool = False) -> Any:  # type: ignore[explicit-any]
         """Returns the cumulant evaluation of the diagram"""
         codes = []
 
@@ -311,7 +311,7 @@ from quantarhei.symbolic.cumulant import evaluate_cumulant
 
         codes.append(code2)
 
-        local_vars: dict[str, Any] = {}
+        local_vars: dict[str, Any] = {}  # type: ignore[explicit-any]
         for cod in codes:
             if verbose:
                 print(cod)

--- a/quantarhei/spectroscopy/fluorescence.py
+++ b/quantarhei/spectroscopy/fluorescence.py
@@ -35,12 +35,12 @@ from ..utils import derived_type
 class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
     """Provides basic container for fluorescence spectrum."""
 
-    def __init__(self, axis: Any = None, data: Any = None) -> None:
+    def __init__(self, axis: Any = None, data: Any = None) -> None:  # type: ignore[explicit-any]
         super().__init__()
         self.axis = axis
         self.data = data
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Set the frequency axis of the spectrum.
 
         Parameters
@@ -50,7 +50,7 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
         """
         self.axis = axis
 
-    def set_data(self, data: Any) -> None:
+    def set_data(self, data: Any) -> None:  # type: ignore[explicit-any]
         """Set the spectral data array.
 
         Parameters
@@ -60,11 +60,11 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
         """
         self.data = data
 
-    def set_by_interpolation(self, x: Any, y: Any, xaxis: str = "frequency") -> None:
+    def set_by_interpolation(self, x: Any, y: Any, xaxis: str = "frequency") -> None:  # type: ignore[explicit-any]
 
         from scipy import interpolate
 
-        om: numpy.ndarray
+        om: numpy.ndarray  # type: ignore[explicit-any]
         if xaxis == "frequency":
             om = numpy.asarray(self.convert_2_internal_u(x))
 
@@ -119,7 +119,7 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
         """Subtracts a value from the spectrum to shift its base line"""
         self.data -= val
 
-    def add_to_data(self, spect: Any) -> None:
+    def add_to_data(self, spect: Any) -> None:  # type: ignore[explicit-any]
         """Add data from a compatible spectrum to this spectrum.
 
         Parameters
@@ -146,7 +146,7 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
 
         self.data += spect.data
 
-    def load_data(
+    def load_data(  # type: ignore[explicit-any]
         self,
         name: str,
         with_axis: Any = None,
@@ -176,7 +176,7 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
 
     # save method is inherited from DFunction
 
-    def plot(
+    def plot(  # type: ignore[explicit-any]
         self,
         fig: Any = None,
         title: str | None = None,
@@ -222,7 +222,7 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
             **kwargs,
         )
 
-    def gaussian_fit(
+    def gaussian_fit(  # type: ignore[explicit-any]
         self, N: int = 1, guess: Any = None, plot: bool = False, Nsvf: int = 251
     ) -> Any:
         """Performs a Gaussian fit of the spectrum based on an initial guess
@@ -241,7 +241,7 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
         if guess is None:
             raise QuantarheiError("Guess is required at this time")
 
-        def funcf(x: Any, *p: Any) -> Any:
+        def funcf(x: Any, *p: Any) -> Any:  # type: ignore[explicit-any]
             return _n_gaussians(x, N, *p)
 
         # minimize, leastsq,
@@ -295,7 +295,7 @@ class FluorSpectrumBase(DFunction, EnergyUnitsManaged):
 #
 
 
-def _gaussian(
+def _gaussian(  # type: ignore[explicit-any]
     x: Any, height: float, center: float, fwhm: float, offset: float = 0.0
 ) -> numpy.ndarray:
     """Gaussian function with a possible offset
@@ -326,7 +326,7 @@ def _gaussian(
     )
 
 
-def _n_gaussians(x: Any, N: int, *params: float) -> Any:
+def _n_gaussians(x: Any, N: int, *params: float) -> Any:  # type: ignore[explicit-any]
     """Sum of N Gaussian functions plus an offset from zero
 
     Parameters
@@ -346,7 +346,7 @@ def _n_gaussians(x: Any, N: int, *params: float) -> Any:
     k = n // 3
 
     if (k * 3 == n) and (k == N):
-        res: float | numpy.ndarray = 0.0
+        res: float | numpy.ndarray = 0.0  # type: ignore[explicit-any]
         pp = numpy.zeros(3)
         for i in range(k):
             pp[0:3] = params[3 * i : 3 * i + 3]
@@ -433,16 +433,16 @@ class FluorSpectrumContainer(Saveable):
         the axis is set automatically when the first spectrum is added.
     """
 
-    def __init__(self, axis: Any = None) -> None:
+    def __init__(self, axis: Any = None) -> None:  # type: ignore[explicit-any]
 
         self.axis = axis
         self.count = 0
-        self.spectra: dict[str, Any] = {}
+        self.spectra: dict[str, Any] = {}  # type: ignore[explicit-any]
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         self.axis = axis
 
-    def set_spectrum(self, spect: Any, tag: Any = None) -> None:
+    def set_spectrum(self, spect: Any, tag: Any = None) -> None:  # type: ignore[explicit-any]
         """Store a fluorescence spectrum, checking axis compatibility.
 
         Parameters
@@ -475,7 +475,7 @@ class FluorSpectrumContainer(Saveable):
         else:
             raise QuantarheiError("Incompatible time axis (equal axis required)")
 
-    def get_spectrum(self, tag: Any) -> Any:
+    def get_spectrum(self, tag: Any) -> Any:  # type: ignore[explicit-any]
         """Return the spectrum identified by tag.
 
         Parameters
@@ -501,7 +501,7 @@ class FluorSpectrumContainer(Saveable):
             return self.spectra[tag]
         raise QuantarheiError("Unknown spectrum")
 
-    def get_spectra(self) -> list[Any]:
+    def get_spectra(self) -> list[Any]:  # type: ignore[explicit-any]
         """Return all stored spectra sorted by their string tags.
 
         Returns
@@ -596,7 +596,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
     TimeAxis = derived_type("TimeAxis", TimeAxis)
     system = derived_type("system", [Molecule, Aggregate])
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any,
         system: Any = None,
@@ -630,7 +630,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
             self._rate_matrix = rate_matrix
             self._has_rate_matrix = True
         self.temperature = temperature
-        self.rwa: float | numpy.ndarray = 0.0
+        self.rwa: float | numpy.ndarray = 0.0  # type: ignore[explicit-any]
 
     def bootstrap(self, rwa: float = 0.0) -> None:
         """ """
@@ -640,7 +640,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
             self.frequencyAxis = self.TimeAxis.get_FrequencyAxis()
             self.frequencyAxis.data += self.rwa
 
-    def calculate(self) -> Any:
+    def calculate(self) -> Any:  # type: ignore[explicit-any]
         """Calculates the fluorescence spectrum"""
         with energy_units("int"):
             if self.system is not None:
@@ -667,7 +667,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
 
             stick_width = 1.0 / 0.1
 
-    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
+    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Converts correlation function to lineshape function
 
         Explicit numerical double integration of the correlation
@@ -702,7 +702,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
         gt = sr + 1j * si
         return gt
 
-    def one_transition_spectrum(self, tr: dict[str, Any]) -> numpy.ndarray:
+    def one_transition_spectrum(self, tr: dict[str, Any]) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates spectrum of one transition"""
         ta = tr["ta"]  # TimeAxis
         dd = tr["dd"]  # transition dipole moment
@@ -740,7 +740,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
         Nt = ta.length  # len(ta.data)
         return ft[Nt // 2 : Nt + Nt // 2]
 
-    def _equilibrium_populations(
+    def _equilibrium_populations(  # type: ignore[explicit-any]
         self, AG: Any, temperature: float = 4.0, relaxation_hamiltonian: Any = None
     ) -> Any:
         if relaxation_hamiltonian:
@@ -756,7 +756,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
             )
         return rho0
 
-    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:
+    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns energy gap correlation function data of an exciton state"""
         # FIXME: works only for 2 level molecules
 
@@ -783,7 +783,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
 
         return ct
 
-    def _excitonic_reorg_energy(self, SS: numpy.ndarray, AG: Any, n: int) -> float:
+    def _excitonic_reorg_energy(self, SS: numpy.ndarray, AG: Any, n: int) -> float:  # type: ignore[explicit-any]
         """Returns the reorganisation energy of an exciton state"""
         # SystemBathInteraction
         sbi = AG.get_SystemBathInteraction()
@@ -806,7 +806,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
                 rg += (SS[kk, n] ** 2) * (SS[kk, n] ** 2) * reorg
         return rg
 
-    def _calculate_monomer(self) -> Any:
+    def _calculate_monomer(self) -> Any:  # type: ignore[explicit-any]
         """Calculates the fluorescence spectrum of a monomer"""
         ta = self.TimeAxis
 
@@ -853,7 +853,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
 
         return spect
 
-    def _calculate_aggregate(
+    def _calculate_aggregate(  # type: ignore[explicit-any]
         self,
         relaxation_tensor: Any = None,
         relaxation_hamiltonian: Any = None,
@@ -883,7 +883,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
             RR.transform(SS)
             gg = []
             if isinstance(RR, TimeDependent):
-                RR_any: Any = RR
+                RR_any: Any = RR  # type: ignore[explicit-any]
                 for ii in range(HH.dim):
                     gg.append(RR_any.data[:, ii, ii, ii, ii])
             else:
@@ -894,7 +894,7 @@ class FluorSpectrumCalculator(EnergyUnitsManaged):
             RR = rate_matrix  # rate matrix is in excitonic basis
             gg = []
             if isinstance(RR, TimeDependent):
-                RR_any2: Any = RR
+                RR_any2: Any = RR  # type: ignore[explicit-any]
                 for ii in range(HH.dim):
                     gg.append(RR_any2.data[:, ii, ii])
             else:

--- a/quantarhei/spectroscopy/labsetup.py
+++ b/quantarhei/spectroscopy/labsetup.py
@@ -497,7 +497,7 @@ class LabSetup:
 
         self.detection_polarization = detection_polarization
 
-    def get_pulse_polarizations(self) -> list[Any]:  # type: ignore[explicit-any]
+    def get_pulse_polarizations(self) -> list[numpy.ndarray]:  # type: ignore[explicit-any]
         """Returns polarizations of the laser pulses
 
 
@@ -519,7 +519,7 @@ class LabSetup:
 
         return pols
 
-    def get_detection_polarization(self) -> Any:  # type: ignore[explicit-any]
+    def get_detection_polarization(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns detection polarizations
 
 
@@ -889,7 +889,7 @@ class LabSetup:
                 + " required"
             )
 
-    def get_pulse_frequency(self, k: int) -> Any:  # type: ignore[explicit-any]
+    def get_pulse_frequency(self, k: int) -> float:
         """Returns frequency of the pulse with index k
 
         Parameters
@@ -943,7 +943,7 @@ class LabSetup:
                 + " required"
             )
 
-    def get_pulse_arrival_times(self) -> Any:  # type: ignore[explicit-any]
+    def get_pulse_arrival_times(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns frequency of the pulse with index k
 
 
@@ -957,7 +957,7 @@ class LabSetup:
         """
         return self.pulse_centers
 
-    def get_pulse_arrival_time(self, k: int) -> Any:  # type: ignore[explicit-any]
+    def get_pulse_arrival_time(self, k: int) -> float:
         """Returns frequency of the pulse with index k
 
         Parameters
@@ -1007,7 +1007,7 @@ class LabSetup:
                 "Wrong number of phases: " + str(self.number_of_pulses) + " required"
             )
 
-    def get_pulse_phases(self) -> Any:  # type: ignore[explicit-any]
+    def get_pulse_phases(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns frequency of the pulse with index k
 
 
@@ -1021,7 +1021,7 @@ class LabSetup:
         """
         return self.phases
 
-    def get_pulse_phase(self, k: int) -> Any:  # type: ignore[explicit-any]
+    def get_pulse_phase(self, k: int) -> float:
         """Returns frequency of the pulse with index k
 
         Parameters

--- a/quantarhei/spectroscopy/labsetup.py
+++ b/quantarhei/spectroscopy/labsetup.py
@@ -64,10 +64,10 @@ class LabSetup:
         )
 
         # auxiliary matrix for orientational averaging
-        self.F4eM4: Any = None
+        self.F4eM4: Any = None  # type: ignore[explicit-any]
 
         # pulse polarizations
-        self.e: numpy.ndarray = numpy.zeros((nopulses, 3), dtype=REAL)
+        self.e: numpy.ndarray = numpy.zeros((nopulses, 3), dtype=REAL)  # type: ignore[explicit-any]
 
         self.timeaxis: TimeAxis | None = None
         self.freqaxis: FrequencyAxis | None = None
@@ -80,22 +80,22 @@ class LabSetup:
         self.axis_type: str | None = None
 
         # pulses in time- and frequency domain
-        self.pulse_t: list[Any] = [None] * nopulses
-        self.pulse_f: list[Any] = [None] * nopulses
+        self.pulse_t: list[Any] = [None] * nopulses  # type: ignore[explicit-any]
+        self.pulse_f: list[Any] = [None] * nopulses  # type: ignore[explicit-any]
 
         self._field_set = False
 
-        self.dscaling: Any = None
+        self.dscaling: Any = None  # type: ignore[explicit-any]
 
         #
         # Pulse characteristics
         #
-        self.omega: numpy.ndarray = numpy.zeros(nopulses, dtype=REAL)
-        self.saved_omega: numpy.ndarray | None = None
-        self.pulse_centers: numpy.ndarray = numpy.zeros(nopulses, dtype=REAL)
+        self.omega: numpy.ndarray = numpy.zeros(nopulses, dtype=REAL)  # type: ignore[explicit-any]
+        self.saved_omega: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.pulse_centers: numpy.ndarray = numpy.zeros(nopulses, dtype=REAL)  # type: ignore[explicit-any]
         self._centers_set = False
-        self.phases: numpy.ndarray = numpy.zeros(nopulses, dtype=REAL)
-        self.delay_phases: numpy.ndarray = numpy.zeros(nopulses, dtype=REAL)
+        self.phases: numpy.ndarray = numpy.zeros(nopulses, dtype=REAL)  # type: ignore[explicit-any]
+        self.delay_phases: numpy.ndarray = numpy.zeros(nopulses, dtype=REAL)  # type: ignore[explicit-any]
 
         self.saved_params = None
 
@@ -106,7 +106,7 @@ class LabSetup:
         # else:
         #    raise QuantarheiError("Pulse shapes must be set first.")
 
-    def set_pulse_shapes(self, axis: Any, params: Any) -> None:
+    def set_pulse_shapes(self, axis: Any, params: Any) -> None:  # type: ignore[explicit-any]
         """Sets the pulse properties
 
 
@@ -435,7 +435,7 @@ class LabSetup:
             )
             raise QuantarheiError(text)
 
-    def set_pulse_polarizations(
+    def set_pulse_polarizations(  # type: ignore[explicit-any]
         self, pulse_polarizations: Any = (X, X, X), detection_polarization: Any = X
     ) -> None:
         """Sets polarizations of the experimental pulses
@@ -497,7 +497,7 @@ class LabSetup:
 
         self.detection_polarization = detection_polarization
 
-    def get_pulse_polarizations(self) -> list[Any]:
+    def get_pulse_polarizations(self) -> list[Any]:  # type: ignore[explicit-any]
         """Returns polarizations of the laser pulses
 
 
@@ -519,7 +519,7 @@ class LabSetup:
 
         return pols
 
-    def get_detection_polarization(self) -> Any:
+    def get_detection_polarization(self) -> Any:  # type: ignore[explicit-any]
         """Returns detection polarizations
 
 
@@ -733,7 +733,7 @@ class LabSetup:
                 "Cannot convert to frequency domain: time domain not set"
             )
 
-    def get_pulse_envelop(self, k: int, t: Any) -> Any:
+    def get_pulse_envelop(self, k: int, t: Any) -> Any:  # type: ignore[explicit-any]
         """Returns a numpy array with the pulse time-domain envelope
 
 
@@ -791,7 +791,7 @@ class LabSetup:
         """
         return self.pulse_t[k].at(t)
 
-    def get_pulse_spectrum(self, k: int, omega: Any) -> Any:
+    def get_pulse_spectrum(self, k: int, omega: Any) -> Any:  # type: ignore[explicit-any]
         """Returns a numpy array with the pulse frequency-domain spectrum
 
         Parameters
@@ -850,7 +850,7 @@ class LabSetup:
         """
         return self.pulse_f[k].at(omega)
 
-    def set_pulse_frequencies(self, omegas: Any) -> None:
+    def set_pulse_frequencies(self, omegas: Any) -> None:  # type: ignore[explicit-any]
         """Sets pulse frequencies
 
 
@@ -877,7 +877,7 @@ class LabSetup:
         """
         # FIXME: energy unit control has to be in place
         if len(omegas) == self.number_of_pulses:
-            omega_val: Any = Manager().convert_energy_2_internal_u(
+            omega_val: Any = Manager().convert_energy_2_internal_u(  # type: ignore[explicit-any]
                 numpy.array(omegas, dtype=REAL)
             )
             self.omega = omega_val
@@ -889,7 +889,7 @@ class LabSetup:
                 + " required"
             )
 
-    def get_pulse_frequency(self, k: int) -> Any:
+    def get_pulse_frequency(self, k: int) -> Any:  # type: ignore[explicit-any]
         """Returns frequency of the pulse with index k
 
         Parameters
@@ -907,7 +907,7 @@ class LabSetup:
         """
         return self.omega[k]
 
-    def set_pulse_arrival_times(self, times: Any) -> None:
+    def set_pulse_arrival_times(self, times: Any) -> None:  # type: ignore[explicit-any]
         """Sets the arrival time (i.e. centers) of the pulses
 
         Parameters
@@ -943,7 +943,7 @@ class LabSetup:
                 + " required"
             )
 
-    def get_pulse_arrival_times(self) -> Any:
+    def get_pulse_arrival_times(self) -> Any:  # type: ignore[explicit-any]
         """Returns frequency of the pulse with index k
 
 
@@ -957,7 +957,7 @@ class LabSetup:
         """
         return self.pulse_centers
 
-    def get_pulse_arrival_time(self, k: int) -> Any:
+    def get_pulse_arrival_time(self, k: int) -> Any:  # type: ignore[explicit-any]
         """Returns frequency of the pulse with index k
 
         Parameters
@@ -975,7 +975,7 @@ class LabSetup:
         """
         return self.pulse_centers[k]
 
-    def set_pulse_phases(self, phases: Any) -> None:
+    def set_pulse_phases(self, phases: Any) -> None:  # type: ignore[explicit-any]
         """Sets the phases of the individual pulses
 
         Parameters
@@ -1007,7 +1007,7 @@ class LabSetup:
                 "Wrong number of phases: " + str(self.number_of_pulses) + " required"
             )
 
-    def get_pulse_phases(self) -> Any:
+    def get_pulse_phases(self) -> Any:  # type: ignore[explicit-any]
         """Returns frequency of the pulse with index k
 
 
@@ -1021,7 +1021,7 @@ class LabSetup:
         """
         return self.phases
 
-    def get_pulse_phase(self, k: int) -> Any:
+    def get_pulse_phase(self, k: int) -> Any:  # type: ignore[explicit-any]
         """Returns frequency of the pulse with index k
 
         Parameters
@@ -1066,9 +1066,9 @@ class LabSetup:
     def get_labfield(self, k: int) -> LabField:
         return LabField(self, k)
 
-    def get_labfields(self) -> list[Any]:
+    def get_labfields(self) -> list[Any]:  # type: ignore[explicit-any]
         """Retruns a list of EField objects for the lab's pulses"""
-        fields: list[Any] = [None] * self.number_of_pulses
+        fields: list[Any] = [None] * self.number_of_pulses  # type: ignore[explicit-any]
 
         for kk in range(self.number_of_pulses):
             ff = self.get_labfield(kk)
@@ -1090,7 +1090,7 @@ class LabSetup:
 
         self.omega[:] = self.saved_omega[:]
 
-    def get_field(self, kk: Any = None, rwa_frequency: Any = None) -> Any:
+    def get_field(self, kk: Any = None, rwa_frequency: Any = None) -> Any:  # type: ignore[explicit-any]
         """Returns the total field of the lab or a single field"""
         if kk is None:
             flds = self.get_labfields()
@@ -1115,7 +1115,7 @@ class LabSetup:
 
         return fld
 
-    def get_field_derivative(self) -> Any:
+    def get_field_derivative(self) -> Any:  # type: ignore[explicit-any]
         """Returns the time derivative of the total field"""
         flds = self.get_labfields()
 
@@ -1142,16 +1142,16 @@ class labsetup(LabSetup):
     pass
 
 
-def _labattr(name: str, target: str, flag: Any = None) -> Any:
+def _labattr(name: str, target: str, flag: Any = None) -> Any:  # type: ignore[explicit-any]
     """Pointer to a field attribute of the LabSep object"""
     storage_name = target
     access_flag = flag
 
-    def prop_getter(self: Any) -> Any:
+    def prop_getter(self: Any) -> Any:  # type: ignore[explicit-any]
         at = getattr(self.labsetup, storage_name)
         return at[self.index]
 
-    def prop_setter(self: Any, value: Any) -> None:
+    def prop_setter(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         at = getattr(self.labsetup, storage_name)
         if access_flag is not None:
             setattr(self, access_flag, True)
@@ -1160,26 +1160,26 @@ def _labattr(name: str, target: str, flag: Any = None) -> Any:
     return property(prop_getter, prop_setter)
 
 
-def _labarray(name: str, target: str) -> Any:
+def _labarray(name: str, target: str) -> Any:  # type: ignore[explicit-any]
     """Pointer to a field array attribute of the LabSep object"""
     storage_name = target
 
-    def prop_getter(self: Any) -> Any:
+    def prop_getter(self: Any) -> Any:  # type: ignore[explicit-any]
         at = getattr(self.labsetup, storage_name)
         return at[self.index, :]
 
-    def prop_setter(self: Any, value: Any) -> None:
+    def prop_setter(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         at = getattr(self.labsetup, storage_name)
         at[self.index, :] = value
 
     return property(prop_getter, prop_setter)
 
 
-def _fieldprop(name: str, flag: str, sign: int) -> Any:
+def _fieldprop(name: str, flag: str, sign: int) -> Any:  # type: ignore[explicit-any]
     """Property returning field values over time"""
     cmplx_sign = sign
 
-    def prop_getter(self: Any) -> Any:
+    def prop_getter(self: Any) -> Any:  # type: ignore[explicit-any]
         if getattr(self.labsetup, flag):
             if cmplx_sign == 1:
                 return self.get_field()
@@ -1192,7 +1192,7 @@ def _fieldprop(name: str, flag: str, sign: int) -> Any:
         else:
             raise QuantarheiError("The property '" + name + "' is not initialited.")
 
-    def prop_setter(self: Any, value: Any) -> None:
+    def prop_setter(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         raise QuantarheiError(
             "The property '" + name + "' is protected" + " and cannot be set."
         )
@@ -1394,7 +1394,7 @@ class LabField:
     field_m = _fieldprop("field_p", "_field_set", -1)
     field = _fieldprop("field", "_field_set", 0)
 
-    def __init__(self, labsetup: Any, k: int) -> None:
+    def __init__(self, labsetup: Any, k: int) -> None:  # type: ignore[explicit-any]
 
         self.labsetup = labsetup
         self.index = k
@@ -1403,15 +1403,15 @@ class LabField:
         # delay phase
         self.set_delay_phase(self.tc)
 
-    def get_phase(self) -> Any:
+    def get_phase(self) -> Any:  # type: ignore[explicit-any]
         """Returns the phase of the pulse"""
         return self.labsetup.phases[self.index]
 
-    def get_delay_phase(self) -> Any:
+    def get_delay_phase(self) -> Any:  # type: ignore[explicit-any]
         """Returns the phase caused by the pulse delay"""
         return self.labsetup.delay_phases[self.index]
 
-    def get_total_phase(self) -> Any:
+    def get_total_phase(self) -> Any:  # type: ignore[explicit-any]
 
         return self.labsetup.delay_phases[self.index] + self.labsetup.phases[self.index]
 
@@ -1427,7 +1427,7 @@ class LabField:
         self.labsetup.phases[self.index] = val
         # FIXME: The pulse field has to be updated
 
-    def get_center(self) -> Any:
+    def get_center(self) -> Any:  # type: ignore[explicit-any]
         """Returns the pulse center time"""
         return self.labsetup.pulse_centers[self.index]
 
@@ -1459,22 +1459,22 @@ class LabField:
         # print("Setting delay phase of", phi, "val=",val, "om=", om)
         self.labsetup.delay_phases[self.index] = phi
 
-    def get_frequency(self) -> Any:
+    def get_frequency(self) -> Any:  # type: ignore[explicit-any]
         return self.labsetup.omega[self.index]
 
     def set_frequency(self, val: float) -> None:
         self.labsetup.omega[self.index] = val
 
-    def get_polarization(self) -> Any:
+    def get_polarization(self) -> Any:  # type: ignore[explicit-any]
         return self.labsetup.e[self.index, :]
 
-    def set_polarization(self, pol: Any) -> None:
+    def set_polarization(self, pol: Any) -> None:  # type: ignore[explicit-any]
         self.labsetup.e[self.index, :] = pol
 
-    def get_fwhm(self) -> Any:
+    def get_fwhm(self) -> Any:  # type: ignore[explicit-any]
         return self.labsetup.saved_params[self.index]["FWHM"]
 
-    def get_field(self, time: Any = None, sign: int = 1) -> Any:
+    def get_field(self, time: Any = None, sign: int = 1) -> Any:  # type: ignore[explicit-any]
         """Returns the electric field of the pulses"""
         if self._center_changed:
             # recalculate pulses
@@ -1498,7 +1498,7 @@ class LabField:
 
         return self.labsetup.pulse_t[self.index].at(time)
 
-    def get_time_axis(self) -> Any:
+    def get_time_axis(self) -> Any:  # type: ignore[explicit-any]
         return self.labsetup.timeaxis
 
     def set_rwa(self, om: float) -> None:
@@ -1509,12 +1509,12 @@ class LabField:
 
         self.labsetup.restore_rwa()
 
-    def as_spline_function(self) -> Any:
+    def as_spline_function(self) -> Any:  # type: ignore[explicit-any]
         """Returns the spline represention of this field"""
         df = DFunction(self.labsetup.timeaxis, self.get_field())
         return df.as_spline_function()
 
-    def get_pulse_envelop(self, tt: Any) -> Any:
+    def get_pulse_envelop(self, tt: Any) -> Any:  # type: ignore[explicit-any]
         """Returns the envelop values"""
         # tma = self.timeaxis
         if self.labsetup.saved_params[self.index]["ptype"] == "Gaussian":
@@ -1537,7 +1537,7 @@ class LabField:
 
         raise QuantarheiError()
 
-    def get_pulse_envelop_function(self) -> Any:
+    def get_pulse_envelop_function(self) -> Any:  # type: ignore[explicit-any]
         """Return a function to be called later"""
         if self.labsetup.saved_params[self.index]["ptype"] == "Gaussian":
             fwhm = self.labsetup.saved_params[self.index]["FWHM"]
@@ -1545,7 +1545,7 @@ class LabField:
             lfc = 4.0 * numpy.log(2.0)
             pi = numpy.pi
 
-            def env(tt: Any) -> Any:
+            def env(tt: Any) -> Any:  # type: ignore[explicit-any]
 
                 val = (
                     (2.0 / fwhm)

--- a/quantarhei/spectroscopy/linear_dichroism.py
+++ b/quantarhei/spectroscopy/linear_dichroism.py
@@ -32,12 +32,12 @@ from ..utils import derived_type
 class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
     """Provides basic container for linear dichroism spectrum."""
 
-    def __init__(self, axis: Any = None, data: Any = None) -> None:
+    def __init__(self, axis: Any = None, data: Any = None) -> None:  # type: ignore[explicit-any]
         super().__init__()
         self.axis = axis
         self.data = data
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Set the frequency axis of the spectrum.
 
         Parameters
@@ -47,7 +47,7 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
         """
         self.axis = axis
 
-    def set_data(self, data: Any) -> None:
+    def set_data(self, data: Any) -> None:  # type: ignore[explicit-any]
         """Set the spectral data array.
 
         Parameters
@@ -57,11 +57,11 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
         """
         self.data = data
 
-    def set_by_interpolation(self, x: Any, y: Any, xaxis: str = "frequency") -> None:
+    def set_by_interpolation(self, x: Any, y: Any, xaxis: str = "frequency") -> None:  # type: ignore[explicit-any]
 
         from scipy import interpolate
 
-        om: numpy.ndarray
+        om: numpy.ndarray  # type: ignore[explicit-any]
         if xaxis == "frequency":
             om = numpy.asarray(self.convert_2_internal_u(x))
 
@@ -116,7 +116,7 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
         """Subtracts a value from the spectrum to shift its base line"""
         self.data -= val
 
-    def add_to_data(self, spect: Any) -> None:
+    def add_to_data(self, spect: Any) -> None:  # type: ignore[explicit-any]
         """Add data from a compatible spectrum to this spectrum.
 
         Parameters
@@ -143,7 +143,7 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
 
         self.data += spect.data
 
-    def load_data(
+    def load_data(  # type: ignore[explicit-any]
         self,
         name: str,
         with_axis: Any = None,
@@ -173,7 +173,7 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
 
     # save method is inherited from DFunction
 
-    def plot(
+    def plot(  # type: ignore[explicit-any]
         self,
         fig: Any = None,
         title: str | None = None,
@@ -219,7 +219,7 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
             **kwargs,
         )
 
-    def gaussian_fit(
+    def gaussian_fit(  # type: ignore[explicit-any]
         self, N: int = 1, guess: Any = None, plot: bool = False, Nsvf: int = 251
     ) -> Any:
         """Performs a Gaussian fit of the spectrum based on an initial guess
@@ -238,7 +238,7 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
         if guess is None:
             raise QuantarheiError("Guess is required at this time")
 
-        def funcf(x: Any, *p: Any) -> Any:
+        def funcf(x: Any, *p: Any) -> Any:  # type: ignore[explicit-any]
             return _n_gaussians(x, N, *p)
 
         # minimize, leastsq,
@@ -292,7 +292,7 @@ class LinDichSpectrumBase(DFunction, EnergyUnitsManaged):
 #
 
 
-def _gaussian(
+def _gaussian(  # type: ignore[explicit-any]
     x: Any, height: float, center: float, fwhm: float, offset: float = 0.0
 ) -> numpy.ndarray:
     """Gaussian function with a possible offset
@@ -323,7 +323,7 @@ def _gaussian(
     )
 
 
-def _n_gaussians(x: Any, N: int, *params: float) -> Any:
+def _n_gaussians(x: Any, N: int, *params: float) -> Any:  # type: ignore[explicit-any]
     """Sum of N Gaussian functions plus an offset from zero
 
     Parameters
@@ -343,7 +343,7 @@ def _n_gaussians(x: Any, N: int, *params: float) -> Any:
     k = n // 3
 
     if (k * 3 == n) and (k == N):
-        res: float | numpy.ndarray = 0.0
+        res: float | numpy.ndarray = 0.0  # type: ignore[explicit-any]
         pp = numpy.zeros(3)
         for i in range(k):
             pp[0:3] = params[3 * i : 3 * i + 3]
@@ -430,16 +430,16 @@ class LinDichSpectrumContainer(Saveable):
         the axis is set automatically when the first spectrum is added.
     """
 
-    def __init__(self, axis: Any = None) -> None:
+    def __init__(self, axis: Any = None) -> None:  # type: ignore[explicit-any]
 
         self.axis = axis
         self.count = 0
-        self.spectra: dict[str, Any] = {}
+        self.spectra: dict[str, Any] = {}  # type: ignore[explicit-any]
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         self.axis = axis
 
-    def set_spectrum(self, spect: Any, tag: Any = None) -> None:
+    def set_spectrum(self, spect: Any, tag: Any = None) -> None:  # type: ignore[explicit-any]
         """Store a linear dichroism spectrum, checking axis compatibility.
 
         Parameters
@@ -472,7 +472,7 @@ class LinDichSpectrumContainer(Saveable):
         else:
             raise QuantarheiError("Incompatible time axis (equal axis required)")
 
-    def get_spectrum(self, tag: Any) -> Any:
+    def get_spectrum(self, tag: Any) -> Any:  # type: ignore[explicit-any]
         """Return the spectrum identified by tag.
 
         Parameters
@@ -498,7 +498,7 @@ class LinDichSpectrumContainer(Saveable):
             return self.spectra[tag]
         raise QuantarheiError("Unknown spectrum")
 
-    def get_spectra(self) -> list[Any]:
+    def get_spectra(self) -> list[Any]:  # type: ignore[explicit-any]
         """Return all stored spectra sorted by their string tags.
 
         Returns
@@ -593,7 +593,7 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
     TimeAxis = derived_type("TimeAxis", TimeAxis)
     system = derived_type("system", [Molecule, Aggregate])
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         timeaxis: Any,
         system: Any = None,
@@ -633,7 +633,7 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
             1 / numpy.linalg.norm(vector_perp_to_membrane)
         )
 
-        self.rwa: float | numpy.ndarray = 0.0
+        self.rwa: float | numpy.ndarray = 0.0  # type: ignore[explicit-any]
 
     def bootstrap(self, rwa: float = 0.0) -> None:
         """ """
@@ -643,7 +643,7 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
             self.frequencyAxis = self.TimeAxis.get_FrequencyAxis()
             self.frequencyAxis.data += self.rwa
 
-    def calculate(self) -> Any:
+    def calculate(self) -> Any:  # type: ignore[explicit-any]
         """Calculates the linear dichroism spectrum"""
         with energy_units("int"):
             if self.system is not None:
@@ -670,7 +670,7 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
 
             stick_width = 1.0 / 0.1
 
-    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
+    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Converts correlation function to lineshape function
 
         Explicit numerical double integration of the correlation
@@ -705,7 +705,7 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
         gt = sr + 1j * si
         return gt
 
-    def one_transition_spectrum(self, tr: dict[str, Any]) -> numpy.ndarray:
+    def one_transition_spectrum(self, tr: dict[str, Any]) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculates spectrum of one transition"""
         ta = tr["ta"]  # TimeAxis
         dd = tr["dd_vec"]  # transition dipole moment
@@ -744,7 +744,7 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
         Nt = ta.length  # len(ta.data)
         return ft[Nt // 2 : Nt + Nt // 2]
 
-    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:
+    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns energy gap correlation function data of an exciton state"""
         # FIXME: works only for 2 level molecules
 
@@ -773,14 +773,14 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
 
         return ct
 
-    def _calculate_monomer(self) -> Any:
+    def _calculate_monomer(self) -> Any:  # type: ignore[explicit-any]
         """Calculates the circular dichroism spectrum of a monomer"""
         raise QuantarheiError(
             "Not yet implemented. Usually, LD is calculated\
                         for aggregates."
         )
 
-    def _calculate_aggregate(
+    def _calculate_aggregate(  # type: ignore[explicit-any]
         self,
         relaxation_tensor: Any = None,
         relaxation_hamiltonian: Any = None,
@@ -810,7 +810,7 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
             RR.transform(SS)
             gg = []
             if isinstance(RR, TimeDependent):
-                RR_any: Any = RR
+                RR_any: Any = RR  # type: ignore[explicit-any]
                 for ii in range(HH.dim):
                     gg.append(RR_any.data[:, ii, ii, ii, ii])
             else:
@@ -821,7 +821,7 @@ class LinDichSpectrumCalculator(EnergyUnitsManaged):
             RR = rate_matrix  # rate matrix is in excitonic basis
             gg = []
             if isinstance(RR, TimeDependent):
-                RR_any2: Any = RR
+                RR_any2: Any = RR  # type: ignore[explicit-any]
                 for ii in range(HH.dim):
                     gg.append(RR_any2.data[:, ii, ii])
             else:

--- a/quantarhei/spectroscopy/lineshapes.py
+++ b/quantarhei/spectroscopy/lineshapes.py
@@ -12,7 +12,7 @@ from ..exceptions import ImplementationError
 class Storage:
     def __init__(self, rel_tol: float = 1e-8) -> None:
         self.params: list[tuple[float, ...]] = []
-        self.results: list[numpy.ndarray] = []
+        self.results: list[numpy.ndarray] = []  # type: ignore[explicit-any]
         self.positions: list[tuple[float, float]] = []
         self.rel_tol = rel_tol  # relative tolerance for parameter comparison
         self.lookup_count = 0
@@ -36,7 +36,7 @@ class Storage:
                 return idx
         return -1
 
-    def store(
+    def store(  # type: ignore[explicit-any]
         self,
         param_tuple: tuple[float, ...],
         pos: tuple[float, float],
@@ -59,7 +59,7 @@ storage = Storage()
 ###############################################################################
 
 
-def gaussian(omega: numpy.ndarray, cent: float, delta: float) -> numpy.ndarray:
+def gaussian(omega: numpy.ndarray, cent: float, delta: float) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Normalized Gaussian line shape"""
     return (
         numpy.sqrt(numpy.log(2.0) / numpy.pi)
@@ -68,17 +68,17 @@ def gaussian(omega: numpy.ndarray, cent: float, delta: float) -> numpy.ndarray:
     )
 
 
-def lorentzian(omega: numpy.ndarray, cent: float, gamma: float) -> numpy.ndarray:
+def lorentzian(omega: numpy.ndarray, cent: float, gamma: float) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Normalized Lorenzian line shape"""
     return (gamma / numpy.pi) / ((omega - cent) ** 2 + gamma**2)
 
 
-def lorentzian_im(omega: numpy.ndarray, cent: float, gamma: float) -> numpy.ndarray:
+def lorentzian_im(omega: numpy.ndarray, cent: float, gamma: float) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Imaginary part of a normalized Lorenzian line shape"""
     return 1j * ((omega - cent) / numpy.pi) / ((omega - cent) ** 2 + gamma**2)
 
 
-def voigt(
+def voigt(  # type: ignore[explicit-any]
     omega: numpy.ndarray, cent: float, delta: float, gamma: float = 0.0
 ) -> numpy.ndarray:
     """Normalized Voigt line shape for absorption"""
@@ -91,7 +91,7 @@ def voigt(
     )
 
 
-def cvoigt(
+def cvoigt(  # type: ignore[explicit-any]
     omega: numpy.ndarray, cent: float, delta: float, gamma: float = 0.0
 ) -> numpy.ndarray:
     """Complex normalized Voigt line shape"""
@@ -108,7 +108,7 @@ def cvoigt(
 ###############################################################################
 
 
-def gaussian2D(
+def gaussian2D(  # type: ignore[explicit-any]
     omega1: numpy.ndarray,
     cent1: float,
     delta1: float,
@@ -125,7 +125,7 @@ def gaussian2D(
     )
 
 
-def voigt2D(
+def voigt2D(  # type: ignore[explicit-any]
     omega1: numpy.ndarray,
     cent1: float,
     delta1: float,
@@ -200,7 +200,7 @@ def voigt2D(
     return data
 
 
-def lorentzian2D(
+def lorentzian2D(  # type: ignore[explicit-any]
     omega1: numpy.ndarray,
     cent1: float,
     gamma1: float,

--- a/quantarhei/spectroscopy/mockabscalculator.py
+++ b/quantarhei/spectroscopy/mockabscalculator.py
@@ -14,7 +14,7 @@ from .abscalculator import AbsSpectrumCalculator
 
 
 class MockAbsSpectrumCalculator(AbsSpectrumCalculator):
-    def bootstrap(  # type: ignore[override]
+    def bootstrap(  # type: ignore[explicit-any, override]
         self,
         rwa: float = 0.0,
         pathways: Any = None,
@@ -66,11 +66,11 @@ class MockAbsSpectrumCalculator(AbsSpectrumCalculator):
         """Set dephasing rate as 1/(dephasing time)"""
         self.dephx = val
 
-    def set_pathways(self, pathways: Any) -> None:
+    def set_pathways(self, pathways: Any) -> None:  # type: ignore[explicit-any]
         """Set Liouville pathways to be used for spectral calculation"""
         self.pathways = pathways
 
-    def calculate(self, raw: bool = False) -> Any:
+    def calculate(self, raw: bool = False) -> Any:  # type: ignore[explicit-any]
         """Calculate the absorption spectrum for all pathways"""
         one = AbsSpectrum()
         one.set_axis(self.oa1)
@@ -84,7 +84,7 @@ class MockAbsSpectrumCalculator(AbsSpectrumCalculator):
 
         return one
 
-    def calculate_pathway(
+    def calculate_pathway(  # type: ignore[explicit-any]
         self, pathway: Any, shape: str = "Gaussian", raw: bool = False
     ) -> numpy.ndarray:
         """Calculate the shape of a Liouville pathway

--- a/quantarhei/spectroscopy/mocktwodcalculator.py
+++ b/quantarhei/spectroscopy/mocktwodcalculator.py
@@ -36,15 +36,15 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
         lineshapes).
     """
 
-    def __init__(self, t1axis: Any, t2axis: Any, t3axis: Any, temp: Any = None) -> None:
+    def __init__(self, t1axis: Any, t2axis: Any, t3axis: Any, temp: Any = None) -> None:  # type: ignore[explicit-any]
         super().__init__(t1axis, t2axis, t3axis)
-        self.widthx: Any = convert(300, "1/cm", "int")
-        self.widthy: Any = convert(300, "1/cm", "int")
-        self.dephx: Any = convert(300, "1/cm", "int")
-        self.dephy: Any = convert(300, "1/cm", "int")
+        self.widthx: Any = convert(300, "1/cm", "int")  # type: ignore[explicit-any]
+        self.widthy: Any = convert(300, "1/cm", "int")  # type: ignore[explicit-any]
+        self.dephx: Any = convert(300, "1/cm", "int")  # type: ignore[explicit-any]
+        self.dephy: Any = convert(300, "1/cm", "int")  # type: ignore[explicit-any]
         self.temp = temp  # Temperature
 
-    def bootstrap(
+    def bootstrap(  # type: ignore[explicit-any]
         self,
         rwa: float = 0.0,
         pad: int = 0,
@@ -80,7 +80,7 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
 
         self.tc = 0
 
-    def get_storage(self) -> Any:
+    def get_storage(self) -> Any:  # type: ignore[explicit-any]
         return storage
 
     def set_width(self, val: float) -> None:
@@ -93,10 +93,10 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
         self.dephx = m.convert_energy_2_internal_u(val)
         self.dephy = m.convert_energy_2_internal_u(val)
 
-    def set_pathways(self, pathways: Any) -> None:
+    def set_pathways(self, pathways: Any) -> None:  # type: ignore[explicit-any]
         self.pathways = pathways
 
-    def calculate_next(self) -> Any:
+    def calculate_next(self) -> Any:  # type: ignore[explicit-any]
         """Calculate next spectrum and increment t2 time"""
         sone = self.calculate_one(self.tc)
         self.tc += 1
@@ -106,7 +106,7 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
         """Set next current t2 time"""
         self.tc = tc
 
-    def calculate_one(self, tc: int) -> Any:
+    def calculate_one(self, tc: int) -> Any:  # type: ignore[explicit-any]
         """Calculate the 2D spectrum for all pathways"""
         onetwod = TwoDResponse()
         onetwod.set_axis_1(self.oa1)
@@ -134,7 +134,7 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
 
         return onetwod
 
-    def calculate(self) -> Any:
+    def calculate(self) -> Any:  # type: ignore[explicit-any]
         """Calculate the 2D spectrum for all pathways"""
         onetwod = TwoDResponse()
         onetwod.set_axis_1(self.oa1)
@@ -163,7 +163,7 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
 
         return onetwod
 
-    def calculate_all_system(
+    def calculate_all_system(  # type: ignore[explicit-any]
         self,
         sys: Any,
         eUt: Any,
@@ -188,7 +188,7 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
             if show_progress:
                 print(" - calculating", kk, "of", Nk, "at t2 =", T2, "fs")
 
-            pways: dict[Any, Any] = dict()
+            pways: dict[Any, Any] = dict()  # type: ignore[explicit-any]
             twod1 = self.calculate_one_system(
                 T2, sys, eUt, lab, selection=selection, pways=pways, dtol=dtol
             )
@@ -208,7 +208,7 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
 
         return tcont
 
-    def calculate_one_system(
+    def calculate_one_system(  # type: ignore[explicit-any]
         self,
         t2: float,
         sys: Any,
@@ -317,13 +317,13 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
 
         return twod1
 
-    def calculate_pathway(self, pathway: Any, shape: str = "Gaussian") -> numpy.ndarray:
+    def calculate_pathway(self, pathway: Any, shape: str = "Gaussian") -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculate the shape of a Liouville pathway"""
         # we can calculate empty pathway
         if pathway is None:
             N1 = self.oa1.length
             N3 = self.oa3.length
-            reph2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)
+            reph2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)  # type: ignore[explicit-any]
             return reph2D
 
         # FIXME: remove the old version sometime soon
@@ -416,7 +416,7 @@ class MockTwoDResponseCalculator(TwoDResponseCalculator):
             return reph2D
 
         if pathway.pathway_type == "NR":
-            nonr2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)
+            nonr2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)  # type: ignore[explicit-any]
 
             if shape == "Gaussian":
                 oo3 = self.oa3.data[:]

--- a/quantarhei/spectroscopy/pathwayanalyzer.py
+++ b/quantarhei/spectroscopy/pathwayanalyzer.py
@@ -67,14 +67,14 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
 
     """
 
-    def __init__(self, pathways: Any = None) -> None:
+    def __init__(self, pathways: Any = None) -> None:  # type: ignore[explicit-any]
         self.pathways = pathways
 
-    def set_pathways(self, pathways: Any) -> None:
+    def set_pathways(self, pathways: Any) -> None:  # type: ignore[explicit-any]
         """Sets pathways to be analyzed"""
         self.pathways = pathways
 
-    def get_pathways(self) -> Any:
+    def get_pathways(self) -> Any:  # type: ignore[explicit-any]
         """Returns Liouville pathways"""
         return self.pathways
 
@@ -83,7 +83,7 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
         return len(self.pathways)
 
     @deprecated
-    def max_pref(self, pathways: Any) -> tuple[float, int]:
+    def max_pref(self, pathways: Any) -> tuple[float, int]:  # type: ignore[explicit-any]
         """Return the maximum of pathway prefactors
 
 
@@ -140,7 +140,7 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
         return max_amplitude(self.pathways)
 
     @deprecated
-    def select_pref_GT(
+    def select_pref_GT(  # type: ignore[explicit-any]
         self,
         val: float,
         pathways: Any = None,
@@ -168,7 +168,7 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
 
         return selected
 
-    def select_amplitude_GT(
+    def select_amplitude_GT(  # type: ignore[explicit-any]
         self, val: float, replace: bool = True, verbose: bool = False
     ) -> Any:
         """Select all pathways with abs value of prefactors greater than a value"""
@@ -180,7 +180,7 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
         else:
             return selected
 
-    def select_frequency_window(
+    def select_frequency_window(  # type: ignore[explicit-any]
         self, window: Any, replace: bool = True, verbose: bool = False
     ) -> Any:
         """Selects pathways with omega_1 and omega_3 in a certain range"""
@@ -191,7 +191,7 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
         else:
             return selected
 
-    def select_omega2(
+    def select_omega2(  # type: ignore[explicit-any]
         self, interval: Any, replace: bool = True, verbose: bool = False
     ) -> Any:
         """Selects pathways with omega_2 in a certain interval"""
@@ -203,12 +203,12 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
             return selected
 
     @deprecated
-    def order_by_pref(self, pthways: Any) -> Any:
+    def order_by_pref(self, pthways: Any) -> Any:  # type: ignore[explicit-any]
         """Orders the list of pathways by pathway prefactors"""
         lst = sorted(pthways, key=lambda pway: abs(pway.pref), reverse=True)
         return lst
 
-    def order_by_amplitude(self, replace: bool = True) -> Any:
+    def order_by_amplitude(self, replace: bool = True) -> Any:  # type: ignore[explicit-any]
 
         orderred = order_by_amplitude(self.pathways)
         if replace:
@@ -216,7 +216,7 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
         else:
             return orderred
 
-    def select_sign(self, sign: float, replace: bool = True) -> Any:
+    def select_sign(self, sign: float, replace: bool = True) -> Any:  # type: ignore[explicit-any]
 
         selected = select_sign(self.pathways, sign)
         if replace:
@@ -224,7 +224,7 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
         else:
             return selected
 
-    def select_type(self, ptype: str = "REPH", replace: bool = True) -> Any:
+    def select_type(self, ptype: str = "REPH", replace: bool = True) -> Any:  # type: ignore[explicit-any]
 
         selected = select_type(self.pathways, ptype)
         if replace:
@@ -235,7 +235,7 @@ class LiouvillePathwayAnalyzer(UnitsManaged):
         return selected
 
 
-def max_amplitude(pathways: Any) -> tuple[float, int]:
+def max_amplitude(pathways: Any) -> tuple[float, int]:  # type: ignore[explicit-any]
     """Return the maximum of pathway prefactors
 
 
@@ -266,7 +266,7 @@ def max_amplitude(pathways: Any) -> tuple[float, int]:
     return (pmax, rec)
 
 
-def select_amplitude_GT(val: float, pathways: Any, verbose: bool = False) -> list[Any]:
+def select_amplitude_GT(val: float, pathways: Any, verbose: bool = False) -> list[Any]:  # type: ignore[explicit-any]
     """Select all pathways with abs value of prefactors greater than a value
 
     Parameters
@@ -300,7 +300,7 @@ def select_amplitude_GT(val: float, pathways: Any, verbose: bool = False) -> lis
     return selected
 
 
-def select_frequency_window(
+def select_frequency_window(  # type: ignore[explicit-any]
     window: Any, pathways: Any, verbose: bool = False
 ) -> list[Any]:
     """Selects pathways with omega_1 and omega_3 in a certain range"""
@@ -332,7 +332,7 @@ def select_frequency_window(
     return selected
 
 
-def select_omega2(
+def select_omega2(  # type: ignore[explicit-any]
     interval: Any,
     pathways: Any,
     secular: bool = True,
@@ -392,13 +392,13 @@ def select_omega2(
 #    for pway in pathways:
 
 
-def order_by_amplitude(pthways: Any) -> list[Any]:
+def order_by_amplitude(pthways: Any) -> list[Any]:  # type: ignore[explicit-any]
     """Orders the list of pathways by pathway prefactors"""
     lst = sorted(pthways, key=lambda pway: abs(pway.pref), reverse=True)
     return lst
 
 
-def select_sign(pathways: Any, sign: float) -> list[Any]:
+def select_sign(pathways: Any, sign: float) -> list[Any]:  # type: ignore[explicit-any]
     """Selects all pathways depending on the overall sign"""
     selected = []
 
@@ -417,7 +417,7 @@ def select_sign(pathways: Any, sign: float) -> list[Any]:
     return selected
 
 
-def select_type(pathways: Any, stype: str) -> list[Any]:
+def select_type(pathways: Any, stype: str) -> list[Any]:  # type: ignore[explicit-any]
     """Selects all pathways of a given type
 
     Parameters
@@ -440,7 +440,7 @@ def select_type(pathways: Any, stype: str) -> list[Any]:
     return selected
 
 
-def select_by_states(pathways: Any, states: Any) -> Any:
+def select_by_states(pathways: Any, states: Any) -> Any:  # type: ignore[explicit-any]
     """Returns one pathway which goes through a given pattern of states
 
     Returns unique pathway which goes through a given pattern of states
@@ -502,7 +502,7 @@ def select_by_states(pathways: Any, states: Any) -> Any:
             return pw
 
 
-def look_for_pathways(
+def look_for_pathways(  # type: ignore[explicit-any]
     name: str = "pathways", ext: str = "qrp", check: bool = False, directory: str = "."
 ) -> numpy.ndarray:
     """Load pathways by t2"""
@@ -528,7 +528,7 @@ def look_for_pathways(
     return t2s
 
 
-def load_pathways_by_t2(
+def load_pathways_by_t2(  # type: ignore[explicit-any]
     t2: float,
     name: str = "pathways",
     ext: str = "qrp",
@@ -548,7 +548,7 @@ def load_pathways_by_t2(
     return pw
 
 
-def save_pathways_by_t2(
+def save_pathways_by_t2(  # type: ignore[explicit-any]
     t2: float,
     name: str = "pathways",
     ext: str = "qrp",
@@ -559,7 +559,7 @@ def save_pathways_by_t2(
 
 
 # FIXME: This is done in an inefficient way, loading the files multiply
-def get_evolution_from_saved_pathways(
+def get_evolution_from_saved_pathways(  # type: ignore[explicit-any]
     states: Any,
     name: str = "pathways",
     ext: str = "qrp",
@@ -593,7 +593,7 @@ def get_evolution_from_saved_pathways(
     # return t2s, evol
 
 
-def get_prefactors_from_saved_pathways(
+def get_prefactors_from_saved_pathways(  # type: ignore[explicit-any]
     states: Any,
     name: str = "pathways",
     ext: str = "qrp",
@@ -625,7 +625,7 @@ def get_prefactors_from_saved_pathways(
     return DFunction(x=taxis, y=evol)
 
 
-def get_TwoDSpectrum_from_saved_pathways(
+def get_TwoDSpectrum_from_saved_pathways(  # type: ignore[explicit-any]
     t2: float,
     t1axis: Any,
     t3axis: Any,
@@ -646,7 +646,7 @@ def get_TwoDSpectrum_from_saved_pathways(
     return twod
 
 
-def get_TwoDSpectrum_from_pathways(pathways: Any, t1axis: Any, t3axis: Any) -> Any:
+def get_TwoDSpectrum_from_pathways(pathways: Any, t1axis: Any, t3axis: Any) -> Any:  # type: ignore[explicit-any]
     """Returns a 2D spectrum calculated based on submitted Liouville pathways"""
     from .mocktwodcalculator import (
         MockTwoDResponseCalculator as MockTwoDSpectrumCalculator,
@@ -660,7 +660,7 @@ def get_TwoDSpectrum_from_pathways(pathways: Any, t1axis: Any, t3axis: Any) -> A
     return twod
 
 
-def get_TwoDSpectrumContainer_from_saved_pathways(
+def get_TwoDSpectrumContainer_from_saved_pathways(  # type: ignore[explicit-any]
     t1axis: Any,
     t3axis: Any,
     name: str = "pathways",
@@ -692,10 +692,10 @@ def get_TwoDSpectrumContainer_from_saved_pathways(
     return tcont
 
 
-def _is_tuple_of_dyads(states: Any) -> bool:
+def _is_tuple_of_dyads(states: Any) -> bool:  # type: ignore[explicit-any]
     """Check if the object is a tuple or list of dyads"""
 
-    def _is_a_dyad(dd: Any) -> bool:
+    def _is_a_dyad(dd: Any) -> bool:  # type: ignore[explicit-any]
         return len(dd) == 2
 
     ret = False
@@ -709,7 +709,7 @@ def _is_tuple_of_dyads(states: Any) -> bool:
     return ret
 
 
-def _get_evol(
+def _get_evol(  # type: ignore[explicit-any]
     t2s: numpy.ndarray,
     states: Any,
     name: str,
@@ -719,7 +719,7 @@ def _get_evol(
 ) -> numpy.ndarray:
     """Return evolution of a single pathway"""
     N = 1
-    evol: numpy.ndarray
+    evol: numpy.ndarray  # type: ignore[explicit-any]
     if _is_tuple_of_dyads(states):
         evol = numpy.zeros(len(t2s), dtype=COMPLEX)
     else:
@@ -751,7 +751,7 @@ def _get_evol(
     return evol
 
 
-def _get_pref(
+def _get_pref(  # type: ignore[explicit-any]
     t2s: numpy.ndarray,
     states: Any,
     name: str,
@@ -761,7 +761,7 @@ def _get_pref(
 ) -> numpy.ndarray:
     """Return evolution of a single pathway"""
     N = 1
-    evol: numpy.ndarray
+    evol: numpy.ndarray  # type: ignore[explicit-any]
     if _is_tuple_of_dyads(states):
         evol = numpy.zeros(len(t2s), dtype=COMPLEX)
     else:

--- a/quantarhei/spectroscopy/pumpprobe.py
+++ b/quantarhei/spectroscopy/pumpprobe.py
@@ -37,11 +37,11 @@ class PumpProbeSpectrum(DFunction):
         self.data = None
         self._has_imag = False
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         self.xaxis = axis
         self.axis = self.xaxis
 
-    def set_data(self, data: Any) -> None:
+    def set_data(self, data: Any) -> None:  # type: ignore[explicit-any]
         self.data = data
 
     def get_PumpProbeSpectrum(self) -> PumpProbeSpectrum:
@@ -60,7 +60,7 @@ class PumpProbeSpectrum(DFunction):
         """Returns the t2 (waiting time) of the spectrum"""
         return self.t2
 
-    def _add_data(self, data: Any) -> None:
+    def _add_data(self, data: Any) -> None:  # type: ignore[explicit-any]
         if self.data is None:
             self.set_data(data)
         else:
@@ -74,20 +74,20 @@ class PumpProbeSpectrum(DFunction):
 class _RWAOverrideSystem:
     """Delegates to a system while overriding the response-backend RWA."""
 
-    def __init__(self, system: Any, rwa: Any, lineshape_timeaxis: Any = None) -> None:
+    def __init__(self, system: Any, rwa: Any, lineshape_timeaxis: Any = None) -> None:  # type: ignore[explicit-any]
         self._system = system
         self._rwa = rwa
         self._lineshape_timeaxis = lineshape_timeaxis
 
-    def get_RWA_suggestion(self) -> Any:
+    def get_RWA_suggestion(self) -> Any:  # type: ignore[explicit-any]
         return self._rwa
 
-    def get_lineshape_functions(self, config: dict | int | None = None) -> Any:
+    def get_lineshape_functions(self, config: dict | int | None = None) -> Any:  # type: ignore[explicit-any]
         return self._system.get_lineshape_functions(
             config=config, timeaxis=self._lineshape_timeaxis
         )
 
-    def __getattr__(self, name: str) -> Any:
+    def __getattr__(self, name: str) -> Any:  # type: ignore[explicit-any]
         return getattr(self._system, name)
 
 
@@ -100,10 +100,10 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
         Waiting-time axis shared by all stored spectra. Default is ``None``.
     """
 
-    def __init__(self, t2axis: Any = None) -> None:
+    def __init__(self, t2axis: Any = None) -> None:  # type: ignore[explicit-any]
 
         self.t2axis = t2axis
-        self.spectra: dict[Any, Any] = {}
+        self.spectra: dict[Any, Any] = {}  # type: ignore[explicit-any]
 
     def plot(self) -> None:
 
@@ -112,10 +112,10 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
         for sp in spctr:
             plt.plot(sp.xaxis.data, sp.data)
 
-    def set_spectrum(self, spec: Any, tag: Any = None) -> None:
+    def set_spectrum(self, spec: Any, tag: Any = None) -> None:  # type: ignore[explicit-any]
         self.spectra[tag] = spec
 
-    def amax(self, spart: Any = None) -> Any:
+    def amax(self, spart: Any = None) -> Any:  # type: ignore[explicit-any]
         mxs = []
         for s in self.get_spectra():
             spect = numpy.real(s.data)
@@ -123,7 +123,7 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
             mxs.append(mx)
         return numpy.amax(numpy.array(mxs))
 
-    def amin(self) -> Any:
+    def amin(self) -> Any:  # type: ignore[explicit-any]
         mxs = []
         for s in self.get_spectra():
             spect = numpy.real(s.data)
@@ -131,7 +131,7 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
             mxs.append(mx)
         return numpy.amin(numpy.array(mxs))
 
-    def plot2D(
+    def plot2D(  # type: ignore[explicit-any]
         self,
         axis: Any = None,
         units: str = "nm",
@@ -195,7 +195,7 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
             plt.colorbar(p, ax=ax)
             fig.savefig("PP_2D_spectra.png", format="png", dpi=1200)
 
-    def plot_slices(
+    def plot_slices(  # type: ignore[explicit-any]
         self, freqs: Any, expRes: Any = None, units: str = "nm"
     ) -> numpy.ndarray:
 
@@ -232,7 +232,7 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
             fig.savefig("PP_slices_spectra.png", format="png", dpi=1200)
         return spectra_freq
 
-    def make_movie(
+    def make_movie(  # type: ignore[explicit-any]
         self,
         filename: str,
         window: Any = None,
@@ -352,7 +352,7 @@ class PumpProbeSpectrumCalculator:
 
     system = derived_type("system", [Molecule, Aggregate])
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         t2axis: Any,
         t3axis: Any,
@@ -414,18 +414,18 @@ class PumpProbeSpectrumCalculator:
         if rate_matrix is not None:
             self._rate_matrix = rate_matrix
             self._has_rate_matrix = True
-        self.goft_matrix: Any = None
-        self.reorg_matrix: Any = None
+        self.goft_matrix: Any = None  # type: ignore[explicit-any]
+        self.reorg_matrix: Any = None  # type: ignore[explicit-any]
 
         # after bootstrap information
-        self.lab: Any = None
-        self.t3s: Any = None
-        self.pathways: Any = None
-        self.rwa: Any = None
-        self.density_matrix_trajectory: Any = density_matrix_trajectory
-        self.population_propagator: Any = population_propagator
-        self.density_matrix_propagator: Any = density_matrix_propagator
-        self.population_time_axis: Any = population_time_axis
+        self.lab: Any = None  # type: ignore[explicit-any]
+        self.t3s: Any = None  # type: ignore[explicit-any]
+        self.pathways: Any = None  # type: ignore[explicit-any]
+        self.rwa: Any = None  # type: ignore[explicit-any]
+        self.density_matrix_trajectory: Any = density_matrix_trajectory  # type: ignore[explicit-any]
+        self.population_propagator: Any = population_propagator  # type: ignore[explicit-any]
+        self.density_matrix_propagator: Any = density_matrix_propagator  # type: ignore[explicit-any]
+        self.population_time_axis: Any = population_time_axis  # type: ignore[explicit-any]
         self.include_nonsecular_remainder = include_nonsecular_remainder
         self.include_remainder = include_remainder
         self.dipole_normalization_tol = dipole_normalization_tol
@@ -434,7 +434,7 @@ class PumpProbeSpectrumCalculator:
 
         self.tc = 0
 
-    def bootstrap(
+    def bootstrap(  # type: ignore[explicit-any]
         self,
         rwa: float = 0.0,
         pathways: Any = None,
@@ -484,10 +484,10 @@ class PumpProbeSpectrumCalculator:
         self.tc = 0
         self.lab = lab
 
-    def set_pathways(self, pathways: Any) -> None:
+    def set_pathways(self, pathways: Any) -> None:  # type: ignore[explicit-any]
         self.pathways = pathways
 
-    def set_density_matrix_trajectory(
+    def set_density_matrix_trajectory(  # type: ignore[explicit-any]
         self, density_matrix_trajectory: Any, timeaxis: Any = None
     ) -> None:
         """Set an externally calculated density-matrix trajectory."""
@@ -496,7 +496,7 @@ class PumpProbeSpectrumCalculator:
         self.density_matrix_propagator = None
         self.population_time_axis = timeaxis
 
-    def set_population_propagator(
+    def set_population_propagator(  # type: ignore[explicit-any]
         self, population_propagator: Any, timeaxis: Any = None
     ) -> None:
         """Set an externally calculated one-exciton population propagator."""
@@ -505,7 +505,7 @@ class PumpProbeSpectrumCalculator:
         self.density_matrix_propagator = None
         self.population_time_axis = timeaxis
 
-    def set_density_matrix_propagator(
+    def set_density_matrix_propagator(  # type: ignore[explicit-any]
         self, density_matrix_propagator: Any, timeaxis: Any = None
     ) -> None:
         """Set an externally calculated one-exciton density-matrix propagator."""
@@ -514,7 +514,7 @@ class PumpProbeSpectrumCalculator:
         self.population_propagator = None
         self.population_time_axis = timeaxis
 
-    def set_dynamics(
+    def set_dynamics(  # type: ignore[explicit-any]
         self,
         density_matrix_trajectory: Any = None,
         population_propagator: Any = None,
@@ -542,7 +542,7 @@ class PumpProbeSpectrumCalculator:
         else:
             self.set_density_matrix_propagator(density_matrix_propagator, timeaxis)
 
-    def bath_reorg(self, cfm: Any, indx: Any) -> float:
+    def bath_reorg(self, cfm: Any, indx: Any) -> float:  # type: ignore[explicit-any]
         coft = cfm.cfuncs[cfm.get_index_by_where((indx, indx))]
         reorg_bath = 0.0
         for parm in coft.params:
@@ -550,7 +550,7 @@ class PumpProbeSpectrumCalculator:
                 reorg_bath += parm["reorg"]
         return reorg_bath
 
-    def _excitonic_reorg_diag(
+    def _excitonic_reorg_diag(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, subtract_bath: bool = True
     ) -> numpy.ndarray:
         """Returns the reorganisation energy of an exciton state"""
@@ -593,7 +593,7 @@ class PumpProbeSpectrumCalculator:
 
         return reorg_exct
 
-    def _site_reorg_diag(self, subtract_bath: bool = True) -> numpy.ndarray:
+    def _site_reorg_diag(self, subtract_bath: bool = True) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the reorganisation energy of an exciton state"""
         # SystemBathInteraction
         sbi = self.system.get_SystemBathInteraction()
@@ -629,7 +629,7 @@ class PumpProbeSpectrumCalculator:
 
         return reorg_site
 
-    def calculate_all_system_approx(
+    def calculate_all_system_approx(  # type: ignore[explicit-any]
         self,
         sys: Any,
         rdmt: Any,
@@ -735,7 +735,7 @@ class PumpProbeSpectrumCalculator:
 
         return tcont
 
-    def _response_backend_trace(self, diagrams: list[str], tau: float, lab: Any) -> Any:
+    def _response_backend_trace(self, diagrams: list[str], tau: float, lab: Any) -> Any:  # type: ignore[explicit-any]
         """Calculate selected response-backend diagrams as a t3 trace at t1 = 0."""
         t1axis = TimeAxis(0.0, 1, self.t3axis.step)
         backend_system = _RWAOverrideSystem(
@@ -756,7 +756,7 @@ class PumpProbeSpectrumCalculator:
 
         return response
 
-    def _full_dipole_rdm_weight(
+    def _full_dipole_rdm_weight(  # type: ignore[explicit-any]
         self, rdm: Any, ii: int, jj: int, tol: float = 1.0e-12
     ) -> Any:
         """Return RDM element normalized by the two preparation dipole lengths."""
@@ -770,7 +770,7 @@ class PumpProbeSpectrumCalculator:
             )
         return rdm[ii, jj] / norm
 
-    def _four_dipole_prefactors(self, lab: Any) -> dict[str, Any]:
+    def _four_dipole_prefactors(self, lab: Any) -> dict[str, Any]:  # type: ignore[explicit-any]
         """Return full orientational prefactors used by response functions."""
         prefactors = {}
         for key in ("abba", "baba"):
@@ -784,7 +784,7 @@ class PumpProbeSpectrumCalculator:
                 )
         return prefactors
 
-    def _response_backend_to_pump_probe(
+    def _response_backend_to_pump_probe(  # type: ignore[explicit-any]
         self, response: numpy.ndarray, tau: float
     ) -> Any:
         """Fourier transform a t1=0 response trace into a pump-probe spectrum."""
@@ -804,7 +804,7 @@ class PumpProbeSpectrumCalculator:
         onepp.set_t2(tau)
         return onepp
 
-    def calculate_all_system_approx_response_backend(
+    def calculate_all_system_approx_response_backend(  # type: ignore[explicit-any]
         self,
         sys: Any,
         rdmt: Any = None,
@@ -864,7 +864,7 @@ class PumpProbeSpectrumCalculator:
 
         if population_time_axis is None:
             population_time_axis = self.t2axis
-        response_kwargs: dict[str, Any] = dict(
+        response_kwargs: dict[str, Any] = dict(  # type: ignore[explicit-any]
             population_time_axis=population_time_axis
         )
         if rdmt is not None:
@@ -926,7 +926,7 @@ class PumpProbeSpectrumCalculator:
 
         return tcont
 
-    def calculate(
+    def calculate(  # type: ignore[explicit-any]
         self,
         system: Any = None,
         lab: Any = None,
@@ -1023,7 +1023,7 @@ class PumpProbeSpectrumCalculator:
 
         raise ValueError("method has to be 'response' or 'legacy'")
 
-    def calculate_all_system(
+    def calculate_all_system(  # type: ignore[explicit-any]
         self, sys: Any, eUt: Any, lab: Any, show_progress: bool = False
     ) -> Any:
         """Calculates all 2D spectra for a system and evolution superoperator"""
@@ -1048,7 +1048,7 @@ class PumpProbeSpectrumCalculator:
 
         return tcont
 
-    def calculate_one_system(
+    def calculate_one_system(  # type: ignore[explicit-any]
         self, t2: float, sys: Any, eUt: Any, lab: Any, pways: Any = None
     ) -> Any:
         """Returns pump-probe spectrum at t2 for a system and evolution
@@ -1112,14 +1112,14 @@ class PumpProbeSpectrumCalculator:
 
         return pprobe1
 
-    def calculate_next(self, t2: float) -> Any:
+    def calculate_next(self, t2: float) -> Any:  # type: ignore[explicit-any]
 
         sone = self.calculate_one(self.tc, t2)
         # print(self.tc, sone)
         self.tc += 1
         return sone
 
-    def calculate_one(self, tc: int, t2: float) -> Any:
+    def calculate_one(self, tc: int, t2: float) -> Any:  # type: ignore[explicit-any]
         """Calculate the 2D spectrum for all pathways"""
         # import time
 
@@ -1136,7 +1136,7 @@ class PumpProbeSpectrumCalculator:
 
         return onepp
 
-    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
+    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Converts correlation function to lineshape function
 
         Explicit numerical double integration of the correlation
@@ -1171,7 +1171,7 @@ class PumpProbeSpectrumCalculator:
         gt = sr + 1j * si
         return gt
 
-    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:
+    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns energy gap correlation function data of an exciton state n"""
         # SystemBathInteraction
         sbi = AG.get_SystemBathInteraction()
@@ -1199,7 +1199,7 @@ class PumpProbeSpectrumCalculator:
         #        print(numpy.isclose(ct,ct3).all())
         return ct
 
-    def _SE_excitonic_cofts(
+    def _SE_excitonic_cofts(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, AG: Any, tau: float = 0
     ) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Returns energy gap correlation function data of an exciton state n"""
@@ -1305,7 +1305,7 @@ class PumpProbeSpectrumCalculator:
 
         return ct3, ct3tau
 
-    def _SE_excitonic_cofts_test(
+    def _SE_excitonic_cofts_test(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, AG: Any, tau: float = 0
     ) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Returns energy gap correlation function data of an exciton state n"""
@@ -1420,7 +1420,7 @@ class PumpProbeSpectrumCalculator:
 
         return gt3, gt3tau
 
-    def _SE_excitonic_gofts(
+    def _SE_excitonic_gofts(  # type: ignore[explicit-any]
         self,
         SS: numpy.ndarray,
         AG: Any,
@@ -1535,7 +1535,7 @@ class PumpProbeSpectrumCalculator:
 
         return gt3tau
 
-    def _excitonic_reorg_energy(
+    def _excitonic_reorg_energy(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, AG: Any
     ) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Returns the reorganisation energy of an exciton state"""
@@ -1570,12 +1570,12 @@ class PumpProbeSpectrumCalculator:
 
         return reorg_exct, reorg_exct_sd
 
-    def calculate_pathways(self, pathways: Any, tau: float) -> numpy.ndarray:
+    def calculate_pathways(self, pathways: Any, tau: float) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculate the shape of a Liouville pathway"""
         # we can calculate empty pathway
         if pathways is None:
             N3 = self.oa3.length
-            ppspec: numpy.ndarray = numpy.zeros(N3, dtype=COMPLEX)
+            ppspec: numpy.ndarray = numpy.zeros(N3, dtype=COMPLEX)  # type: ignore[explicit-any]
             return ppspec
 
         N3 = self.oa3.length
@@ -1769,7 +1769,7 @@ class PumpProbeSpectrumCalculator:
 
         return data
 
-    def calculate_pathways_rdm(
+    def calculate_pathways_rdm(  # type: ignore[explicit-any]
         self,
         rdm0: Any,
         rdm: Any,
@@ -1973,7 +1973,7 @@ class PumpProbeSpectrumCalculator:
 
         return onepp
 
-    def calculate_pathways_rdm_novoderezhkin(
+    def calculate_pathways_rdm_novoderezhkin(  # type: ignore[explicit-any]
         self,
         rdm0: Any,
         rdm: Any,
@@ -2149,7 +2149,7 @@ class PumpProbeSpectrumCalculator:
         return onepp
 
 
-def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:
+def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:  # type: ignore[explicit-any]
     """Calculates pump-probe spectrum from 2D spectrum
 
     Calculates pump-probe spectrum from 2D spectrum
@@ -2209,7 +2209,7 @@ class MockPumpProbeSpectrumCalculator(MockTwoDSpectrumCalculator):
         lineshapes).
     """
 
-    def calculate_all_system(
+    def calculate_all_system(  # type: ignore[explicit-any]
         self,
         sys: Any,
         eUt: Any,
@@ -2253,7 +2253,7 @@ class MockPumpProbeSpectrumCalculator(MockTwoDSpectrumCalculator):
             tcont = super().calculate_all_system(sys, eUt, lab)
             return tcont.get_PumpProbeSpectrumContainer()
 
-    def calculate_one_system(
+    def calculate_one_system(  # type: ignore[explicit-any]
         self,
         t2: float,
         sys: Any,

--- a/quantarhei/spectroscopy/pumpprobe2.py
+++ b/quantarhei/spectroscopy/pumpprobe2.py
@@ -31,11 +31,11 @@ class PumpProbeSpectrum(DFunction):
         self.data = None
         self._has_imag = False
 
-    def set_axis(self, axis: Any) -> None:
+    def set_axis(self, axis: Any) -> None:  # type: ignore[explicit-any]
         self.xaxis = axis
         self.axis = self.xaxis
 
-    def set_data(self, data: Any) -> None:
+    def set_data(self, data: Any) -> None:  # type: ignore[explicit-any]
         self.data = data
 
     def get_PumpProbeSpectrum(self) -> PumpProbeSpectrum:
@@ -54,7 +54,7 @@ class PumpProbeSpectrum(DFunction):
         """Returns the t2 (waiting time) of the spectrum"""
         return self.t2
 
-    def _add_data(self, data: Any) -> None:
+    def _add_data(self, data: Any) -> None:  # type: ignore[explicit-any]
         if self.data is None:
             self.set_data(data)
         else:
@@ -68,10 +68,10 @@ class PumpProbeSpectrum(DFunction):
 class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
     """Container for a set of pump-probe spectra"""
 
-    def __init__(self, t2axis: Any = None) -> None:
+    def __init__(self, t2axis: Any = None) -> None:  # type: ignore[explicit-any]
 
         self.t2axis = t2axis
-        self.spectra: dict[Any, Any] = {}
+        self.spectra: dict[Any, Any] = {}  # type: ignore[explicit-any]
 
     def plot(self) -> None:
 
@@ -80,10 +80,10 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
         for sp in spctr:
             plt.plot(sp.xaxis.data, sp.data)
 
-    def set_spectrum(self, spec: Any, tag: Any = None) -> None:
+    def set_spectrum(self, spec: Any, tag: Any = None) -> None:  # type: ignore[explicit-any]
         self.spectra[tag] = spec
 
-    def amax(self, spart: Any = None) -> Any:
+    def amax(self, spart: Any = None) -> Any:  # type: ignore[explicit-any]
         mxs = []
         for s in self.get_spectra():
             spect = numpy.real(s.data)
@@ -91,7 +91,7 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
             mxs.append(mx)
         return numpy.amax(numpy.array(mxs))
 
-    def amin(self) -> Any:
+    def amin(self) -> Any:  # type: ignore[explicit-any]
         mxs = []
         for s in self.get_spectra():
             spect = numpy.real(s.data)
@@ -99,7 +99,7 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
             mxs.append(mx)
         return numpy.amin(numpy.array(mxs))
 
-    def plot2D(
+    def plot2D(  # type: ignore[explicit-any]
         self,
         axis: Any = None,
         units: str = "nm",
@@ -163,7 +163,7 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
             plt.colorbar(p, ax=ax)
             fig.savefig("PP_2D_spectra.png", format="png", dpi=1200)
 
-    def plot_slices(
+    def plot_slices(  # type: ignore[explicit-any]
         self, freqs: Any, expRes: Any = None, units: str = "nm"
     ) -> numpy.ndarray:
 
@@ -200,7 +200,7 @@ class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
             fig.savefig("PP_slices_spectra.png", format="png", dpi=1200)
         return spectra_freq
 
-    def make_movie(
+    def make_movie(  # type: ignore[explicit-any]
         self,
         filename: str,
         window: Any = None,
@@ -297,7 +297,7 @@ class PumpProbeSpectrumCalculator:
 
     system = derived_type("system", [Molecule, Aggregate])
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         t2axis: Any,
         t3axis: Any,
@@ -338,20 +338,20 @@ class PumpProbeSpectrumCalculator:
         if rate_matrix is not None:
             self._rate_matrix = rate_matrix
             self._has_rate_matrix = True
-        self.goft_matrix: Any = None
-        self.reorg_matrix: Any = None
+        self.goft_matrix: Any = None  # type: ignore[explicit-any]
+        self.reorg_matrix: Any = None  # type: ignore[explicit-any]
 
         # after bootstrap information
-        self.lab: Any = None
-        self.t3s: Any = None
-        self.pathways: Any = None
-        self.rwa: Any = None
+        self.lab: Any = None  # type: ignore[explicit-any]
+        self.t3s: Any = None  # type: ignore[explicit-any]
+        self.pathways: Any = None  # type: ignore[explicit-any]
+        self.rwa: Any = None  # type: ignore[explicit-any]
 
         self.verbose = False
 
         self.tc = 0
 
-    def bootstrap(
+    def bootstrap(  # type: ignore[explicit-any]
         self,
         rwa: float = 0.0,
         pathways: Any = None,
@@ -401,10 +401,10 @@ class PumpProbeSpectrumCalculator:
         self.tc = 0
         self.lab = lab
 
-    def set_pathways(self, pathways: Any) -> None:
+    def set_pathways(self, pathways: Any) -> None:  # type: ignore[explicit-any]
         self.pathways = pathways
 
-    def bath_reorg(self, cfm: Any, indx: Any) -> float:
+    def bath_reorg(self, cfm: Any, indx: Any) -> float:  # type: ignore[explicit-any]
         coft = cfm.cfuncs[cfm.get_index_by_where((indx, indx))]
         reorg_bath = 0.0
         for parm in coft.params:
@@ -412,7 +412,7 @@ class PumpProbeSpectrumCalculator:
                 reorg_bath += parm["reorg"]
         return reorg_bath
 
-    def _excitonic_reorg_diag(
+    def _excitonic_reorg_diag(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, subtract_bath: bool = True
     ) -> numpy.ndarray:
         """Returns the reorganisation energy of an exciton state"""
@@ -455,7 +455,7 @@ class PumpProbeSpectrumCalculator:
 
         return reorg_exct
 
-    def _site_reorg_diag(self, subtract_bath: bool = True) -> numpy.ndarray:
+    def _site_reorg_diag(self, subtract_bath: bool = True) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the reorganisation energy of an exciton state"""
         # SystemBathInteraction
         sbi = self.system.get_SystemBathInteraction()
@@ -491,7 +491,7 @@ class PumpProbeSpectrumCalculator:
 
         return reorg_site
 
-    def calculate_all_system_approx(
+    def calculate_all_system_approx(  # type: ignore[explicit-any]
         self,
         sys: Any,
         rdmt: Any,
@@ -580,7 +580,7 @@ class PumpProbeSpectrumCalculator:
 
         return tcont
 
-    def calculate_all_system(
+    def calculate_all_system(  # type: ignore[explicit-any]
         self, sys: Any, eUt: Any, lab: Any, show_progress: bool = False
     ) -> Any:
         """Calculates all 2D spectra for a system and evolution superoperator"""
@@ -605,7 +605,7 @@ class PumpProbeSpectrumCalculator:
 
         return tcont
 
-    def calculate_one_system(
+    def calculate_one_system(  # type: ignore[explicit-any]
         self, t2: float, sys: Any, eUt: Any, lab: Any, pways: Any = None
     ) -> Any:
         """Returns pump-probe spectrum at t2 for a system and evolution
@@ -669,14 +669,14 @@ class PumpProbeSpectrumCalculator:
 
         return pprobe1
 
-    def calculate_next(self, t2: float) -> Any:
+    def calculate_next(self, t2: float) -> Any:  # type: ignore[explicit-any]
 
         sone = self.calculate_one(self.tc, t2)
         # print(self.tc, sone)
         self.tc += 1
         return sone
 
-    def calculate_one(self, tc: int, t2: float) -> Any:
+    def calculate_one(self, tc: int, t2: float) -> Any:  # type: ignore[explicit-any]
         """Calculate the 2D spectrum for all pathways"""
         # import time
 
@@ -693,7 +693,7 @@ class PumpProbeSpectrumCalculator:
 
         return onepp
 
-    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:
+    def _c2g(self, timeaxis: Any, coft: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Converts correlation function to lineshape function
 
         Explicit numerical double integration of the correlation
@@ -728,7 +728,7 @@ class PumpProbeSpectrumCalculator:
         gt = sr + 1j * si
         return gt
 
-    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:
+    def _excitonic_coft(self, SS: numpy.ndarray, AG: Any, n: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns energy gap correlation function data of an exciton state n"""
         # SystemBathInteraction
         sbi = AG.get_SystemBathInteraction()
@@ -756,7 +756,7 @@ class PumpProbeSpectrumCalculator:
         #        print(numpy.isclose(ct,ct3).all())
         return ct
 
-    def _SE_excitonic_cofts(
+    def _SE_excitonic_cofts(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, AG: Any, tau: float = 0
     ) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Returns energy gap correlation function data of an exciton state n"""
@@ -862,7 +862,7 @@ class PumpProbeSpectrumCalculator:
 
         return ct3, ct3tau
 
-    def _SE_excitonic_cofts_test(
+    def _SE_excitonic_cofts_test(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, AG: Any, tau: float = 0
     ) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Returns energy gap correlation function data of an exciton state n"""
@@ -977,7 +977,7 @@ class PumpProbeSpectrumCalculator:
 
         return gt3, gt3tau
 
-    def _SE_excitonic_gofts(
+    def _SE_excitonic_gofts(  # type: ignore[explicit-any]
         self,
         SS: numpy.ndarray,
         AG: Any,
@@ -1092,7 +1092,7 @@ class PumpProbeSpectrumCalculator:
 
         return gt3tau
 
-    def _excitonic_reorg_energy(
+    def _excitonic_reorg_energy(  # type: ignore[explicit-any]
         self, SS: numpy.ndarray, AG: Any
     ) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Returns the reorganisation energy of an exciton state"""
@@ -1127,12 +1127,12 @@ class PumpProbeSpectrumCalculator:
 
         return reorg_exct, reorg_exct_sd
 
-    def calculate_pathways(self, pathways: Any, tau: float) -> numpy.ndarray:
+    def calculate_pathways(self, pathways: Any, tau: float) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculate the shape of a Liouville pathway"""
         # we can calculate empty pathway
         if pathways is None:
             N3 = self.oa3.length
-            ppspec: numpy.ndarray = numpy.zeros(N3, dtype=COMPLEX)
+            ppspec: numpy.ndarray = numpy.zeros(N3, dtype=COMPLEX)  # type: ignore[explicit-any]
             return ppspec
 
         N3 = self.oa3.length
@@ -1326,7 +1326,7 @@ class PumpProbeSpectrumCalculator:
 
         return data
 
-    def calculate_pathways_rdm(
+    def calculate_pathways_rdm(  # type: ignore[explicit-any]
         self,
         rdm0: Any,
         rdm: Any,
@@ -1491,7 +1491,7 @@ class PumpProbeSpectrumCalculator:
 
         return onepp
 
-    def calculate_pathways_rdm_novoderezhkin(
+    def calculate_pathways_rdm_novoderezhkin(  # type: ignore[explicit-any]
         self,
         rdm0: Any,
         rdm: Any,
@@ -1632,7 +1632,7 @@ class PumpProbeSpectrumCalculator:
         return onepp
 
 
-def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:
+def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:  # type: ignore[explicit-any]
     """Calculates pump-probe spectrum from 2D spectrum
 
     Calculates pump-probe spectrum from 2D spectrum
@@ -1670,7 +1670,7 @@ def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:
 class MockPumpProbeSpectrumCalculator(MockTwoDSpectrumCalculator):
     """Effective line shape pump-probe spectrum calculator"""
 
-    def calculate_all_system(
+    def calculate_all_system(  # type: ignore[explicit-any]
         self,
         sys: Any,
         eUt: Any,
@@ -1689,7 +1689,7 @@ class MockPumpProbeSpectrumCalculator(MockTwoDSpectrumCalculator):
             tcont = super().calculate_all_system(sys, eUt, lab)
             return tcont.get_PumpProbeSpectrumContainer()
 
-    def calculate_one_system(
+    def calculate_one_system(  # type: ignore[explicit-any]
         self,
         t2: float,
         sys: Any,

--- a/quantarhei/spectroscopy/response_implementations.py
+++ b/quantarhei/spectroscopy/response_implementations.py
@@ -25,7 +25,7 @@ ONE_JUMP_LINE_SHAPE_ARGUMENTS = (
 )
 
 
-def _require_line_shape_arguments(gg: Any, response_name: str) -> None:
+def _require_line_shape_arguments(gg: Any, response_name: str) -> None:  # type: ignore[explicit-any]
     """Checks that line-shape storage has all one-jump response arguments."""
     if not hasattr(gg, "time_mapping"):
         raise Exception(
@@ -44,14 +44,14 @@ def _require_line_shape_arguments(gg: Any, response_name: str) -> None:
         )
 
 
-def _jump_time_metadata(evol: Any) -> dict[str, Any]:
+def _jump_time_metadata(evol: Any) -> dict[str, Any]:  # type: ignore[explicit-any]
     """Returns one-jump integration metadata from response evolution data."""
     if isinstance(evol, tuple) and len(evol) > 4 and isinstance(evol[4], dict):
         return evol[4]
     return {}
 
 
-def _endpoint_t2_weight(evol: Any, left: int, right: int, default: Any) -> Any:
+def _endpoint_t2_weight(evol: Any, left: int, right: int, default: Any) -> Any:  # type: ignore[explicit-any]
     """Returns an externally supplied t2 endpoint weight if available."""
     metadata = _jump_time_metadata(evol)
     endpoint = metadata.get("density_matrix_endpoint_t2", None)
@@ -60,7 +60,7 @@ def _endpoint_t2_weight(evol: Any, left: int, right: int, default: Any) -> Any:
     return endpoint[left, right]
 
 
-def _single_jump_times(t2: Any, evol: Any) -> numpy.ndarray:
+def _single_jump_times(t2: Any, evol: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Returns jump times from the population time axis and graining."""
     t2_value = float(t2)
     if t2_value == 0.0:
@@ -88,7 +88,7 @@ def _single_jump_times(t2: Any, evol: Any) -> numpy.ndarray:
     )
 
 
-def _single_jump_transfer_matrix(t2: Any, s2: Any, evol: Any, KK: Any) -> Any:
+def _single_jump_transfer_matrix(t2: Any, s2: Any, evol: Any, KK: Any) -> Any:  # type: ignore[explicit-any]
     """Returns the one-jump transfer matrix density for a fixed jump time."""
     metadata = _jump_time_metadata(evol)
     axis = metadata.get("jump_time_axis", None)
@@ -123,7 +123,7 @@ def _single_jump_transfer_matrix(t2: Any, s2: Any, evol: Any, KK: Any) -> Any:
     return transfer
 
 
-def _truncate_single_jump_times(
+def _truncate_single_jump_times(  # type: ignore[explicit-any]
     t2: Any, s2s: numpy.ndarray, transfers: list[Any], evol: Any
 ) -> tuple[numpy.ndarray, list[Any]]:
     """Drop s2 points whose one-jump kernel is negligible."""
@@ -155,7 +155,7 @@ def _truncate_single_jump_times(
     return s2s[first : last + 1], transfers[first : last + 1]
 
 
-def _single_jump_kernel_diagnostics(
+def _single_jump_kernel_diagnostics(  # type: ignore[explicit-any]
     s2s: numpy.ndarray, transfers: list[Any], used_points: int, skipped: bool
 ) -> dict[str, Any]:
     """Return diagnostic information about the one-jump kernel."""
@@ -182,7 +182,7 @@ def _single_jump_kernel_diagnostics(
     }
 
 
-def _set_single_jump_diagnostics(
+def _set_single_jump_diagnostics(  # type: ignore[explicit-any]
     evol: Any, response_name: str, diagnostics: dict[str, Any]
 ) -> None:
     """Store one-jump diagnostics in response evolution metadata."""
@@ -192,7 +192,7 @@ def _set_single_jump_diagnostics(
     metadata["jump_diagnostics"] = all_diagnostics
 
 
-def _replace_transfer_matrix(evol: Any, transfer_matrix: Any) -> Any:
+def _replace_transfer_matrix(evol: Any, transfer_matrix: Any) -> Any:  # type: ignore[explicit-any]
     """Return response evolution data with a fixed transfer matrix."""
     if isinstance(evol, tuple) and len(evol) > 4:
         return evol[:3] + (transfer_matrix,) + evol[4:]
@@ -201,7 +201,7 @@ def _replace_transfer_matrix(evol: Any, transfer_matrix: Any) -> Any:
     return evol
 
 
-def _evaluate_single_jump_response(
+def _evaluate_single_jump_response(  # type: ignore[explicit-any]
     response_func: Any,
     t2: Any,
     s2: Any,
@@ -233,7 +233,7 @@ def _evaluate_single_jump_response(
             gg._reset_defaults = old_defaults
 
 
-def _integrate_single_jump_response(
+def _integrate_single_jump_response(  # type: ignore[explicit-any]
     response_func: Any,
     response_name: str,
     t2: Any,
@@ -304,7 +304,7 @@ def _integrate_single_jump_response(
     return ret
 
 
-def R1g(
+def R1g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -354,7 +354,7 @@ def R1g(
     F4 = system.get_F4d("abba")
     dfac = np.einsum("i,abi->ab", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for aa in band1:
             a = aa - 1
@@ -389,7 +389,7 @@ def R1g(
     return np.transpose(ret)
 
 
-def R2g(
+def R2g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -439,7 +439,7 @@ def R2g(
     F4 = system.get_F4d("baba")
     dfac = np.einsum("i,abi->ab", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for aa in band1:
             a = aa - 1
@@ -476,7 +476,7 @@ def R2g(
     return np.transpose(ret)
 
 
-def R3g(
+def R3g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -525,7 +525,7 @@ def R3g(
     F4 = system.get_F4d("bbaa")
     dfac = np.einsum("i,abi->ab", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for aa in band1:
             a = aa - 1
@@ -563,7 +563,7 @@ def R3g(
     return np.transpose(ret)
 
 
-def R4g(
+def R4g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -612,7 +612,7 @@ def R4g(
     F4 = system.get_F4d("bbaa")
     dfac = np.einsum("i,abi->ab", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for aa in band1:
             a = aa - 1
@@ -640,7 +640,7 @@ def R4g(
     return np.transpose(ret)
 
 
-def R1f(
+def R1f(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -694,7 +694,7 @@ def R1f(
     F4 = system.get_F4d("fbfaba")
     dfac = np.einsum("i,fabi->fab", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for ff in band2:
             f = ff - N1 - N0
@@ -742,7 +742,7 @@ def R1f(
     return np.transpose(ret)
 
 
-def R1f_wrong(
+def R1f_wrong(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -796,7 +796,7 @@ def R1f_wrong(
     F4 = system.get_F4d("fbfaba")
     dfac = np.einsum("i,fabi->fab", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for ff in band2:
             f = ff - N1 - N0
@@ -844,7 +844,7 @@ def R1f_wrong(
     return np.transpose(ret)
 
 
-def R2f(
+def R2f(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -898,7 +898,7 @@ def R2f(
     F4 = system.get_F4d("fafbba")
     dfac = np.einsum("i,fabi->fab", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
 
     for g in band0:
         for ff in band2:
@@ -957,7 +957,7 @@ def R2f(
     return np.transpose(ret)
 
 
-def R2f_wrong(
+def R2f_wrong(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1011,7 +1011,7 @@ def R2f_wrong(
     F4 = system.get_F4d("fafbba")
     dfac = np.einsum("i,fabi->fab", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
 
     for g in band0:
         for ff in band2:
@@ -1070,7 +1070,7 @@ def R2f_wrong(
     return np.transpose(ret)
 
 
-def R1g_scM0g(
+def R1g_scM0g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1120,7 +1120,7 @@ def R1g_scM0g(
     F4 = system.get_F4d("bbaa")
     dfac = np.einsum("i,bai->ba", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for aa in band1:
             a = aa - 1
@@ -1145,7 +1145,7 @@ def R1g_scM0g(
     return np.transpose(ret)
 
 
-def R2g_scM0g(
+def R2g_scM0g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1195,7 +1195,7 @@ def R2g_scM0g(
     F4 = system.get_F4d("bbaa")
     dfac = np.einsum("i,bai->ba", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for aa in band1:
             a = aa - 1
@@ -1222,7 +1222,7 @@ def R2g_scM0g(
     return np.transpose(ret)
 
 
-def R1f_scM0g(
+def R1f_scM0g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1276,7 +1276,7 @@ def R1f_scM0g(
     F4 = system.get_F4d("fbfbaa")
     dfac = np.einsum("i,fbai->fba", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for ff in band2:
             f = ff - N1 - N0
@@ -1314,7 +1314,7 @@ def R1f_scM0g(
     return np.transpose(ret)
 
 
-def R2f_scM0g(
+def R2f_scM0g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1368,7 +1368,7 @@ def R2f_scM0g(
     F4 = system.get_F4d("fbfbaa")
     dfac = np.einsum("i,fbai->fba", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
 
     for g in band0:
         for ff in band2:
@@ -1417,7 +1417,7 @@ def R2f_scM0g(
     return np.transpose(ret)
 
 
-def R1f_scM0e(
+def R1f_scM0e(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1471,7 +1471,7 @@ def R1f_scM0e(
     F4 = system.get_F4d("fbfbaa")
     dfac = np.einsum("i,fbai->fba", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
     for g in band0:
         for ff in band2:
             f = ff - N1 - N0
@@ -1509,7 +1509,7 @@ def R1f_scM0e(
     return np.transpose(ret)
 
 
-def R2f_scM0e(
+def R2f_scM0e(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1563,7 +1563,7 @@ def R2f_scM0e(
     F4 = system.get_F4d("fbfbaa")
     dfac = np.einsum("i,fbai->fba", lab.F4eM4, F4)
 
-    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)
+    ret: numpy.ndarray = np.zeros((len(t1), len(t3)), dtype=COMPLEX)  # type: ignore[explicit-any]
 
     lam = gg.get_reorganization_energies()
     # print("lam = ", convert(lam,"int","1/cm"))
@@ -1615,7 +1615,7 @@ def R2f_scM0e(
     return np.transpose(ret)
 
 
-def R1g_scM1g(
+def R1g_scM1g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1635,7 +1635,7 @@ def R1g_scM1g(
     )
 
 
-def R2g_scM1g(
+def R2g_scM1g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1650,7 +1650,7 @@ def R2g_scM1g(
     )
 
 
-def R1f_scM1g(
+def R1f_scM1g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1665,7 +1665,7 @@ def R1f_scM1g(
     )
 
 
-def R2f_scM1g(
+def R2f_scM1g(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1680,7 +1680,7 @@ def R2f_scM1g(
     )
 
 
-def R1f_scM1e(
+def R1f_scM1e(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1695,7 +1695,7 @@ def R1f_scM1e(
     )
 
 
-def R2f_scM1e(
+def R2f_scM1e(  # type: ignore[explicit-any]
     t2: Any,
     t1: numpy.ndarray,
     t3: numpy.ndarray,
@@ -1736,6 +1736,6 @@ dc["R1f_scM1e"] = R1f_scM1e
 dc["R2f_scM1e"] = R2f_scM1e
 
 
-def get_implementation(name: str) -> Any:
+def get_implementation(name: str) -> Any:  # type: ignore[explicit-any]
     """Returns a dictionary of functions"""
     return dc[name]

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -173,7 +173,7 @@ RESPONSE_DIAGRAMS = {
 }
 
 
-def get_response_diagram_info(diagram: str) -> dict[str, Any]:
+def get_response_diagram_info(diagram: str) -> dict[str, Any]:  # type: ignore[explicit-any]
     """Returns explicit metadata for a nonlinear response diagram."""
     try:
         return RESPONSE_DIAGRAMS[diagram].copy()
@@ -181,14 +181,14 @@ def get_response_diagram_info(diagram: str) -> dict[str, Any]:
         raise Exception("Unknown response diagram: " + diagram)
 
 
-def _rate_matrix_data(rate_matrix: Any) -> numpy.ndarray:
+def _rate_matrix_data(rate_matrix: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Returns numerical data from a rate matrix object or array."""
     if hasattr(rate_matrix, "data"):
         return numpy.asarray(rate_matrix.data)
     return numpy.asarray(rate_matrix)
 
 
-def get_single_exciton_rate_matrix(system: Any, rate_matrix: Any) -> numpy.ndarray:
+def get_single_exciton_rate_matrix(system: Any, rate_matrix: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Returns the single-exciton block of a rate matrix.
 
     ``OpenSystem.get_RateMatrix`` returns rates indexed by the full Hamiltonian
@@ -211,7 +211,7 @@ def get_single_exciton_rate_matrix(system: Any, rate_matrix: Any) -> numpy.ndarr
     raise Exception("Rate matrix has to be an array of rank 2 or 3")
 
 
-def get_common_time_axis(*axes: Any) -> Any:
+def get_common_time_axis(*axes: Any) -> Any:  # type: ignore[explicit-any]
     """Returns a common zero-start TimeAxis covering all submitted axes."""
     dt = min(axis.step for axis in axes)
     tmax = max(axis.max for axis in axes)
@@ -219,7 +219,7 @@ def get_common_time_axis(*axes: Any) -> Any:
     return TimeAxis(0.0, length, dt)
 
 
-def validate_2d_time_axes(t1s: Any, t2s: Any, t3s: Any) -> None:
+def validate_2d_time_axes(t1s: Any, t2s: Any, t3s: Any) -> None:  # type: ignore[explicit-any]
     """Validates 2D time axes for relaxation-enabled calculations."""
     if not numpy.isclose(t1s.step, t3s.step):
         raise Exception("t1 and t3 axes must have the same time step")
@@ -229,7 +229,7 @@ def validate_2d_time_axes(t1s: Any, t2s: Any, t3s: Any) -> None:
         raise Exception("t2 time step must be a multiple of t1/t3 time step")
 
 
-def _axis_indices(axis: Any, base_axis: Any) -> numpy.ndarray:
+def _axis_indices(axis: Any, base_axis: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Returns integer indices of ``axis`` values on ``base_axis``."""
     if not axis.is_subset_of(base_axis):
         raise Exception("TimeAxis is not a subset of the population time axis")
@@ -263,7 +263,7 @@ class NonLinearResponse:
         Time axis for the second coherence period.
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         lab: Any,
         system: Any,
@@ -326,20 +326,20 @@ class NonLinearResponse:
         self.jump_time_graining = jump_time_graining
         self.jump_kernel_cutoff = jump_kernel_cutoff
         self.jump_kernel_zero_cutoff = jump_kernel_zero_cutoff
-        self.KK: numpy.ndarray
-        self.U0_t1: numpy.ndarray
-        self.U0_t2: numpy.ndarray
-        self.U0_t3: numpy.ndarray
-        self.U0_population: numpy.ndarray
-        self.U0fe_t3: numpy.ndarray | None = None
-        self.Uee: numpy.ndarray
-        self.U1_t2: numpy.ndarray
-        self.Usingle_t2: numpy.ndarray
-        self.Ujump_t2: tuple[numpy.ndarray, ...]
-        self.Uremainder_t2: numpy.ndarray
-        self.Utransfer_t2: numpy.ndarray
-        self.diagnostics: dict[str, Any] = {}
-        self._previous_response_matrix: numpy.ndarray | None = None
+        self.KK: numpy.ndarray  # type: ignore[explicit-any]
+        self.U0_t1: numpy.ndarray  # type: ignore[explicit-any]
+        self.U0_t2: numpy.ndarray  # type: ignore[explicit-any]
+        self.U0_t3: numpy.ndarray  # type: ignore[explicit-any]
+        self.U0_population: numpy.ndarray  # type: ignore[explicit-any]
+        self.U0fe_t3: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.Uee: numpy.ndarray  # type: ignore[explicit-any]
+        self.U1_t2: numpy.ndarray  # type: ignore[explicit-any]
+        self.Usingle_t2: numpy.ndarray  # type: ignore[explicit-any]
+        self.Ujump_t2: tuple[numpy.ndarray, ...]  # type: ignore[explicit-any]
+        self.Uremainder_t2: numpy.ndarray  # type: ignore[explicit-any]
+        self.Utransfer_t2: numpy.ndarray  # type: ignore[explicit-any]
+        self.diagnostics: dict[str, Any] = {}  # type: ignore[explicit-any]
+        self._previous_response_matrix: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
         external_count = sum(
             item is not None
@@ -407,7 +407,7 @@ class NonLinearResponse:
         else:
             self.set_rate_matrix(KK, population_time_axis=population_time_axis)
 
-    def calculate_matrix(self, t2: float) -> Any:
+    def calculate_matrix(self, t2: float) -> Any:  # type: ignore[explicit-any]
         """Calculate the matrix of response values over t1 and t3 times.
 
         Parameters
@@ -436,7 +436,7 @@ class NonLinearResponse:
         # population decay factors at t2
         U0t2 = self.U0_t2[:, t2i]
 
-        metadata: dict[str, Any] = {
+        metadata: dict[str, Any] = {  # type: ignore[explicit-any]
             "jump_time_axis": self.population_time_axis,
             "jump_time_zero_index": pzeroi,
             "jump_time_t2_index": pt2i,
@@ -469,7 +469,7 @@ class NonLinearResponse:
         self._update_diagnostics(t2, data, metadata)
         return data
 
-    def _update_diagnostics(
+    def _update_diagnostics(  # type: ignore[explicit-any]
         self, t2: float, data: numpy.ndarray, metadata: dict[str, Any]
     ) -> None:
         """Update response diagnostics after a t2 calculation."""
@@ -538,7 +538,7 @@ class NonLinearResponse:
             return 0
         return 1 if self._uses_single_jump_storage() else 0
 
-    def _get_transfer_matrix(self, t2i: int) -> numpy.ndarray:
+    def _get_transfer_matrix(self, t2i: int) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns transfer propagator for the current response channel."""
         if self.transfer_channel is not None and self.transfer_channel.startswith(
             "scM1"
@@ -546,7 +546,7 @@ class NonLinearResponse:
             return self.Usingle_t2[:, :, t2i]
         return self.Uremainder_t2[:, :, t2i]
 
-    def _get_remainder_propagator(
+    def _get_remainder_propagator(  # type: ignore[explicit-any]
         self, jumps: tuple[numpy.ndarray, ...]
     ) -> numpy.ndarray:
         """Returns propagation not covered by explicit jump contributions."""
@@ -555,7 +555,7 @@ class NonLinearResponse:
             jump_sum += jump
         return self.Uee - jump_sum
 
-    def _population_propagator_data(self, population_propagator: Any) -> numpy.ndarray:
+    def _population_propagator_data(self, population_propagator: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns population propagator data in ``(N, N, Nt)`` order."""
         data = numpy.asarray(
             population_propagator.data
@@ -576,7 +576,7 @@ class NonLinearResponse:
             "or (Nt, N, N), where N is the number of single-exciton states"
         )
 
-    def _density_matrix_propagator_data(
+    def _density_matrix_propagator_data(  # type: ignore[explicit-any]
         self, density_matrix_propagator: Any
     ) -> numpy.ndarray:
         """Returns density-matrix propagator data in ``(N, N, N, N, Nt)`` order."""
@@ -599,7 +599,7 @@ class NonLinearResponse:
             "or (Nt, N, N, N, N), where N is the number of single-exciton states"
         )
 
-    def _density_matrix_trajectory_data(
+    def _density_matrix_trajectory_data(  # type: ignore[explicit-any]
         self, density_matrix_trajectory: Any
     ) -> numpy.ndarray:
         """Returns density-matrix trajectory data in ``(N, N, Nt)`` order."""
@@ -629,7 +629,7 @@ class NonLinearResponse:
             "(Nt, N, N), or the corresponding full-system shape"
         )
 
-    def _ground_exciton_dipole_lengths(self) -> numpy.ndarray:
+    def _ground_exciton_dipole_lengths(self) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Returns lengths of ground-to-one-exciton transition dipoles."""
         self.sys.diagonalize()
         band0 = self.sys.get_band(0)
@@ -644,7 +644,7 @@ class NonLinearResponse:
             lengths[aa] = numpy.linalg.norm(self.sys.DD[state, ground, :])
         return lengths
 
-    def set_density_matrix_trajectory(
+    def set_density_matrix_trajectory(  # type: ignore[explicit-any]
         self,
         density_matrix_trajectory: Any,
         population_time_axis: Any = None,
@@ -714,7 +714,7 @@ class NonLinearResponse:
         self.Uremainder_t2 = numpy.zeros_like(self.Uee)
         self.Utransfer_t2 = self.Uremainder_t2
 
-    def set_density_matrix_propagator(
+    def set_density_matrix_propagator(  # type: ignore[explicit-any]
         self,
         density_matrix_propagator: Any,
         population_time_axis: Any = None,
@@ -785,7 +785,7 @@ class NonLinearResponse:
         self.Uremainder_t2 = Uremainder[:, :, it2]
         self.Utransfer_t2 = self.Uremainder_t2
 
-    def set_population_propagator(
+    def set_population_propagator(  # type: ignore[explicit-any]
         self,
         population_propagator: Any,
         population_time_axis: Any = None,
@@ -849,7 +849,7 @@ class NonLinearResponse:
         self.Uremainder_t2 = self.Uee - self.U1_t2
         self.Utransfer_t2 = self.Uremainder_t2
 
-    def set_rate_matrix(
+    def set_rate_matrix(  # type: ignore[explicit-any]
         self, KK: numpy.ndarray, population_time_axis: Any = None
     ) -> None:
         """Set the rate matrix and pre-compute the evolution coefficients.
@@ -965,7 +965,7 @@ class NonLinearResponse:
             # time dependent rate matrix
             for aa in range(dim):
                 if numpy.all(KK[:, aa, aa] <= 0.0):
-                    cumulative: numpy.ndarray = numpy.zeros(
+                    cumulative: numpy.ndarray = numpy.zeros(  # type: ignore[explicit-any]
                         population_time_axis.length, dtype=REAL
                     )
                     for ii in range(population_time_axis.length - 1):
@@ -1048,7 +1048,7 @@ class LiouvillePathway:
 
         self.F4n = numpy.zeros(3)
 
-    def set_dipoles(
+    def set_dipoles(  # type: ignore[explicit-any]
         self,
         d1: numpy.ndarray,
         d2: numpy.ndarray | None = None,
@@ -1099,7 +1099,7 @@ class LiouvillePathway:
 
         self._frequencies_set = True
 
-    def get_frequencies(self) -> tuple[float | numpy.ndarray, float | numpy.ndarray]:
+    def get_frequencies(self) -> tuple[float | numpy.ndarray, float | numpy.ndarray]:  # type: ignore[explicit-any]
         """Returns the two main frequencies of the response"""
         if self._frequencies_set:
             fr = (
@@ -1134,7 +1134,7 @@ class LiouvillePathway:
             self._rwa = 0.0
             self._rwa_set = False
 
-    def get_rwa(self) -> float | numpy.ndarray:
+    def get_rwa(self) -> float | numpy.ndarray:  # type: ignore[explicit-any]
         """Returns the RWA frequency"""
         return Manager().convert_energy_2_internal_u(self._rwa)
 
@@ -1148,7 +1148,7 @@ class ResponseFunction(LiouvillePathway):
         Type of the Liouville pathway (e.g. ``"R1g"``, ``"R2g"``).
     """
 
-    def calculate_matrix(
+    def calculate_matrix(  # type: ignore[explicit-any]
         self, lab: Any, sys: Any, t2: float, t1s: Any, t3s: Any, rwa: float
     ) -> Any:
         """Calculates the matrix of response values in t1 and t3 times
@@ -1194,11 +1194,11 @@ class ResponseFunction(LiouvillePathway):
 
         return dip * val * et13
 
-    def set_evaluation_function(self, func: Any) -> None:
+    def set_evaluation_function(self, func: Any) -> None:  # type: ignore[explicit-any]
         """Sets the function to be evaluated to get the response matrix"""
         self.func = func
 
-    def set_auxliary_arguments(self, args: tuple[Any, ...]) -> None:
+    def set_auxliary_arguments(self, args: tuple[Any, ...]) -> None:  # type: ignore[explicit-any]
         """Sets additional arguments and their values for evaluation calls
 
 

--- a/quantarhei/spectroscopy/twod22.py
+++ b/quantarhei/spectroscopy/twod22.py
@@ -57,7 +57,7 @@ class DFunction2:
     discrete function
     """
 
-    def __init__(self, x: Any = None, y: Any = None, z: Any = None) -> None:
+    def __init__(self, x: Any = None, y: Any = None, z: Any = None) -> None:  # type: ignore[explicit-any]
         pass
 
     def save(
@@ -65,10 +65,10 @@ class DFunction2:
     ) -> None:
         pass
 
-    def load(self, filename: str | IO[bytes], test: bool = False) -> Any:
+    def load(self, filename: str | IO[bytes], test: bool = False) -> Any:  # type: ignore[explicit-any]
         pass
 
-    def plot(self, **kwargs: Any) -> None:
+    def plot(self, **kwargs: Any) -> None:  # type: ignore[explicit-any]
         pass
 
 
@@ -90,22 +90,22 @@ class TwoDSpectrumBase(DFunction2):
     def __init__(self) -> None:
         super().__init__()
 
-        self.data: numpy.ndarray | None = None
-        self.xaxis: Any = None
-        self.yaxis: Any = None
+        self.data: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.xaxis: Any = None  # type: ignore[explicit-any]
+        self.yaxis: Any = None  # type: ignore[explicit-any]
 
-        self.reph2D: numpy.ndarray | None = None
-        self.nonr2D: numpy.ndarray | None = None
+        self.reph2D: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.nonr2D: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
-    def set_axis_1(self, axis: Any) -> None:
+    def set_axis_1(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Sets the x-axis of te spectrum (omega_1 axis)"""
         self.xaxis = axis
 
-    def set_axis_3(self, axis: Any) -> None:
+    def set_axis_3(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Sets the y-axis of te spectrum (omega_3 axis)"""
         self.yaxis = axis
 
-    def set_data(self, data: numpy.ndarray, dtype: str = "Tot") -> None:
+    def set_data(self, data: numpy.ndarray, dtype: str = "Tot") -> None:  # type: ignore[explicit-any]
         if dtype == "Tot":
             self.data = data
 
@@ -118,7 +118,7 @@ class TwoDSpectrumBase(DFunction2):
         else:
             raise QuantarheiError("Unknow type of data: " + dtype)
 
-    def add_data(self, data: numpy.ndarray, dtype: str = "Tot") -> None:
+    def add_data(self, data: numpy.ndarray, dtype: str = "Tot") -> None:  # type: ignore[explicit-any]
         if dtype == "Tot":
             if self.data is None:
                 self.data = numpy.zeros(data.shape, dtype=data.dtype)
@@ -142,7 +142,7 @@ class TwoDSpectrumBase(DFunction2):
     ) -> None:
         super().save(filename)
 
-    def load(self, filename: str | IO[bytes], test: bool = False) -> Any:
+    def load(self, filename: str | IO[bytes], test: bool = False) -> Any:  # type: ignore[explicit-any]
         super().load(filename)
 
 
@@ -198,13 +198,13 @@ class TwoDSpectrum(TwoDSpectrumBase, Saveable):
         self.reph2D = self.reph2D / val
         self.nonr2D = self.nonr2D / val
 
-    def get_PumpProbeSpectrum(self) -> Any:
+    def get_PumpProbeSpectrum(self) -> Any:  # type: ignore[explicit-any]
         """Returns a PumpProbeSpectrum corresponding to the 2D spectrum"""
         from .pumpprobe import calculate_from_2D
 
         return calculate_from_2D(self)
 
-    def plot(
+    def plot(  # type: ignore[explicit-any]
         self,
         fig: Any = None,
         window: list | None = None,
@@ -460,10 +460,10 @@ class TwoDSpectrum(TwoDSpectrumBase, Saveable):
 
         plt.savefig(filename, dpi=dpi)
 
-    def _create_root_group(self, start: Any, name: str) -> Any:
+    def _create_root_group(self, start: Any, name: str) -> Any:  # type: ignore[explicit-any]
         return start.create_group(name)
 
-    def _save_attributes(self, rt: Any) -> None:
+    def _save_attributes(self, rt: Any) -> None:  # type: ignore[explicit-any]
         rt.attrs.create("t2", self.t2)
         keeps = []
         if self.keep_pathways:
@@ -477,34 +477,34 @@ class TwoDSpectrum(TwoDSpectrumBase, Saveable):
 
         rt.attrs.create("keeps", keeps)
 
-    def _load_attributes(self, rt: Any) -> None:
+    def _load_attributes(self, rt: Any) -> None:  # type: ignore[explicit-any]
         self.t2 = rt.attrs["t2"]
         keeps = rt.attrs["keeps"]
         self.keep_pathways = keeps[0] == 1
         self.keep_stypes = keeps[1] == 1
 
-    def _save_data(self, rt: Any) -> None:
+    def _save_data(self, rt: Any) -> None:  # type: ignore[explicit-any]
         if self.keep_stypes:
             rt.create_dataset("reph2D", data=self.reph2D)
             rt.create_dataset("nonr2D", data=self.nonr2D)
         else:
             rt.create_dataset("data", data=self.data)
 
-    def _load_data(self, rt: Any) -> None:
+    def _load_data(self, rt: Any) -> None:  # type: ignore[explicit-any]
         if self.keep_stypes:
             self.reph2D = numpy.array(rt["reph2D"])
             self.nonr2D = numpy.array(rt["nonr2D"])
         else:
             self.data = numpy.array(rt["data"])
 
-    def _save_axis(self, rt: Any, name: str, ax: Any) -> None:
+    def _save_axis(self, rt: Any, name: str, ax: Any) -> None:  # type: ignore[explicit-any]
         axdir = rt.create_group(name)
         axdir.attrs.create("start", ax.start)
         axdir.attrs.create("length", ax.length)
         axdir.attrs.create("step", ax.step)
         # FIXME: atype and time_start
 
-    def _load_axis(self, rt: Any, name: str) -> FrequencyAxis:
+    def _load_axis(self, rt: Any, name: str) -> FrequencyAxis:  # type: ignore[explicit-any]
         axdir = rt[name]
         start = axdir.attrs["start"]
         length = axdir.attrs["length"]
@@ -562,7 +562,7 @@ class TwoDSpectrumContainer(Saveable):
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, t2axis: Any = None, keep_pathways: bool = False, keep_stypes: bool = True
     ) -> None:
 
@@ -573,7 +573,7 @@ class TwoDSpectrumContainer(Saveable):
         if self.keep_pathways:
             raise QuantarheiError("Container keeping pathways not available yet")
 
-        self.spectra: dict[Any, Any] = {}
+        self.spectra: dict[Any, Any] = {}  # type: ignore[explicit-any]
 
     def set_spectrum(self, spect: TwoDSpectrum) -> None:
         """Stores spectrum for time t2
@@ -613,7 +613,7 @@ class TwoDSpectrumContainer(Saveable):
                 ven2.append(self.spectra[k])
         return ven2
 
-    def get_PumpProbeSpectrumContainer(self, skip: int = 0) -> Any:
+    def get_PumpProbeSpectrumContainer(self, skip: int = 0) -> Any:  # type: ignore[explicit-any]
         """Converts this container into PumpProbeSpectrumContainer"""
         from .pumpprobe import PumpProbeSpectrumContainer
 
@@ -639,7 +639,7 @@ class TwoDSpectrumContainer(Saveable):
 
         return ppcont
 
-    def get_point_evolution(self, x: float, y: float, times: Any) -> numpy.ndarray:
+    def get_point_evolution(self, x: float, y: float, times: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         """Tracks an evolution of a single point on the 2D spectrum"""
         vals = numpy.zeros(times.length)
         k = 0
@@ -650,16 +650,16 @@ class TwoDSpectrumContainer(Saveable):
 
         return vals
 
-    def _create_root_group(self, start: Any, name: str) -> Any:
+    def _create_root_group(self, start: Any, name: str) -> Any:  # type: ignore[explicit-any]
         return start.create_group(name)
 
-    def _save_axis(self, rt: Any, name: str, ax: Any) -> None:
+    def _save_axis(self, rt: Any, name: str, ax: Any) -> None:  # type: ignore[explicit-any]
         axdir = rt.create_group(name)
         axdir.attrs.create("start", ax.start)
         axdir.attrs.create("length", ax.length)
         axdir.attrs.create("step", ax.step)
 
-    def _load_axis(self, rt: Any, name: str) -> TimeAxis:
+    def _load_axis(self, rt: Any, name: str) -> TimeAxis:  # type: ignore[explicit-any]
         axdir = rt[name]
         start = axdir.attrs["start"]
         length = axdir.attrs["length"]
@@ -759,7 +759,7 @@ class TwoDSpectrumContainer(Saveable):
         if iteration == total:
             print()
 
-    def make_movie(
+    def make_movie(  # type: ignore[explicit-any]
         self,
         filename: str,
         window: list | None = None,
@@ -855,7 +855,7 @@ class TwoDSpectrumCalculator:
 
     system = derived_type("system", [Molecule, Aggregate])
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         t1axis: Any,
         t2axis: Any,
@@ -928,16 +928,16 @@ class TwoDSpectrumCalculator:
         # self._have_aceto = False
 
         # after bootstrap information
-        self.sys: Any = None
-        self.lab: Any = None
-        self.t1s: Any = None
-        self.t3s: Any = None
-        self.rmin: Any = None
-        self.rwa: Any = None
-        self.oa1: Any = None
-        self.oa3: Any = None
-        self.Uee: Any = None
-        self.Uc0: Any = None
+        self.sys: Any = None  # type: ignore[explicit-any]
+        self.lab: Any = None  # type: ignore[explicit-any]
+        self.t1s: Any = None  # type: ignore[explicit-any]
+        self.t3s: Any = None  # type: ignore[explicit-any]
+        self.rmin: Any = None  # type: ignore[explicit-any]
+        self.rwa: Any = None  # type: ignore[explicit-any]
+        self.oa1: Any = None  # type: ignore[explicit-any]
+        self.oa3: Any = None  # type: ignore[explicit-any]
+        self.Uee: Any = None  # type: ignore[explicit-any]
+        self.Uc0: Any = None  # type: ignore[explicit-any]
 
         self.tc = 0
 
@@ -946,7 +946,7 @@ class TwoDSpectrumCalculator:
         if self.verbose:
             print(string)
 
-    def bootstrap(
+    def bootstrap(  # type: ignore[explicit-any]
         self, rwa: float = 0.0, lab: Any = None, verbose: bool = False
     ) -> None:
         """Sets up the environment for 2D calculation"""
@@ -1354,7 +1354,7 @@ class MockTwoDSpectrumCalculator(TwoDSpectrumCalculator):
 
     """
 
-    def __init__(self, t1axis: Any, t3axis: Any) -> None:
+    def __init__(self, t1axis: Any, t3axis: Any) -> None:  # type: ignore[explicit-any]
         t2axis = TimeAxis()
         super().__init__(t1axis, t2axis, t3axis)
         self.widthx = convert(300, "1/cm", "int")
@@ -1362,7 +1362,7 @@ class MockTwoDSpectrumCalculator(TwoDSpectrumCalculator):
         self.dephx = convert(300, "1/cm", "int")
         self.dephy = convert(300, "1/cm", "int")
 
-    def bootstrap(
+    def bootstrap(  # type: ignore[explicit-any]
         self,
         rwa: float = 0.0,
         pathways: Any = None,
@@ -1420,7 +1420,7 @@ class MockTwoDSpectrumCalculator(TwoDSpectrumCalculator):
 
         return onetwod
 
-    def calculate_pathway(self, pathway: Any, shape: str = "Gaussian") -> numpy.ndarray:
+    def calculate_pathway(self, pathway: Any, shape: str = "Gaussian") -> numpy.ndarray:  # type: ignore[explicit-any]
         """Calculate the shape of a Liouville pathway"""
         noe = 1 + pathway.order + pathway.relax_order
 
@@ -1457,7 +1457,7 @@ class MockTwoDSpectrumCalculator(TwoDSpectrumCalculator):
         # print(shape, widthx, widthy)
 
         if pathway.pathway_type == "R":
-            reph2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)
+            reph2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)  # type: ignore[explicit-any]
 
             if shape == "Gaussian":
                 oo3 = self.oa3.data[:]
@@ -1487,7 +1487,7 @@ class MockTwoDSpectrumCalculator(TwoDSpectrumCalculator):
             return reph2D
 
         if pathway.pathway_type == "NR":
-            nonr2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)
+            nonr2D: numpy.ndarray = numpy.zeros((N1, N3), dtype=COMPLEX)  # type: ignore[explicit-any]
 
             if shape == "Gaussian":
                 oo3 = self.oa3.data[:]

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -27,7 +27,7 @@ from ..utils import derived_type
 from .twodresponse import TwoDResponse
 
 
-def _apply_response_window(data: numpy.ndarray) -> numpy.ndarray:
+def _apply_response_window(data: numpy.ndarray) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Apply the endpoint half-weight used before Fourier transformation."""
     ret = data.copy()
     ret[:, 0] *= 0.5
@@ -35,7 +35,7 @@ def _apply_response_window(data: numpy.ndarray) -> numpy.ndarray:
     return ret
 
 
-def _fourier_transform_response(data: numpy.ndarray, signal: str) -> numpy.ndarray:
+def _fourier_transform_response(data: numpy.ndarray, signal: str) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Transform a time-domain response contribution to a 2D spectrum."""
     data = _apply_response_window(data)
 
@@ -50,7 +50,7 @@ def _fourier_transform_response(data: numpy.ndarray, signal: str) -> numpy.ndarr
     return numpy.fft.fftshift(ftresp)
 
 
-def _pad_response_data(
+def _pad_response_data(  # type: ignore[explicit-any]
     data: numpy.ndarray, pad: int, window: numpy.ndarray | None = None
 ) -> numpy.ndarray:
     """Pad a response contribution in the same way as the total response."""
@@ -108,7 +108,7 @@ class TwoDResponseCalculator:
     _has_responses = False
     _has_system = False
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         t1axis: Any,
         t2axis: Any,
@@ -218,7 +218,7 @@ class TwoDResponseCalculator:
         self.population_dynamics_mode = population_dynamics_mode
         self.include_nonsecular_remainder = include_nonsecular_remainder
         self.dipole_normalization_tol = dipole_normalization_tol
-        self.response_diagnostics: list[dict[str, Any]] = []
+        self.response_diagnostics: list[dict[str, Any]] = []  # type: ignore[explicit-any]
 
         # FIXME: check the compatibility of the axes
 
@@ -238,13 +238,13 @@ class TwoDResponseCalculator:
         self.dynamics = dynamics
 
         # unprotected properties
-        self.data: numpy.ndarray | None = None
+        self.data: numpy.ndarray | None = None  # type: ignore[explicit-any]
 
-        self.responses: list[Any] = []
+        self.responses: list[Any] = []  # type: ignore[explicit-any]
 
         self._relaxation_tensor = None
         self._rate_matrix = None
-        self._response_rate_matrix: Any = None
+        self._response_rate_matrix: Any = None  # type: ignore[explicit-any]
         self._relaxation_hamiltonian = None
         self._population_time_axis = population_time_axis
         self._has_relaxation_tensor = False
@@ -267,20 +267,20 @@ class TwoDResponseCalculator:
         #
         # after bootstrap information
         #
-        self.sys: Any = None
-        self.lab: Any = None
-        self.t1s: Any = None
-        self.t3s: Any = None
-        self.rmin: Any = None
-        self.rwa: Any = None
-        self.oa1: Any = None
-        self.oa3: Any = None
-        self.Uee: Any = None
-        self.Uc0: Any = None
+        self.sys: Any = None  # type: ignore[explicit-any]
+        self.lab: Any = None  # type: ignore[explicit-any]
+        self.t1s: Any = None  # type: ignore[explicit-any]
+        self.t3s: Any = None  # type: ignore[explicit-any]
+        self.rmin: Any = None  # type: ignore[explicit-any]
+        self.rwa: Any = None  # type: ignore[explicit-any]
+        self.oa1: Any = None  # type: ignore[explicit-any]
+        self.oa3: Any = None  # type: ignore[explicit-any]
+        self.Uee: Any = None  # type: ignore[explicit-any]
+        self.Uc0: Any = None  # type: ignore[explicit-any]
 
         self.tc = 0
 
-    def _detection_weight(self, resp: Any) -> float:
+    def _detection_weight(self, resp: Any) -> float:  # type: ignore[explicit-any]
         """Returns the detection weight for a response contribution."""
         if self.twodtype == "2DES":
             return 1.0
@@ -299,12 +299,12 @@ class TwoDResponseCalculator:
 
         raise Exception("Unknown type of 2D spectrum: " + self.twodtype)
 
-    def _vprint(self, *args: Any, **kwargs: Any) -> None:
+    def _vprint(self, *args: Any, **kwargs: Any) -> None:  # type: ignore[explicit-any]
         """Prints a string if the self.verbose attribute is True"""
         if self.verbose:
             print(*args, **kwargs)
 
-    def bootstrap(
+    def bootstrap(  # type: ignore[explicit-any]
         self,
         rwa: float = 0.0,
         pad: int = 0,
@@ -473,13 +473,13 @@ class TwoDResponseCalculator:
         """Resets the population time of the calculations"""
         self.tc = 0
 
-    def calculate_next(self) -> Any:
+    def calculate_next(self) -> Any:  # type: ignore[explicit-any]
         """Calculate next population time of a 2D spectrum"""
         sone = self.calculate_one(self.tc)
         self.tc += 1
         return sone
 
-    def calculate_one(self, tc: int) -> Any:
+    def calculate_one(self, tc: int) -> Any:  # type: ignore[explicit-any]
         """Calculate one population time"""
         try:
             tt2 = self.t2axis.data[tc]
@@ -532,14 +532,14 @@ class TwoDResponseCalculator:
         resp_Nsewt = numpy.zeros((Nr1, Nr3), dtype=ntype, order=order)
         resp_Resawt = numpy.zeros((Nr1, Nr3), dtype=ntype, order=order)
         resp_Nesawt = numpy.zeros((Nr1, Nr3), dtype=ntype, order=order)
-        response_pieces: list[tuple[Any, numpy.ndarray]] = []
+        response_pieces: list[tuple[Any, numpy.ndarray]] = []  # type: ignore[explicit-any]
 
         if self._has_system and not self._has_responses:
             #
             # Calculating all responses from the system
             #
             self.resp_fcions = []
-            response_kwargs: dict[str, Any] = dict(
+            response_kwargs: dict[str, Any] = dict(  # type: ignore[explicit-any]
                 rate_matrix=self._response_rate_matrix,
                 population_propagator=self.population_propagator,
                 density_matrix_propagator=self.density_matrix_propagator,
@@ -808,7 +808,7 @@ class TwoDResponseCalculator:
                         raise QuantarheiError("Unknown response type")
 
                 elif isinstance(resp, LiouvillePathway):
-                    resp_any: Any = resp
+                    resp_any: Any = resp  # type: ignore[explicit-any]
                     if resp.rtype == "R":
                         data = resp_any.calculate_matrix(
                             self.lab, None, tt2, self.t1s, self.t3s, self.rwa
@@ -949,7 +949,7 @@ class TwoDResponseCalculator:
 
         return onetwod
 
-    def calculate(self) -> Any:
+    def calculate(self) -> Any:  # type: ignore[explicit-any]
         """Returns 2D spectrum
 
         Calculates and returns TwoDResponseContainer containing 2D spectrum
@@ -998,7 +998,7 @@ class TwoDResponseCalculator:
 
         raise ImplementationError("2D calculation in this mode not implemented.")
 
-    def reset_evaluation_functions(self, fcions: list[Any]) -> None:
+    def reset_evaluation_functions(self, fcions: list[Any]) -> None:  # type: ignore[explicit-any]
         """Resets the evaluation functions used by the reseponse functions"""
         if self._has_responses:
             for rsp, fce in zip(self.resp_fcions, fcions):

--- a/quantarhei/spectroscopy/twodcontainer.py
+++ b/quantarhei/spectroscopy/twodcontainer.py
@@ -57,7 +57,7 @@ class TwoDResponseContainer(Saveable):
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, t2axis: Any = None, keep_pathways: bool = False, keep_stypes: bool = True
     ) -> None:
 
@@ -69,18 +69,18 @@ class TwoDResponseContainer(Saveable):
 
         self.itype: str | None = None
         self.index = 0
-        self.tags: list[Any] = []
+        self.tags: list[Any] = []  # type: ignore[explicit-any]
 
         if self.keep_pathways:
             raise QuantarheiError("Container keeping pathways not available yet")
 
-        self.spectra: dict[Any, Any] = {}
+        self.spectra: dict[Any, Any] = {}  # type: ignore[explicit-any]
         self._which: float | None = None
 
         if t2axis is not None:
             self.use_indexing_type(itype=t2axis)
 
-    def use_indexing_type(self, itype: Any) -> None:
+    def use_indexing_type(self, itype: Any) -> None:  # type: ignore[explicit-any]
         """Sets the type of indices used to identify spectra
 
         Parameters
@@ -116,7 +116,7 @@ class TwoDResponseContainer(Saveable):
         else:
             raise QuantarheiError("Unknown indexing type")
 
-    def set_spectrum(self, spect: Any, tag: Any = None) -> Any:
+    def set_spectrum(self, spect: Any, tag: Any = None) -> Any:  # type: ignore[explicit-any]
         """Stores spectrum with a tag (time, index, etc.)
 
         Stores the spectrum according to present indexing scheme
@@ -192,7 +192,7 @@ class TwoDResponseContainer(Saveable):
         self._which = None
         return False
 
-    def get_spectrum_by_index(self, indx: int) -> Any:
+    def get_spectrum_by_index(self, indx: int) -> Any:  # type: ignore[explicit-any]
         """Returns spectrum by integet index
 
         The integer index is assigned to all spectra in the order they were
@@ -209,11 +209,11 @@ class TwoDResponseContainer(Saveable):
 
         return self.spectra[self.tags[indx]]
 
-    def get_response(self, tag: Any) -> Any:
+    def get_response(self, tag: Any) -> Any:  # type: ignore[explicit-any]
         """Same as get_spectrum, but the name more sense for a response container"""
         return self.get_spectrum(tag)
 
-    def get_spectrum(self, tag: Any) -> Any:
+    def get_spectrum(self, tag: Any) -> Any:  # type: ignore[explicit-any]
         """Returns spectrum corresponing to time t2
 
         Checks if the time t2 is present in the t2axis
@@ -248,13 +248,13 @@ class TwoDResponseContainer(Saveable):
         else:
             raise QuantarheiError("Unknown type of indexing")
 
-    def set_data_flag(self, flag: Any) -> None:
+    def set_data_flag(self, flag: Any) -> None:  # type: ignore[explicit-any]
         """Sets data flag for all spectra in the container"""
         for tag in self.spectra:
             sp = self.spectra[tag]
             sp.set_data_flag(flag)
 
-    def get_TwoDSpectrumContainer(self, stype: Any = signal_TOTL) -> Any:
+    def get_TwoDSpectrumContainer(self, stype: Any = signal_TOTL) -> Any:  # type: ignore[explicit-any]
         """Returns a container with specific spectra"""
         if self.itype in ["ValueAxis", "TimeAxis", "FrequencyAxis"]:
             axis = self.axis.deepcopy()
@@ -270,14 +270,14 @@ class TwoDResponseContainer(Saveable):
 
         raise QuantarheiError("")
 
-    def get_nearest(self, val: float) -> Any:
+    def get_nearest(self, val: float) -> Any:  # type: ignore[explicit-any]
 
         if self.itype == "FrequencyAxis":
             # print(Manager().current_units["frequency"])
             # print(Manager().current_units["energy"])
             nval = Manager().convert_energy_2_internal_u(val)
             # get tags and convert them to numbers
-            ntags: numpy.ndarray = numpy.zeros(len(self.tags), dtype=REAL)
+            ntags: numpy.ndarray = numpy.zeros(len(self.tags), dtype=REAL)  # type: ignore[explicit-any]
             k = 0
             for stag in self.tags:
                 # print(stag)
@@ -294,7 +294,7 @@ class TwoDResponseContainer(Saveable):
         """Returns the length of the container"""
         return len(self.spectra.keys())
 
-    def get_spectra(self, start: Any = None, end: Any = None) -> list[Any]:
+    def get_spectra(self, start: Any = None, end: Any = None) -> list[Any]:  # type: ignore[explicit-any]
         """Returns a list of the calculated spectra
 
         Returns all spectra or an interval of spectra when `start` and `end`
@@ -320,7 +320,7 @@ class TwoDResponseContainer(Saveable):
                 ven2.append(self.spectra[k])
         return ven2
 
-    def get_PumpProbeSpectrumContainer(self, skip: int = 0) -> Any:
+    def get_PumpProbeSpectrumContainer(self, skip: int = 0) -> Any:  # type: ignore[explicit-any]
         """Converts this response container into PumpProbeSpectrumContainer.
 
         Each stored :class:`TwoDResponse` already contains enough spectral
@@ -367,7 +367,7 @@ class TwoDResponseContainer(Saveable):
 
         return ppcont
 
-    def get_integrated_area_evolution(
+    def get_integrated_area_evolution(  # type: ignore[explicit-any]
         self, times: Any, area: Any, dpart: Any = part_REAL
     ) -> Any:
         """Returns the integrated area of the 2D spectra as a function of their index"""
@@ -385,7 +385,7 @@ class TwoDResponseContainer(Saveable):
 
         return DFunction(times, vals)
 
-    def get_point_evolution(self, x: float, y: float, times: Any) -> Any:
+    def get_point_evolution(self, x: float, y: float, times: Any) -> Any:  # type: ignore[explicit-any]
         """Tracks an evolution of a single point on the 2D spectrum
 
 
@@ -415,7 +415,7 @@ class TwoDResponseContainer(Saveable):
 
         return DFunction(times, vals)
 
-    def global_fit_exponential(self, guess: Any = None) -> Any:
+    def global_fit_exponential(self, guess: Any = None) -> Any:  # type: ignore[explicit-any]
         """Global fit of the data with exponentials"""
         from functools import partial
 
@@ -431,7 +431,7 @@ class TwoDResponseContainer(Saveable):
 
         return params
 
-    def fft(
+    def fft(  # type: ignore[explicit-any]
         self,
         ffttype: str = "complex-positive",
         window: Any = None,
@@ -554,7 +554,7 @@ class TwoDResponseContainer(Saveable):
         #
 
         # window function
-        ftdata: numpy.ndarray = numpy.zeros(data.shape, dtype=data.dtype)
+        ftdata: numpy.ndarray = numpy.zeros(data.shape, dtype=data.dtype)  # type: ignore[explicit-any]
         Nwin = len(winfce.data)
         Ndat = data.shape[2]
         for i_n in range(data.shape[0]):
@@ -582,23 +582,23 @@ class TwoDResponseContainer(Saveable):
 
         return new_container
 
-    def _create_root_group(self, start: Any, name: str) -> Any:
+    def _create_root_group(self, start: Any, name: str) -> Any:  # type: ignore[explicit-any]
         return start.create_group(name)
 
-    def _save_axis(self, rt: Any, name: str, ax: Any) -> None:
+    def _save_axis(self, rt: Any, name: str, ax: Any) -> None:  # type: ignore[explicit-any]
         axdir = rt.create_group(name)
         axdir.attrs.create("start", ax.start)
         axdir.attrs.create("length", ax.length)
         axdir.attrs.create("step", ax.step)
 
-    def _load_axis(self, rt: Any, name: str) -> Any:
+    def _load_axis(self, rt: Any, name: str) -> Any:  # type: ignore[explicit-any]
         axdir = rt[name]
         start = axdir.attrs["start"]
         length = axdir.attrs["length"]
         step = axdir.attrs["step"]
         return TimeAxis(start, length, step)
 
-    def trimall_to(self, window: Any = None) -> None:
+    def trimall_to(self, window: Any = None) -> None:  # type: ignore[explicit-any]
         """Trims all spectra in the container
 
         Parameters
@@ -614,7 +614,7 @@ class TwoDResponseContainer(Saveable):
                 s.trim_to(window=axes)
 
     # FIXME: this is still legacy version
-    def amax(self, spart: Any = part_REAL) -> Any:
+    def amax(self, spart: Any = part_REAL) -> Any:  # type: ignore[explicit-any]
         """Returns maximum amplitude of the spectra in the container"""
         mxs = []
         for s in self.get_spectra():
@@ -666,7 +666,7 @@ class TwoDResponseContainer(Saveable):
         if iteration == total:
             print()
 
-    def make_movie(
+    def make_movie(  # type: ignore[explicit-any]
         self,
         filename: str,
         window: Any = None,
@@ -785,7 +785,7 @@ class TwoDResponseContainer(Saveable):
 #                    return
 
 
-def _exp_2D_data0(params: Any, times: Any = None, cont: Any = None) -> numpy.ndarray:
+def _exp_2D_data0(params: Any, times: Any = None, cont: Any = None) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Returns a residue between time dependent matrix data and a matrix
     multipled by a sum of exponentials
 
@@ -827,7 +827,7 @@ def _exp_2D_data0(params: Any, times: Any = None, cont: Any = None) -> numpy.nda
 
 
 class TwoDSpectrumContainer(TwoDResponseContainer):
-    def __init__(self, t2axis: Any = None, dtype: Any = signal_TOTL) -> None:
+    def __init__(self, t2axis: Any = None, dtype: Any = signal_TOTL) -> None:  # type: ignore[explicit-any]
 
         self.t2axis = t2axis
 
@@ -835,28 +835,28 @@ class TwoDSpectrumContainer(TwoDResponseContainer):
 
         self.itype: str | None = None
         self.index = 0
-        self.tags: list[Any] = []
+        self.tags: list[Any] = []  # type: ignore[explicit-any]
         self.dtype = dtype
 
-        self.spectra: dict[Any, Any] = {}
+        self.spectra: dict[Any, Any] = {}  # type: ignore[explicit-any]
         self._which: float | None = None
 
         if t2axis is not None:
             self.use_indexing_type(itype=t2axis)
 
-    def set_data_flag(self, flag: Any) -> None:
+    def set_data_flag(self, flag: Any) -> None:  # type: ignore[explicit-any]
         """Sets data flag for all spectra in the container"""
         if flag != self.dtype:
             raise QuantarheiError("Cannot change spectra type")
 
-    def get_TwoDSpectrumContainer(self, stype: Any = signal_TOTL) -> Any:
+    def get_TwoDSpectrumContainer(self, stype: Any = signal_TOTL) -> Any:  # type: ignore[explicit-any]
         """Returns a container with specific spectra"""
         if stype == self.dtype:
             return self
         raise QuantarheiError("Cannot change spectra type in this container")
 
     # FIXME: This needs to be reimplemented
-    def get_PumpProbeSpectrumContainer(self, skip: int = 0) -> Any:
+    def get_PumpProbeSpectrumContainer(self, skip: int = 0) -> Any:  # type: ignore[explicit-any]
         """Converts this container into PumpProbeSpectrumContainer"""
         if self.dtype == signal_TOTL:
             from .pumpprobe import PumpProbeSpectrumContainer
@@ -902,7 +902,7 @@ class TwoDSpectrumContainer(TwoDResponseContainer):
             "Cannot calculate Pump-probe from 2D spectra of type" + self.dtype
         )
 
-    def normalize2(
+    def normalize2(  # type: ignore[explicit-any]
         self, norm: float = 1.0, each: bool = False, dpart: Any = part_REAL
     ) -> Any:
         """Normalize the whole container of spectra
@@ -928,7 +928,7 @@ class TwoDSpectrumContainer(TwoDResponseContainer):
 
         """
         nsp = len(self.spectra)
-        mxs: numpy.ndarray = numpy.zeros(nsp, dtype=REAL)
+        mxs: numpy.ndarray = numpy.zeros(nsp, dtype=REAL)  # type: ignore[explicit-any]
         ii = 0
         for tag in self.spectra.keys():
             sp = self.get_spectrum(tag)
@@ -946,7 +946,7 @@ class TwoDSpectrumContainer(TwoDResponseContainer):
 
         return nmax
 
-    def fft(
+    def fft(  # type: ignore[explicit-any]
         self,
         ffttype: str = "complex-positive",
         window: Any = None,
@@ -1071,7 +1071,7 @@ class TwoDSpectrumContainer(TwoDResponseContainer):
         #
 
         # window function
-        ftdata: numpy.ndarray = numpy.zeros(data.shape, dtype=data.dtype)
+        ftdata: numpy.ndarray = numpy.zeros(data.shape, dtype=data.dtype)  # type: ignore[explicit-any]
         Nwin = len(winfce.data)
         Ndat = data.shape[2]
         for i_n in range(data.shape[0]):
@@ -1099,7 +1099,7 @@ class TwoDSpectrumContainer(TwoDResponseContainer):
 
         return new_container
 
-    def unitedir(self, dname: str) -> Any:
+    def unitedir(self, dname: str) -> Any:  # type: ignore[explicit-any]
 
         clist = self.loaddir(dname)
 

--- a/quantarhei/spectroscopy/twodresponse.py
+++ b/quantarhei/spectroscopy/twodresponse.py
@@ -159,7 +159,7 @@ def _resolution2number(res: str) -> int:
     raise QuantarheiError("Unknow resolution level in TwoDSpectrum")
 
 
-def _get_type_and_tag(obj: Any, storage: dict) -> dict:
+def _get_type_and_tag(obj: Any, storage: dict) -> dict:  # type: ignore[explicit-any]
 
     if obj.current_dtype not in _ptypes:
         # check the current_type attribute
@@ -180,7 +180,7 @@ def _get_type_and_tag(obj: Any, storage: dict) -> dict:
     return piece
 
 
-def _pathways_to_processes(obj: Any, process: str) -> numpy.ndarray | None:
+def _pathways_to_processes(obj: Any, process: str) -> numpy.ndarray | None:  # type: ignore[explicit-any]
 
     if obj.storage_initialized:
         data = numpy.zeros((obj.xaxis.length, obj.yaxis.length), dtype=COMPLEX)
@@ -206,7 +206,7 @@ def _pathways_to_processes(obj: Any, process: str) -> numpy.ndarray | None:
     return data
 
 
-def _pathways_to_signals(obj: Any, signal: str) -> numpy.ndarray | None:
+def _pathways_to_signals(obj: Any, signal: str) -> numpy.ndarray | None:  # type: ignore[explicit-any]
 
     if obj.storage_initialized:
         data = numpy.zeros((obj.xaxis.length, obj.yaxis.length), dtype=COMPLEX)
@@ -232,7 +232,7 @@ def _pathways_to_signals(obj: Any, signal: str) -> numpy.ndarray | None:
     return data
 
 
-def _pathways_to_total(obj: Any) -> numpy.ndarray | None:
+def _pathways_to_total(obj: Any) -> numpy.ndarray | None:  # type: ignore[explicit-any]
 
     if obj.storage_initialized:
         data = numpy.zeros((obj.xaxis.length, obj.yaxis.length), dtype=COMPLEX)
@@ -245,7 +245,7 @@ def _pathways_to_total(obj: Any) -> numpy.ndarray | None:
     return data
 
 
-def _types_to_processes(obj: Any, process: str) -> numpy.ndarray | None:
+def _types_to_processes(obj: Any, process: str) -> numpy.ndarray | None:  # type: ignore[explicit-any]
     """Sums pathways of different types into a specified process spectrum"""
     if obj.storage_initialized:
         data = numpy.zeros((obj.xaxis.length, obj.yaxis.length), dtype=COMPLEX)
@@ -272,7 +272,7 @@ def _types_to_processes(obj: Any, process: str) -> numpy.ndarray | None:
     return data
 
 
-def _types_to_signals(obj: Any, signal: str) -> numpy.ndarray | None:
+def _types_to_signals(obj: Any, signal: str) -> numpy.ndarray | None:  # type: ignore[explicit-any]
     """Sums pathways of different types into a specified signal spectrum"""
     if obj.storage_initialized:
         data = numpy.zeros((obj.xaxis.length, obj.yaxis.length), dtype=COMPLEX)
@@ -300,7 +300,7 @@ def _types_to_signals(obj: Any, signal: str) -> numpy.ndarray | None:
     return data
 
 
-def _signals_to_total(obj: Any) -> numpy.ndarray | None:
+def _signals_to_total(obj: Any) -> numpy.ndarray | None:  # type: ignore[explicit-any]
     """Sums spectra corresponding to different signals into the total spectrum"""
     if obj.storage_initialized:
         data = numpy.zeros((obj.xaxis.length, obj.yaxis.length), dtype=COMPLEX)
@@ -318,7 +318,7 @@ def _signals_to_total(obj: Any) -> numpy.ndarray | None:
     return data
 
 
-def _processes_to_total(obj: Any) -> numpy.ndarray | None:
+def _processes_to_total(obj: Any) -> numpy.ndarray | None:  # type: ignore[explicit-any]
     """Sums spectra corresponding to different processes into the total spectrum"""
     if obj.storage_initialized:
         data = numpy.zeros((obj.xaxis.length, obj.yaxis.length), dtype=COMPLEX)
@@ -336,7 +336,7 @@ def _processes_to_total(obj: Any) -> numpy.ndarray | None:
     return data
 
 
-def _types_to_total(obj: Any) -> numpy.ndarray | None:
+def _types_to_total(obj: Any) -> numpy.ndarray | None:  # type: ignore[explicit-any]
     """Sums all pathways into the total spectrum"""
     if obj.storage_initialized:
         data = numpy.zeros((obj.xaxis.length, obj.yaxis.length), dtype=COMPLEX)
@@ -351,7 +351,7 @@ def _types_to_total(obj: Any) -> numpy.ndarray | None:
     return data
 
 
-def twodspectrum_dictionary(name: str, dtype: Any) -> Any:
+def twodspectrum_dictionary(name: str, dtype: Any) -> Any:  # type: ignore[explicit-any]
     """Defines operations of setting and retrieving (getting) data
 
     Operations on the storage of two-dimensional spectral data
@@ -360,7 +360,7 @@ def twodspectrum_dictionary(name: str, dtype: Any) -> Any:
     """
     storage_name = "_" + name
 
-    def prop_getter(self: Any) -> Any:
+    def prop_getter(self: Any) -> Any:  # type: ignore[explicit-any]
 
         storage = getattr(self, storage_name)
 
@@ -531,7 +531,7 @@ def twodspectrum_dictionary(name: str, dtype: Any) -> Any:
         else:
             raise ImplementationError("not implemented")
 
-    def prop_setter(self: Any, value: Any) -> None:
+    def prop_setter(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
 
         ini = self.storage_initialized
         if not ini:
@@ -618,14 +618,14 @@ def twodspectrum_dictionary(name: str, dtype: Any) -> Any:
 TwoDSpectrumDataArray = partial(twodspectrum_dictionary, dtype=numbers.Complex)
 
 
-def twod_data_wrapper(dtype: Any) -> Any:
+def twod_data_wrapper(dtype: Any) -> Any:  # type: ignore[explicit-any]
     """Handles access to the d__data property of TwoDSpectrum"""
     storage_name = "d__data"
 
-    def prop_getter(self: Any) -> Any:
+    def prop_getter(self: Any) -> Any:  # type: ignore[explicit-any]
         return getattr(self, storage_name)
 
-    def prop_setter(self: Any, value: Any) -> None:
+    def prop_setter(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         if self._allow_data_writing:
             try:
                 vl = check_numpy_array(value)
@@ -663,7 +663,7 @@ class TwoDResponseBase(DataSaveable):
     #
     d__data = TwoDSpectrumDataArray("d__data")
     data = DataWrapper()
-    _d__data: Any
+    _d__data: Any  # type: ignore[explicit-any]
 
     _allow_data_writing = False
 
@@ -676,8 +676,8 @@ class TwoDResponseBase(DataSaveable):
         #
         # The followinh attributes will be removed
         ##########################################
-        self.reph2D: numpy.ndarray | None = None
-        self.nonr2D: numpy.ndarray | None = None
+        self.reph2D: numpy.ndarray | None = None  # type: ignore[explicit-any]
+        self.nonr2D: numpy.ndarray | None = None  # type: ignore[explicit-any]
         # self.data = None
 
         self.dtype: str | None = None
@@ -703,11 +703,11 @@ class TwoDResponseBase(DataSaveable):
         """Sets back the protection of the data property"""
         self._allow_data_writing = False
 
-    def set_axis_1(self, axis: Any) -> None:
+    def set_axis_1(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Sets the x-axis of te spectrum (omega_1 axis)"""
         self.xaxis = axis
 
-    def set_axis_3(self, axis: Any) -> None:
+    def set_axis_3(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Sets the y-axis of te spectrum (omega_3 axis)"""
         self.yaxis = axis
 
@@ -729,7 +729,7 @@ class TwoDResponseBase(DataSaveable):
             raise QuantarheiError("Unknown data type for TwoDSpectrum object")
 
     # FIXME: to be replaced
-    def set_data(
+    def set_data(  # type: ignore[explicit-any]
         self, data: numpy.ndarray, dtype: str = signal_TOTL
     ) -> None:  # "Tot"):
         """Sets the data of the 2D spectrum
@@ -770,7 +770,7 @@ class TwoDResponseBase(DataSaveable):
             raise QuantarheiError("Unknow type of data: " + dtype)
 
     # FIMXE: to be relaced
-    def add_data(
+    def add_data(  # type: ignore[explicit-any]
         self, data: numpy.ndarray, dtype: str = signal_TOTL
     ) -> None:  # "Tot"):
 
@@ -1036,7 +1036,7 @@ class TwoDResponseBase(DataSaveable):
             )
 
     # FIXME: this will become the main add_data method
-    def _add_data(
+    def _add_data(  # type: ignore[explicit-any]
         self,
         data: numpy.ndarray,
         resolution: str | None = None,
@@ -1213,7 +1213,7 @@ class TwoDResponseBase(DataSaveable):
                 )
 
     # FIXME: implement
-    def _set_data(
+    def _set_data(  # type: ignore[explicit-any]
         self, data: numpy.ndarray, dtype: str = _total, tag: str | None = None
     ) -> None:
         """Sets the 2D spectrum data
@@ -1251,7 +1251,7 @@ class TwoDResponseBase(DataSaveable):
         data_dict = {}
         if self.storage_resolution == "pathways":
             for typ in _ptypes:
-                piece: Any
+                piece: Any  # type: ignore[explicit-any]
                 try:
                     piece = self._d__data[typ]
                 except KeyError:
@@ -1345,7 +1345,7 @@ class TwoDResponse(TwoDSpectrumBase, Saveable):
         """Returns the t2 (waiting time) of the spectrum"""
         return self.t2
 
-    def get_value_at(self, x: float, y: float) -> Any:
+    def get_value_at(self, x: float, y: float) -> Any:  # type: ignore[explicit-any]
         """Returns value of the spectrum at a given coordinate"""
         legacy = False
 
@@ -1372,10 +1372,10 @@ class TwoDResponse(TwoDSpectrumBase, Saveable):
             # FIXME: try linear interpolation
             return self.d__data[iy, ix]
 
-    def get_area_integral(self, area: Any, dpart: str = part_REAL) -> Any:
+    def get_area_integral(self, area: Any, dpart: str = part_REAL) -> Any:  # type: ignore[explicit-any]
         """Returns an integral of a given area in the 2D spectrum"""
 
-        def integral_square(
+        def integral_square(  # type: ignore[explicit-any]
             x1: float,
             x2: float,
             y1: float,
@@ -1504,7 +1504,7 @@ class TwoDResponse(TwoDSpectrumBase, Saveable):
 
         return fce
 
-    def get_anti_diagonal_cut(self, point: Any) -> None:
+    def get_anti_diagonal_cut(self, point: Any) -> None:  # type: ignore[explicit-any]
 
         pass
 
@@ -1548,7 +1548,7 @@ class TwoDResponse(TwoDSpectrumBase, Saveable):
                 data = data_dict[data_key]
                 data[:, :] = data / val
 
-    def get_PumpProbeSpectrum(self) -> Any:
+    def get_PumpProbeSpectrum(self) -> Any:  # type: ignore[explicit-any]
         """Returns a PumpProbeSpectrum corresponding to the 2D spectrum"""
         # from .pumpprobe import PumpProbeSpectrumCalculator
         from . import pumpprobe as pp
@@ -1575,7 +1575,7 @@ class TwoDResponse(TwoDSpectrumBase, Saveable):
 
         return twod
 
-    def plot(
+    def plot(  # type: ignore[explicit-any]
         self,
         fig: Any = None,
         window: list | None = None,
@@ -1920,8 +1920,8 @@ class TwoDResponse(TwoDSpectrumBase, Saveable):
             # reconstruct xaxis
             assert self.xaxis is not None
             assert self.yaxis is not None
-            xaxis_fa: Any = self.xaxis
-            yaxis_fa: Any = self.yaxis
+            xaxis_fa: Any = self.xaxis  # type: ignore[explicit-any]
+            yaxis_fa: Any = self.yaxis  # type: ignore[explicit-any]
             start_1 = self.xaxis.data[i1_min]
             length_1 = i1_max - i1_min
             step_1 = self.xaxis.step

--- a/quantarhei/spectroscopy/twodspect.py
+++ b/quantarhei/spectroscopy/twodspect.py
@@ -57,18 +57,18 @@ class TwoDSpectrum(DataSaveable, Saveable):
 
         self.xaxis: ValueAxis | None = None
         self.yaxis: ValueAxis | None = None
-        self.data: numpy.ndarray | None = None
+        self.data: numpy.ndarray | None = None  # type: ignore[explicit-any]
         self.dtype: str | None = None
 
         self.t2 = -1.0
 
-        self.params: Any = None
+        self.params: Any = None  # type: ignore[explicit-any]
 
-    def set_axis_1(self, axis: Any) -> None:
+    def set_axis_1(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Sets the x-axis of te spectrum (omega_1 axis)"""
         self.xaxis = axis
 
-    def set_axis_3(self, axis: Any) -> None:
+    def set_axis_3(self, axis: Any) -> None:  # type: ignore[explicit-any]
         """Sets the y-axis of te spectrum (omega_3 axis)"""
         self.yaxis = axis
 
@@ -91,11 +91,11 @@ class TwoDSpectrum(DataSaveable, Saveable):
         else:
             raise QuantarheiError("Unknown data type for TwoDSpectrum object")
 
-    def get_spectrum_type(self) -> Any:
+    def get_spectrum_type(self) -> Any:  # type: ignore[explicit-any]
 
         return self.dtype
 
-    def set_data(
+    def set_data(  # type: ignore[explicit-any]
         self, data: numpy.ndarray, dtype: str = signal_TOTL
     ) -> None:  # "Tot"):
         """Set the data of the 2D spectrum.
@@ -138,13 +138,13 @@ class TwoDSpectrum(DataSaveable, Saveable):
                 + str(data.shape)
             )
 
-    def add_data(self, data: numpy.ndarray) -> None:
+    def add_data(self, data: numpy.ndarray) -> None:  # type: ignore[explicit-any]
         """Sets the data of the 2D spectrum"""
         if self.data is None:
             raise QuantarheiError("Data is not initialized: use set_data method.")
         self.data += data
 
-    def overlay_pulses(self, lab: Any) -> None:
+    def overlay_pulses(self, lab: Any) -> None:  # type: ignore[explicit-any]
         """Use labsetup class to overlay pulse spectra over this 2D spectrum"""
         assert self.xaxis is not None
         assert self.yaxis is not None
@@ -175,7 +175,7 @@ class TwoDSpectrum(DataSaveable, Saveable):
         """Returns the t2 (waiting time) of the spectrum"""
         return self.t2
 
-    def log_params(self, params: Any = None) -> None:
+    def log_params(self, params: Any = None) -> None:  # type: ignore[explicit-any]
         """Store custom information about the spectrum
 
 
@@ -185,10 +185,10 @@ class TwoDSpectrum(DataSaveable, Saveable):
         """
         self.params = params
 
-    def get_log_params(self) -> Any:
+    def get_log_params(self) -> Any:  # type: ignore[explicit-any]
         return self.params
 
-    def get_value_at(self, x: float, y: float) -> Any:
+    def get_value_at(self, x: float, y: float) -> Any:  # type: ignore[explicit-any]
         """Returns value of the spectrum at a given coordinate"""
         if self.dtype is None:
             raise QuantarheiError("Data type not set")
@@ -299,7 +299,7 @@ class TwoDSpectrum(DataSaveable, Saveable):
 
         return fce
 
-    def get_anti_diagonal_cut(self, point: Any) -> None:
+    def get_anti_diagonal_cut(self, point: Any) -> None:  # type: ignore[explicit-any]
 
         pass
 
@@ -325,13 +325,13 @@ class TwoDSpectrum(DataSaveable, Saveable):
             return numpy.amin(numpy.abs(self.data))
         raise QuantarheiError("Unknown data part")
 
-    def get_area_integral(self, area: Any, dpart: str = part_REAL) -> Any:
+    def get_area_integral(self, area: Any, dpart: str = part_REAL) -> Any:  # type: ignore[explicit-any]
         """Returns an integral of a given area in the 2D spectrum"""
         assert self.xaxis is not None
         assert self.yaxis is not None
         assert self.data is not None
 
-        def integral_square(
+        def integral_square(  # type: ignore[explicit-any]
             x1: float,
             x2: float,
             y1: float,
@@ -373,7 +373,7 @@ class TwoDSpectrum(DataSaveable, Saveable):
             return int_fce(x1, x2, y1, y2, numpy.abs(data), dx, dy)
         raise QuantarheiError("Unknown data part")
 
-    def get_area_max(
+    def get_area_max(  # type: ignore[explicit-any]
         self, area: Any, dpart: str = part_REAL, loc: list | None = None
     ) -> Any:
         """Returns a max value in a given area in the 2D spectrum"""
@@ -381,7 +381,7 @@ class TwoDSpectrum(DataSaveable, Saveable):
         assert self.yaxis is not None
         assert self.data is not None
 
-        def find_in_square(
+        def find_in_square(  # type: ignore[explicit-any]
             x1: float,
             x2: float,
             y1: float,
@@ -392,7 +392,7 @@ class TwoDSpectrum(DataSaveable, Saveable):
         ) -> float:
             return numpy.amax(data)
 
-        def loc_in_square(
+        def loc_in_square(  # type: ignore[explicit-any]
             x1: float,
             x2: float,
             y1: float,
@@ -618,7 +618,7 @@ class TwoDSpectrum(DataSaveable, Saveable):
         self.data[:, :] = ndata[:, :]
 
     # FIXME: implement this
-    def get_PumpProbeSpectrum(self) -> Any:
+    def get_PumpProbeSpectrum(self) -> Any:  # type: ignore[explicit-any]
         """Returns a PumpProbeSpectrum corresponding to the 2D spectrum"""
         # from .pumpprobe import PumpProbeSpectrumCalculator
         from . import pumpprobe as pp
@@ -629,7 +629,7 @@ class TwoDSpectrum(DataSaveable, Saveable):
         # return ppc.calculate_from_2D(self)
         return pp.calculate_from_2D(self)
 
-    def plot(
+    def plot(  # type: ignore[explicit-any]
         self,
         fig: Any = None,
         window: list | None = None,
@@ -980,8 +980,8 @@ class TwoDSpectrum(DataSaveable, Saveable):
         if window is not None:
             assert self.xaxis is not None
             assert self.yaxis is not None
-            xaxis_fa: Any = self.xaxis
-            yaxis_fa: Any = self.yaxis
+            xaxis_fa: Any = self.xaxis  # type: ignore[explicit-any]
+            yaxis_fa: Any = self.yaxis  # type: ignore[explicit-any]
             axis = window
             w1_min = axis[0]
             w1_max = axis[1]

--- a/quantarhei/symbolic/cumulant.py
+++ b/quantarhei/symbolic/cumulant.py
@@ -34,7 +34,7 @@ if not _SYMPY_AVAILABLE:
     # Stub base classes so the module loads without sympy.
     # Instantiating any of these will raise ImportError via _require_sympy().
     class _SympyStub:  # type: ignore[no-redef]
-        def __init_subclass__(cls, **kwargs: Any) -> None:
+        def __init_subclass__(cls, **kwargs: Any) -> None:  # type: ignore[explicit-any]
             pass
 
     QExpr = _SympyStub  # type: ignore[assignment,misc]
@@ -51,13 +51,13 @@ if not _SYMPY_AVAILABLE:
 
 
 class CumulantExpr(QExpr):
-    def _eval_simplify(
+    def _eval_simplify(  # type: ignore[explicit-any]
         self, ratio: Any, measure: Any, rational: Any, inverse: Any, doit: Any
     ) -> Any:
         return self._evaluate_second_order_rules()
         # return A._getExpr()
 
-    def getOrder(self, n: int) -> Any:
+    def getOrder(self, n: int) -> Any:  # type: ignore[explicit-any]
         if n == self._calculate_order(self):
             return self
         add = self.args[0]
@@ -68,7 +68,7 @@ class CumulantExpr(QExpr):
 
         return CumulantExpr(A)
 
-    def evaluate(self, large: bool = False) -> Any:
+    def evaluate(self, large: bool = False) -> Any:  # type: ignore[explicit-any]
         expr = self.expand()
         expr = expr.getOrder(2)
         # print(expr)
@@ -86,7 +86,7 @@ class CumulantExpr(QExpr):
     ***************************************************************************
     """
 
-    def _evaluate_second_order_rules(self) -> Any:
+    def _evaluate_second_order_rules(self) -> Any:  # type: ignore[explicit-any]
         """Evaluates second order terms in terms of the line shape function"""
         a = Wild("a")
         b = Wild("b")
@@ -169,7 +169,7 @@ class CumulantExpr(QExpr):
 
         return A
 
-    def _make_positive(self, arg: Any) -> Any:
+    def _make_positive(self, arg: Any) -> Any:  # type: ignore[explicit-any]
         a = Wild("a")
         b = Wild("b")
         w = Wild("w")
@@ -182,7 +182,7 @@ class CumulantExpr(QExpr):
         A = A.replace(w * g2(a, b, -arg), w * conjugate(g2(b, a, arg)))
         return A
 
-    def _expand_in_large(self, arg: Any) -> Any:
+    def _expand_in_large(self, arg: Any) -> Any:  # type: ignore[explicit-any]
         a = Wild("a")
         b = Wild("b")
         w = Wild("w")
@@ -195,7 +195,7 @@ class CumulantExpr(QExpr):
         A = A.replace(w * g2(a, b, arg + t1), 0)
         return A
 
-    def _leading_index(self, arg: Any) -> Any:
+    def _leading_index(self, arg: Any) -> Any:  # type: ignore[explicit-any]
         a = Wild("a")
         w = Wild("w")
         t1 = Wild("t1")
@@ -206,13 +206,13 @@ class CumulantExpr(QExpr):
         A = A.replace(w * lam(a, arg), w * lam(arg, a))
         return A
 
-    def _eliminate_off_diagonal(self) -> Any:
+    def _eliminate_off_diagonal(self) -> Any:  # type: ignore[explicit-any]
         return self
 
-    def _getExpr(self) -> Any:
+    def _getExpr(self) -> Any:  # type: ignore[explicit-any]
         return self.args[0]
 
-    def _calculate_order(self, expr: Any) -> int:
+    def _calculate_order(self, expr: Any) -> int:  # type: ignore[explicit-any]
         """Calculates a perturbation order of the expression expr"""
         content = expr
         order = 0
@@ -243,35 +243,35 @@ class CumulantExpr(QExpr):
 class Ugde(Operator):
     nargs = 2
 
-    def _eval_rewrite_as_gg(self, a: Any, t: Any) -> Any:
+    def _eval_rewrite_as_gg(self, a: Any, t: Any) -> Any:  # type: ignore[explicit-any]
         return 1 - I * hh_plus(a, t) - gg_plus(a, a, t)
 
 
 class Uedg(Operator):
     nargs = 2
 
-    def _eval_rewrite_as_gg(self, a: Any, t: Any) -> Any:
+    def _eval_rewrite_as_gg(self, a: Any, t: Any) -> Any:  # type: ignore[explicit-any]
         return 1 + I * hh_plus(a, t) - Dagger(gg_plus(a, a, t))
 
 
 class Uged(Operator):
     nargs = 2
 
-    def _eval_rewrite_as_gg(self, a: Any, t: Any) -> Any:
+    def _eval_rewrite_as_gg(self, a: Any, t: Any) -> Any:  # type: ignore[explicit-any]
         return 1 + I * hh_minus(a, t) - gg_minus(a, a, t)
 
 
 class Uegd(Operator):
     nargs = 2
 
-    def _eval_rewrite_as_gg(self, a: Any, t: Any) -> Any:
+    def _eval_rewrite_as_gg(self, a: Any, t: Any) -> Any:  # type: ignore[explicit-any]
         return 1 - I * hh_minus(a, t) - Dagger(gg_minus(a, a, t))
 
 
 class ExpdV(Operator):
     nargs = 3
 
-    def _eval_rewrite_as_gg(self, a: Any, t: Any, x: Any) -> Any:
+    def _eval_rewrite_as_gg(self, a: Any, t: Any, x: Any) -> Any:  # type: ignore[explicit-any]
         return 1 + x * dV(a, t) + x**2 * dV(a, t) * dV(a, t)
 
 
@@ -311,7 +311,7 @@ class gg(Function):
     nargs = (1, 2, 3)
 
     @classmethod
-    def eval(cls, a: Any, b: Any, x: Any) -> Any:
+    def eval(cls, a: Any, b: Any, x: Any) -> Any:  # type: ignore[explicit-any]
         if x.is_Number:
             if x is S.Zero:
                 return S.Zero
@@ -326,7 +326,7 @@ class g21(Function):
     nargs = (1, 2, 3)
 
     @classmethod
-    def eval(cls, a: Any, b: Any, x: Any) -> Any:
+    def eval(cls, a: Any, b: Any, x: Any) -> Any:  # type: ignore[explicit-any]
         if x.is_Number:
             if x is S.Zero:
                 return S.Zero
@@ -339,7 +339,7 @@ class g1(Function):
     nargs = (1, 2, 3)
 
     @classmethod
-    def eval(cls, a: Any, b: Any, x: Any) -> Any:
+    def eval(cls, a: Any, b: Any, x: Any) -> Any:  # type: ignore[explicit-any]
         if x.is_Number:
             if x is S.Zero:
                 return S.Zero
@@ -375,7 +375,7 @@ class lam(Function):
 """High level cumulant evaluation function """
 
 
-def evaluate_cumulant(
+def evaluate_cumulant(  # type: ignore[explicit-any]
     cuml: Any,
     positive_times: list[Any] | None = None,
     leading_index: Any | None = None,
@@ -433,7 +433,7 @@ def evaluate_cumulant(
     return ss
 
 
-def transform_to_Python_vec(
+def transform_to_Python_vec(  # type: ignore[explicit-any]
     expr: Any, target_name: str = "gf.gg", conj_func: str = "numpy.conj"
 ) -> Any:
     """Transforms the sympy cumulant evaluation into a matrix Python code
@@ -508,7 +508,7 @@ def transform_to_Python_vec(
     )
 
 
-def transform_to_einsum_expr(
+def transform_to_einsum_expr(  # type: ignore[explicit-any]
     expr: Any,
     participation_matrix: Any | None = None,
     index: int = 0,
@@ -542,10 +542,10 @@ def transform_to_einsum_expr(
     use_exciton = participation_matrix is not None
     MM = participation_matrix if use_exciton else None
 
-    def get_time_str(t_expr: Any) -> str:
+    def get_time_str(t_expr: Any) -> str:  # type: ignore[explicit-any]
         return str(sp.simplify(t_expr)).replace(" ", "")
 
-    def parse_axes(t_expr: Any) -> set[int]:
+    def parse_axes(t_expr: Any) -> set[int]:  # type: ignore[explicit-any]
         """Return a set of active axes for a time expression."""
         if dimensions is None:
             return set()
@@ -591,7 +591,7 @@ def transform_to_einsum_expr(
         rhs_indices = "i" + index_labels[:num_dims]  # e.g., ijk
         return f'"i,{rhs_indices}"'
 
-    def convert_gg(a: Any, b: Any, t: Any) -> Any:
+    def convert_gg(a: Any, b: Any, t: Any) -> Any:  # type: ignore[explicit-any]
         t_str = get_time_str(t)
         axes = parse_axes(t)
         reshape = build_reshape_string(axes)
@@ -647,7 +647,7 @@ class GFInitiator:
 
     """
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self, t1s: numpy.ndarray, t3s: numpy.ndarray, gdict: dict[str, Any]
     ) -> None:
 
@@ -666,7 +666,7 @@ class GFInitiator:
 
         self.set_lineshape_functions(gdict)
 
-    def set_lineshape_functions(self, gdict: dict[str, Any]) -> None:
+    def set_lineshape_functions(self, gdict: dict[str, Any]) -> None:  # type: ignore[explicit-any]
         """Sets the lineshape functions.
 
         Parameters:
@@ -713,7 +713,7 @@ class GFInitiator:
                     key, self.t1s, t2, self.t3s
                 )
 
-    def eval_gg_t2_tn(
+    def eval_gg_t2_tn(  # type: ignore[explicit-any]
         self, key: str, t2: float, t1: numpy.ndarray, t3: numpy.ndarray, zero: int = 0
     ) -> numpy.ndarray:
         """Lineshape function g(t1 + t2) or g(t2 + t3)
@@ -751,7 +751,7 @@ class GFInitiator:
 
         return ret
 
-    def eval_gg_t1_t2_t3(
+    def eval_gg_t1_t2_t3(  # type: ignore[explicit-any]
         self, key: str, t1: numpy.ndarray, t2: float, t3: numpy.ndarray
     ) -> numpy.ndarray:
         """Lineshape function g(t1 + t2 + t3)"""

--- a/quantarhei/testing/behave.py
+++ b/quantarhei/testing/behave.py
@@ -15,7 +15,7 @@ from typing import Any
 from ..exceptions import QuantarheiError
 
 
-def quantarhei_installed(context: Any, version: str | None = None) -> None:
+def quantarhei_installed(context: Any, version: str | None = None) -> None:  # type: ignore[explicit-any]
     """Tests if quantarhei is installed and sets version to context if it is
 
 
@@ -37,7 +37,7 @@ def quantarhei_installed(context: Any, version: str | None = None) -> None:
         assert context.version == version
 
 
-def shell_command(context: Any, cmd: str, err_msg: str = "Shell command error") -> None:
+def shell_command(context: Any, cmd: str, err_msg: str = "Shell command error") -> None:  # type: ignore[explicit-any]
     """Runs a shell command in current directory
 
 
@@ -62,7 +62,7 @@ def shell_command(context: Any, cmd: str, err_msg: str = "Shell command error") 
         raise QuantarheiError(err_msg)
 
 
-def check_output_contains(context: Any, text: str, err_msg: str) -> None:
+def check_output_contains(context: Any, text: str, err_msg: str) -> None:  # type: ignore[explicit-any]
     """Checks that message contains certain text
 
 
@@ -84,13 +84,13 @@ def check_output_contains(context: Any, text: str, err_msg: str) -> None:
         raise QuantarheiError(err_msg)
 
 
-def secure_temp_dir(context: Any) -> None:
+def secure_temp_dir(context: Any) -> None:  # type: ignore[explicit-any]
     """Creates temporary directory and stores its info into context"""
     tmpd = tempfile.TemporaryDirectory()
     context.tempdir = tmpd
 
 
-def cleanup_temp_dir(context: Any) -> None:
+def cleanup_temp_dir(context: Any) -> None:  # type: ignore[explicit-any]
     """Cleans up temporary directory"""
     try:
         os.chdir(context.cwd)
@@ -103,7 +103,7 @@ def cleanup_temp_dir(context: Any) -> None:
         print("Temporary directory cannot be cleaned up - does it exist?")
 
 
-def fetch_test_feature_file(context: Any, filename: str) -> None:
+def fetch_test_feature_file(context: Any, filename: str) -> None:  # type: ignore[explicit-any]
     """Fetches the file with a given name from the storage of test files"""
     resource_package = "quantarhei"
     resource_path = "/".join(("testing", "resources", "behave", filename))
@@ -125,7 +125,7 @@ class testdir:
 
     """
 
-    def __init__(self, context: Any) -> None:
+    def __init__(self, context: Any) -> None:  # type: ignore[explicit-any]
 
         self.context = context
         try:
@@ -139,7 +139,7 @@ class testdir:
         self.context.cwd = os.getcwd()
         os.chdir(self.context.tempdir.name)
 
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:  # type: ignore[explicit-any]
         os.chdir(self.context.cwd)
         if exc_type is not None:
             cleanup_temp_dir(self.context)

--- a/quantarhei/testing/behave.py
+++ b/quantarhei/testing/behave.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import tempfile
+import types
 
 # non-standard imports
 from importlib.resources import files
@@ -139,7 +140,12 @@ class testdir:
         self.context.cwd = os.getcwd()
         os.chdir(self.context.tempdir.name)
 
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:  # type: ignore[explicit-any]
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+    ) -> None:
         os.chdir(self.context.cwd)
         if exc_type is not None:
             cleanup_temp_dir(self.context)

--- a/quantarhei/testing/feature.py
+++ b/quantarhei/testing/feature.py
@@ -25,11 +25,11 @@ class FeatureFileGenerator:
         self._examples: str | None = None
         self._has_examples = False
 
-        self._givens: list[Any] = []
+        self._givens: list[Any] = []  # type: ignore[explicit-any]
         self._has_givens = False
-        self._whens: list[Any] = []
+        self._whens: list[Any] = []  # type: ignore[explicit-any]
         self._has_whens = False
-        self._thens: list[Any] = []
+        self._thens: list[Any] = []  # type: ignore[explicit-any]
         self._has_thens = False
 
     def _process_feature(self) -> str:
@@ -66,7 +66,7 @@ class FeatureFileGenerator:
                 if self._save:
                     self._out += line + "\n"
 
-    def add_Given(self, func: Callable[..., Any]) -> None:
+    def add_Given(self, func: Callable[..., Any]) -> None:  # type: ignore[explicit-any]
         if not self._has_feature:
             raise QuantarheiError()
         string = func.__doc__
@@ -78,7 +78,7 @@ class FeatureFileGenerator:
         self._givens.append(func.__doc__)
         self._has_givens = True
 
-    def add_When(self, func: Callable[..., Any]) -> None:
+    def add_When(self, func: Callable[..., Any]) -> None:  # type: ignore[explicit-any]
         if not self._has_givens:
             raise QuantarheiError()
         string = func.__doc__
@@ -90,7 +90,7 @@ class FeatureFileGenerator:
         self._whens.append(func.__doc__)
         self._has_whens = True
 
-    def add_Then(self, func: Callable[..., Any]) -> None:
+    def add_Then(self, func: Callable[..., Any]) -> None:  # type: ignore[explicit-any]
         if not self._has_whens:
             raise QuantarheiError()
         string = func.__doc__

--- a/quantarhei/utils/logging.py
+++ b/quantarhei/utils/logging.py
@@ -23,7 +23,7 @@ def init_logging() -> None:
     manager.initialized = True
 
 
-def log_urgent(*args: Any, **kwargs: Any) -> None:
+def log_urgent(*args: Any, **kwargs: Any) -> None:  # type: ignore[explicit-any]
     """Log a message at the ``LOG_URGENT`` (level 1) priority.
 
     Parameters
@@ -36,7 +36,7 @@ def log_urgent(*args: Any, **kwargs: Any) -> None:
     printlog(*args, loglevel=LOG_URGENT, **kwargs)
 
 
-def log_report(*args: Any, **kwargs: Any) -> None:
+def log_report(*args: Any, **kwargs: Any) -> None:  # type: ignore[explicit-any]
     """Log a message at the ``LOG_REPORT`` (level 3) priority.
 
     Parameters
@@ -49,7 +49,7 @@ def log_report(*args: Any, **kwargs: Any) -> None:
     printlog(*args, loglevel=LOG_REPORT, **kwargs)
 
 
-def log_info(*args: Any, **kwargs: Any) -> None:
+def log_info(*args: Any, **kwargs: Any) -> None:  # type: ignore[explicit-any]
     """Log a message at the ``LOG_INFO`` (level 5) priority.
 
     Parameters
@@ -62,7 +62,7 @@ def log_info(*args: Any, **kwargs: Any) -> None:
     printlog(*args, loglevel=LOG_INFO, **kwargs)
 
 
-def log_detail(*args: Any, **kwargs: Any) -> None:
+def log_detail(*args: Any, **kwargs: Any) -> None:  # type: ignore[explicit-any]
     """Log a message at the ``LOG_DETAIL`` (level 7) priority.
 
     Parameters
@@ -75,7 +75,7 @@ def log_detail(*args: Any, **kwargs: Any) -> None:
     printlog(*args, loglevel=LOG_DETAIL, **kwargs)
 
 
-def log_quick(*args: Any, verbose: bool = True, **kwargs: Any) -> None:
+def log_quick(*args: Any, verbose: bool = True, **kwargs: Any) -> None:  # type: ignore[explicit-any]
     """Log a message at the ``LOG_QUICK`` (level 9) priority.
 
     This is the most verbose level; the call is a no-op when
@@ -96,7 +96,7 @@ def log_quick(*args: Any, verbose: bool = True, **kwargs: Any) -> None:
     printlog(*args, loglevel=LOG_QUICK, **kwargs)
 
 
-def printlog(
+def printlog(  # type: ignore[explicit-any]
     *args: Any,
     verbose: bool = True,
     loglevel: int = 5,
@@ -248,7 +248,7 @@ def loglevels2bool(loglevs: list[int], verbose: bool = False) -> list[bool]:
     return verb
 
 
-def tprint(var: str, messg: str | None = None, default: Any = None) -> None:
+def tprint(var: str, messg: str | None = None, default: Any = None) -> None:  # type: ignore[explicit-any]
     """Print the value of a named variable from global scope.
 
     If ``default`` is provided, missing variables are silently set to it.

--- a/quantarhei/utils/types.py
+++ b/quantarhei/utils/types.py
@@ -7,16 +7,16 @@ from typing import Any
 import numpy
 
 
-def array_property(name: str, shape: tuple[int, ...] | None = None) -> Any:
+def array_property(name: str, shape: tuple[int, ...] | None = None) -> Any:  # type: ignore[explicit-any]
     """Controls the access to an array property of package classes"""
     storage_name = "_" + name
 
     @property  # type: ignore[misc]
-    def prop(self: Any) -> numpy.ndarray:
+    def prop(self: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
         return getattr(self, storage_name)
 
     @prop.setter
-    def prop(self: Any, value: Any) -> None:
+    def prop(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         try:
             vl = check_numpy_array(value)
             if not (shape == None):
@@ -29,7 +29,7 @@ def array_property(name: str, shape: tuple[int, ...] | None = None) -> Any:
     return prop
 
 
-def units_managed_property(name: str, dtype: type) -> Any:
+def units_managed_property(name: str, dtype: type) -> Any:  # type: ignore[explicit-any]
     """Scalar property with units managed
 
     Warning: The type of the property depends on the object; The object
@@ -38,13 +38,13 @@ def units_managed_property(name: str, dtype: type) -> Any:
     storage_name = "_" + name
 
     @property  # type: ignore[misc]
-    def prop(self: Any) -> Any:
+    def prop(self: Any) -> Any:  # type: ignore[explicit-any]
         val = getattr(self, storage_name)
         return self.convert_2_current_u(val)  # This is a method defined in
         # the class which handles units
 
     @prop.setter
-    def prop(self: Any, value: Any) -> None:
+    def prop(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         if isinstance(value, dtype):
             setattr(self, storage_name, self.convert_2_internal_u(value))
         else:
@@ -53,7 +53,7 @@ def units_managed_property(name: str, dtype: type) -> Any:
     return prop
 
 
-def units_managed_array_property(
+def units_managed_array_property(  # type: ignore[explicit-any]
     name: str, dtype: type, shape: tuple[int, ...] | None = None
 ) -> Any:
     """Array property with units managed
@@ -64,13 +64,13 @@ def units_managed_array_property(
     storage_name = "_" + name
 
     @property  # type: ignore[misc]
-    def prop(self: Any) -> Any:
+    def prop(self: Any) -> Any:  # type: ignore[explicit-any]
         val = getattr(self, storage_name)
         return self.convert_2_current_u(val)  # This is a method defined in
         # the class which handles units
 
     @prop.setter
-    def prop(self: Any, value: Any) -> None:
+    def prop(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
 
         try:
             vl = check_numpy_array(value)
@@ -84,14 +84,14 @@ def units_managed_array_property(
     return prop
 
 
-def basis_managed_array_property(
+def basis_managed_array_property(  # type: ignore[explicit-any]
     name: str, dtype: type, shape: tuple[int, ...] | None = None
 ) -> Any:
 
     storage_name = "_" + name
 
     @property  # type: ignore[misc]
-    def prop(self: Any) -> Any:
+    def prop(self: Any) -> Any:  # type: ignore[explicit-any]
 
         # check if basis id corresponds to the one known by Manager
         cb = self.manager.get_current_basis()
@@ -107,7 +107,7 @@ def basis_managed_array_property(
         return getattr(self, storage_name)
 
     @prop.setter
-    def prop(self: Any, value: Any) -> None:
+    def prop(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
 
         # check if basis id corresponds to the one known by Manager
         cb = self.manager.get_current_basis()
@@ -132,14 +132,14 @@ def basis_managed_array_property(
     return prop
 
 
-def managed_array_property(
+def managed_array_property(  # type: ignore[explicit-any]
     name: str, dtype: type, shape: tuple[int, ...] | None = None
 ) -> Any:
     """Property with the units and basis management"""
     storage_name = "_" + name
 
     @property  # type: ignore[misc]
-    def prop(self: Any) -> Any:
+    def prop(self: Any) -> Any:  # type: ignore[explicit-any]
 
         # check if basis id corresponds to the one known by Manager
         cb = self.manager.get_current_basis()
@@ -156,7 +156,7 @@ def managed_array_property(
         return self.convert_2_current_u(val)
 
     @prop.setter
-    def prop(self: Any, value: Any) -> None:
+    def prop(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
 
         # check if basis id corresponds to the one known by Manager
         cb = self.manager.get_current_basis()
@@ -181,7 +181,7 @@ def managed_array_property(
     return prop
 
 
-def check_numpy_array(val: Any) -> numpy.ndarray:
+def check_numpy_array(val: Any) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Checks if argument is a numpy array.
 
     If the argument is a list, it converts it into numpy array. Otherwise,
@@ -199,15 +199,15 @@ def check_numpy_array(val: Any) -> numpy.ndarray:
     raise TypeError("List or numpy.ndarray required")
 
 
-def typed_property(name: str, dtype: type) -> Any:
+def typed_property(name: str, dtype: type) -> Any:  # type: ignore[explicit-any]
     storage_name = "_" + name
 
     @property  # type: ignore[misc]
-    def prop(self: Any) -> Any:
+    def prop(self: Any) -> Any:  # type: ignore[explicit-any]
         return getattr(self, storage_name)
 
     @prop.setter
-    def prop(self: Any, value: Any) -> None:
+    def prop(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         if isinstance(value, dtype):
             setattr(self, storage_name, value)
         else:
@@ -216,15 +216,15 @@ def typed_property(name: str, dtype: type) -> Any:
     return prop
 
 
-def list_of_typed_property(name: str, dtype: type) -> Any:
+def list_of_typed_property(name: str, dtype: type) -> Any:  # type: ignore[explicit-any]
     storage_name = "_" + name
 
     @property  # type: ignore[misc]
-    def prop(self: Any) -> Any:
+    def prop(self: Any) -> Any:  # type: ignore[explicit-any]
         return getattr(self, storage_name)
 
     @prop.setter
-    def prop(self: Any, value: Any) -> None:
+    def prop(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         if isinstance(value, list):
             for el in value:
                 if not isinstance(el, dtype):
@@ -237,15 +237,15 @@ def list_of_typed_property(name: str, dtype: type) -> Any:
     return prop
 
 
-def alt_type_property(name: str, dtype: Any) -> Any:
+def alt_type_property(name: str, dtype: Any) -> Any:  # type: ignore[explicit-any]
     storage_name = "_" + name
 
     @property  # type: ignore[misc]
-    def prop(self: Any) -> Any:
+    def prop(self: Any) -> Any:  # type: ignore[explicit-any]
         return getattr(self, storage_name)
 
     @prop.setter
-    def prop(self: Any, value: Any) -> None:
+    def prop(self: Any, value: Any) -> None:  # type: ignore[explicit-any]
         if isinstance(dtype, list):
             isset = False
             for tps in dtype:
@@ -263,7 +263,7 @@ def alt_type_property(name: str, dtype: Any) -> Any:
     return prop
 
 
-def derived_type(name: str, dtype_in: Any) -> Any:
+def derived_type(name: str, dtype_in: Any) -> Any:  # type: ignore[explicit-any]
     if isinstance(dtype_in, list):
         tp = partial(alt_type_property, dtype=dtype_in)
     else:

--- a/quantarhei/utils/vectors.py
+++ b/quantarhei/utils/vectors.py
@@ -9,7 +9,7 @@ Dxy = (1.0, 1.0, 0.0) / numpy.sqrt(2)
 Axy = (-1.0, 1.0, 0.0) / numpy.sqrt(2)
 
 
-def normalize2(vec: numpy.ndarray, norm: float = 1.0) -> numpy.ndarray:
+def normalize2(vec: numpy.ndarray, norm: float = 1.0) -> numpy.ndarray:  # type: ignore[explicit-any]
     """Normalize a vector to a specified magnitude.
 
     Parameters
@@ -30,7 +30,7 @@ def normalize2(vec: numpy.ndarray, norm: float = 1.0) -> numpy.ndarray:
     return out
 
 
-def norm(vec: numpy.ndarray) -> float:
+def norm(vec: numpy.ndarray) -> float:  # type: ignore[explicit-any]
     """Return the Euclidean norm of a vector.
 
     Parameters

--- a/quantarhei/wizard/input/input.py
+++ b/quantarhei/wizard/input/input.py
@@ -25,7 +25,7 @@ def ahoj(a: float) -> None:
 a = 5.0
 
 
-def expr(code: str, context: dict[str, Any] | None = None) -> Any:
+def expr(code: str, context: dict[str, Any] | None = None) -> Any:  # type: ignore[explicit-any]
     """Eval a math expression and return the result
 
     To be honest, I have no idea how this works
@@ -73,12 +73,12 @@ class Input:
     """
 
     # YAML-injected attributes — set dynamically via setattr in __init__
-    define_usecases: Any
-    tasks: Any
-    script: Any
-    path: Any
+    define_usecases: Any  # type: ignore[explicit-any]
+    tasks: Any  # type: ignore[explicit-any]
+    script: Any  # type: ignore[explicit-any]
+    path: Any  # type: ignore[explicit-any]
 
-    def __init__(
+    def __init__(  # type: ignore[explicit-any]
         self,
         file_or_dict: str | dict[str, Any],
         math_allowed_in: list[Any] | None = None,
@@ -172,7 +172,7 @@ class Input:
             print("\nInput file summary:\n")
             print(self.data)
 
-    def strings_2_floats_dictionary(
+    def strings_2_floats_dictionary(  # type: ignore[explicit-any]
         self, dictionary: dict[str, Any], keys: list[str]
     ) -> dict[str, Any]:
         """Converts selected keys of a dictionary from string expression to float"""
@@ -186,7 +186,7 @@ class Input:
             ndict[key] = val
         return ndict
 
-    def strings_2_floats_lists(self, inlist: list[Any]) -> None:
+    def strings_2_floats_lists(self, inlist: list[Any]) -> None:  # type: ignore[explicit-any]
         """Converts every string in a list into float"""
         N = len(inlist)
 
@@ -195,7 +195,7 @@ class Input:
             val = self.string_2_float_prop(val)
             inlist[k] = val
 
-    def string_2_float_prop(self, prop: Any) -> Any:
+    def string_2_float_prop(self, prop: Any) -> Any:  # type: ignore[explicit-any]
         """If the submitted object is a string it is converted to float"""
         if isinstance(prop, str):
             val = expr(prop)

--- a/quantarhei/wizard/simulations/excitondynamics.py
+++ b/quantarhei/wizard/simulations/excitondynamics.py
@@ -11,14 +11,14 @@ class ExcitonDynamics(Simulation):
     """Excitonic Dynamics Simulation"""
 
     # Attributes set dynamically from configuration input
-    molecules: Any
-    exciton_multiplicity: Any
-    relaxation_theory: Any
-    sys_operators: Any
-    rates: Any
-    timeaxis: Any
-    tasks: Any
-    rho0: Any
+    molecules: Any  # type: ignore[explicit-any]
+    exciton_multiplicity: Any  # type: ignore[explicit-any]
+    relaxation_theory: Any  # type: ignore[explicit-any]
+    sys_operators: Any  # type: ignore[explicit-any]
+    rates: Any  # type: ignore[explicit-any]
+    timeaxis: Any  # type: ignore[explicit-any]
+    tasks: Any  # type: ignore[explicit-any]
+    rho0: Any  # type: ignore[explicit-any]
 
     def _build(self) -> None:
         """Here we prepare objects for the simulation"""

--- a/quantarhei/wizard/simulations/simulation.py
+++ b/quantarhei/wizard/simulations/simulation.py
@@ -14,7 +14,7 @@ class Simulation(Saveable):
     WARNING = 5
     ERROR = 1
 
-    _file: Any
+    _file: Any  # type: ignore[explicit-any]
 
     def __init__(self, loglevel: int = 0) -> None:
         self._loglevel = loglevel
@@ -101,7 +101,7 @@ class Simulation(Saveable):
 
         self._printlog(grstring, loglevel=0)
 
-    def _printlog(self, *args: Any, loglevel: int = 0) -> None:
+    def _printlog(self, *args: Any, loglevel: int = 0) -> None:  # type: ignore[explicit-any]
         """Logs output on screen and into a file"""
         # define loglevel
         if loglevel < self.verbosity:


### PR DESCRIPTION
## Summary

- Adds `disallow_any_explicit = true` to `[tool.mypy]` in `pyproject.toml`
- Adds `# type: ignore[explicit-any]` to all 1106 existing `Any` usages as baseline
- New code must either use proper types or explicitly opt out with the same marker
- Pre-commit hook enforces this automatically since it already runs mypy

Closes #402

## How it works

Any new explicit `Any` annotation will fail the pre-commit mypy check:
```
error: Explicit "Any" is not allowed  [explicit-any]
```

To silence when genuinely needed:
```python
data: dict[str, Any]  # type: ignore[explicit-any]
```

## Test plan

- [x] mypy passes (only pre-existing unrelated `call-overload` errors remain)
- [x] All 245 tests pass
- [x] Pre-commit hooks pass (ruff, ruff-format, mypy)