### PR TITLE
#408 Improvements of 2D spectra calculation

### DIFF
--- a/examples/benchmark_twod_storage.py
+++ b/examples/benchmark_twod_storage.py
@@ -1,0 +1,178 @@
+"""Benchmark 2D response calculation with jump-order approximations.
+
+The script compares the current zero-jump transfer approximation
+(``jump_order=0``) with the one-jump-ready approximation (``jump_order=1``).
+For one-jump runs, the calculator selects ``FunctionStorage(config=1)`` and
+splits transfer pathways into explicit single-jump and remainder contributions.
+
+Run from the repository root, for example:
+
+    python examples/benchmark_twod_storage.py --nt 32 --nt2 12 --dt 10.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import resource
+import subprocess
+import sys
+import tempfile
+import time
+import tracemalloc
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault(
+    "MPLCONFIGDIR", os.path.join(tempfile.gettempdir(), "quantarhei-mpl-cache")
+)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import quantarhei as qr
+from quantarhei.spectroscopy import X
+
+
+def _rss_mb() -> float:
+    """Return peak resident set size in MB on macOS/Linux."""
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return rss / (1024.0 * 1024.0)
+    return rss / 1024.0
+
+
+def _build_system(nt: int, nt2: int, dt: float) -> Any:
+    env_axis = qr.TimeAxis(0.0, nt, dt)
+
+    with qr.energy_units("1/cm"):
+        m1 = qr.Molecule([0.0, 12000.0])
+        m2 = qr.Molecule([0.0, 12300.0])
+
+        params = dict(
+            ftype="OverdampedBrownian",
+            reorg=40.0,
+            cortime=100.0,
+            T=100,
+            matsubara=20,
+        )
+        m1.set_transition_environment((0, 1), qr.CorrelationFunction(env_axis, params))
+        m2.set_transition_environment((0, 1), qr.CorrelationFunction(env_axis, params))
+
+    m1.set_dipole(0, 1, [1.0, 0.8, 0.8])
+    m2.set_dipole(0, 1, [0.8, 0.8, 0.0])
+
+    agg = qr.Aggregate(molecules=[m1, m2])
+    with qr.energy_units("1/cm"):
+        agg.set_resonance_coupling(0, 1, 100.0)
+
+    agg.build(mult=2)
+    agg.diagonalize()
+    return agg
+
+
+def _run_single(jump_order: int, nt: int, nt2: int, dt: float) -> dict[str, Any]:
+    t1_axis = qr.TimeAxis(0.0, nt, dt)
+    t2_axis = qr.TimeAxis(0.0, nt2, dt)
+    t3_axis = qr.TimeAxis(0.0, nt, dt)
+
+    system = _build_system(nt, nt2, dt)
+
+    lab = qr.LabSetup()
+    lab.set_pulse_polarizations(pulse_polarizations=(X, X, X), detection_polarization=X)
+
+    tracemalloc.start()
+    start = time.perf_counter()
+
+    calc = qr.TwoDResponseCalculator(
+        t1_axis, t2_axis, t3_axis, system=system, jump_order=jump_order
+    )
+    with qr.energy_units("1/cm"):
+        calc.bootstrap(rwa=12100.0, pad=0, lab=lab)
+
+    gg = system.get_lineshape_functions()
+    storage_size_mb = float(gg.data_size)
+    storage_stride = int(gg.data_stride)
+    storage_arguments = len(gg.time_mapping)
+
+    response = calc.calculate()
+    container = response.get_TwoDSpectrumContainer()
+    spectrum = container.get_spectrum(t2_axis.data[0])
+    checksum = float(abs(spectrum.data).sum())
+
+    elapsed = time.perf_counter() - start
+    current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    return {
+        "jump_order": jump_order,
+        "nt": nt,
+        "nt2": nt2,
+        "dt": dt,
+        "elapsed_s": elapsed,
+        "tracemalloc_current_mb": current / (1024.0 * 1024.0),
+        "tracemalloc_peak_mb": peak / (1024.0 * 1024.0),
+        "max_rss_mb": _rss_mb(),
+        "storage_data_size_mb": storage_size_mb,
+        "storage_stride": storage_stride,
+        "storage_arguments": storage_arguments,
+        "checksum": checksum,
+    }
+
+
+def _print_table(results: list[dict[str, Any]]) -> None:
+    print(
+        "jump  args  stride  storage_MB  elapsed_s  trace_peak_MB  max_RSS_MB  checksum"
+    )
+    for result in results:
+        print(
+            f"{result['jump_order']:>4}  "
+            f"{result['storage_arguments']:>4}  "
+            f"{result['storage_stride']:>6}  "
+            f"{result['storage_data_size_mb']:>10.3f}  "
+            f"{result['elapsed_s']:>9.3f}  "
+            f"{result['tracemalloc_peak_mb']:>13.3f}  "
+            f"{result['max_rss_mb']:>10.3f}  "
+            f"{result['checksum']:.6e}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--nt", type=int, default=24)
+    parser.add_argument("--nt2", type=int, default=8)
+    parser.add_argument("--dt", type=float, default=10.0)
+    parser.add_argument("--single-jump-order", type=int, choices=(0, 1))
+    args = parser.parse_args()
+
+    if args.single_jump_order is not None:
+        print(json.dumps(_run_single(args.single_jump_order, args.nt, args.nt2, args.dt)))
+        return
+
+    results = []
+    for jump_order in (0, 1):
+        command = [
+            sys.executable,
+            __file__,
+            "--single-jump-order",
+            str(jump_order),
+            "--nt",
+            str(args.nt),
+            "--nt2",
+            str(args.nt2),
+            "--dt",
+            str(args.dt),
+        ]
+        completed = subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        results.append(json.loads(completed.stdout.strip().splitlines()[-1]))
+
+    _print_table(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/benchmark_twod_storage.py
+++ b/examples/benchmark_twod_storage.py
@@ -71,7 +71,9 @@ def _build_system(nt: int, nt2: int, dt: float) -> Any:
     return agg
 
 
-def _run_single(jump_order: int, nt: int, nt2: int, dt: float) -> dict[str, Any]:
+def _run_single(
+    jump_order: int, nt: int, nt2: int, dt: float, jump_integration_steps: int
+) -> dict[str, Any]:
     t1_axis = qr.TimeAxis(0.0, nt, dt)
     t2_axis = qr.TimeAxis(0.0, nt2, dt)
     t3_axis = qr.TimeAxis(0.0, nt, dt)
@@ -85,7 +87,12 @@ def _run_single(jump_order: int, nt: int, nt2: int, dt: float) -> dict[str, Any]
     start = time.perf_counter()
 
     calc = qr.TwoDResponseCalculator(
-        t1_axis, t2_axis, t3_axis, system=system, jump_order=jump_order
+        t1_axis,
+        t2_axis,
+        t3_axis,
+        system=system,
+        jump_order=jump_order,
+        jump_integration_steps=jump_integration_steps,
     )
     with qr.energy_units("1/cm"):
         calc.bootstrap(rwa=12100.0, pad=0, lab=lab)
@@ -106,6 +113,7 @@ def _run_single(jump_order: int, nt: int, nt2: int, dt: float) -> dict[str, Any]
 
     return {
         "jump_order": jump_order,
+        "jump_integration_steps": jump_integration_steps,
         "nt": nt,
         "nt2": nt2,
         "dt": dt,
@@ -122,11 +130,12 @@ def _run_single(jump_order: int, nt: int, nt2: int, dt: float) -> dict[str, Any]
 
 def _print_table(results: list[dict[str, Any]]) -> None:
     print(
-        "jump  args  stride  storage_MB  elapsed_s  trace_peak_MB  max_RSS_MB  checksum"
+        "jump  s2pts  args  stride  storage_MB  elapsed_s  trace_peak_MB  max_RSS_MB  checksum"
     )
     for result in results:
         print(
             f"{result['jump_order']:>4}  "
+            f"{result['jump_integration_steps']:>5}  "
             f"{result['storage_arguments']:>4}  "
             f"{result['storage_stride']:>6}  "
             f"{result['storage_data_size_mb']:>10.3f}  "
@@ -142,11 +151,22 @@ def main() -> None:
     parser.add_argument("--nt", type=int, default=24)
     parser.add_argument("--nt2", type=int, default=8)
     parser.add_argument("--dt", type=float, default=10.0)
+    parser.add_argument("--jump-integration-steps", type=int, default=1)
     parser.add_argument("--single-jump-order", type=int, choices=(0, 1))
     args = parser.parse_args()
 
     if args.single_jump_order is not None:
-        print(json.dumps(_run_single(args.single_jump_order, args.nt, args.nt2, args.dt)))
+        print(
+            json.dumps(
+                _run_single(
+                    args.single_jump_order,
+                    args.nt,
+                    args.nt2,
+                    args.dt,
+                    args.jump_integration_steps,
+                )
+            )
+        )
         return
 
     results = []
@@ -162,6 +182,8 @@ def main() -> None:
             str(args.nt2),
             "--dt",
             str(args.dt),
+            "--jump-integration-steps",
+            str(args.jump_integration_steps),
         ]
         completed = subprocess.run(
             command,

--- a/examples/benchmark_twod_storage.py
+++ b/examples/benchmark_twod_storage.py
@@ -71,8 +71,19 @@ def _build_system(nt: int, nt2: int, dt: float) -> Any:
     return agg
 
 
+def _s2_point_count(t2_axis: Any, jump_time_graining: int) -> int:
+    """Return the number of s2 grid points used for the largest t2."""
+    if t2_axis.length == 0:
+        return 0
+    t2_index = t2_axis.length - 1
+    indices = list(range(0, t2_index + 1, jump_time_graining))
+    if not indices or indices[-1] != t2_index:
+        indices.append(t2_index)
+    return len(indices)
+
+
 def _run_single(
-    jump_order: int, nt: int, nt2: int, dt: float, jump_integration_steps: int
+    jump_order: int, nt: int, nt2: int, dt: float, jump_time_graining: int
 ) -> dict[str, Any]:
     t1_axis = qr.TimeAxis(0.0, nt, dt)
     t2_axis = qr.TimeAxis(0.0, nt2, dt)
@@ -92,7 +103,7 @@ def _run_single(
         t3_axis,
         system=system,
         jump_order=jump_order,
-        jump_integration_steps=jump_integration_steps,
+        jump_time_graining=jump_time_graining,
     )
     with qr.energy_units("1/cm"):
         calc.bootstrap(rwa=12100.0, pad=0, lab=lab)
@@ -113,7 +124,8 @@ def _run_single(
 
     return {
         "jump_order": jump_order,
-        "jump_integration_steps": jump_integration_steps,
+        "jump_time_graining": jump_time_graining,
+        "s2_point_count": _s2_point_count(t2_axis, jump_time_graining),
         "nt": nt,
         "nt2": nt2,
         "dt": dt,
@@ -130,12 +142,13 @@ def _run_single(
 
 def _print_table(results: list[dict[str, Any]]) -> None:
     print(
-        "jump  s2pts  args  stride  storage_MB  elapsed_s  trace_peak_MB  max_RSS_MB  checksum"
+        "jump  grain  s2pts  args  stride  storage_MB  elapsed_s  trace_peak_MB  max_RSS_MB  checksum"
     )
     for result in results:
         print(
             f"{result['jump_order']:>4}  "
-            f"{result['jump_integration_steps']:>5}  "
+            f"{result['jump_time_graining']:>5}  "
+            f"{result['s2_point_count']:>5}  "
             f"{result['storage_arguments']:>4}  "
             f"{result['storage_stride']:>6}  "
             f"{result['storage_data_size_mb']:>10.3f}  "
@@ -151,7 +164,7 @@ def main() -> None:
     parser.add_argument("--nt", type=int, default=24)
     parser.add_argument("--nt2", type=int, default=8)
     parser.add_argument("--dt", type=float, default=10.0)
-    parser.add_argument("--jump-integration-steps", type=int, default=1)
+    parser.add_argument("--jump-time-graining", type=int, default=1)
     parser.add_argument("--single-jump-order", type=int, choices=(0, 1))
     args = parser.parse_args()
 
@@ -163,7 +176,7 @@ def main() -> None:
                     args.nt,
                     args.nt2,
                     args.dt,
-                    args.jump_integration_steps,
+                    args.jump_time_graining,
                 )
             )
         )
@@ -182,8 +195,8 @@ def main() -> None:
             str(args.nt2),
             "--dt",
             str(args.dt),
-            "--jump-integration-steps",
-            str(args.jump_integration_steps),
+            "--jump-time-graining",
+            str(args.jump_time_graining),
         ]
         completed = subprocess.run(
             command,

--- a/examples/benchmark_twod_storage.py
+++ b/examples/benchmark_twod_storage.py
@@ -83,7 +83,13 @@ def _s2_point_count(t2_axis: Any, jump_time_graining: int) -> int:
 
 
 def _run_single(
-    jump_order: int, nt: int, nt2: int, dt: float, jump_time_graining: int
+    jump_order: int,
+    nt: int,
+    nt2: int,
+    dt: float,
+    jump_time_graining: int,
+    jump_kernel_cutoff: float,
+    jump_kernel_zero_cutoff: float,
 ) -> dict[str, Any]:
     t1_axis = qr.TimeAxis(0.0, nt, dt)
     t2_axis = qr.TimeAxis(0.0, nt2, dt)
@@ -104,6 +110,8 @@ def _run_single(
         system=system,
         jump_order=jump_order,
         jump_time_graining=jump_time_graining,
+        jump_kernel_cutoff=jump_kernel_cutoff,
+        jump_kernel_zero_cutoff=jump_kernel_zero_cutoff,
     )
     with qr.energy_units("1/cm"):
         calc.bootstrap(rwa=12100.0, pad=0, lab=lab)
@@ -117,6 +125,19 @@ def _run_single(
     container = response.get_TwoDSpectrumContainer()
     spectrum = container.get_spectrum(t2_axis.data[0])
     checksum = float(abs(spectrum.data).sum())
+    jump_diagnostics = [
+        diag.get("jump", {})
+        for diag in calc.response_diagnostics
+        if str(diag.get("transfer_channel", "")).startswith("scM1")
+    ]
+    skipped_jumps = sum(1 for diag in jump_diagnostics if diag.get("skipped", False))
+    used_s2_points = sum(int(diag.get("used_points", 0)) for diag in jump_diagnostics)
+    remainder_changes = [
+        diag["remainder_relative_change"]
+        for diag in calc.response_diagnostics
+        if diag.get("remainder_relative_change") is not None
+    ]
+    max_remainder_change = max(remainder_changes, default=0.0)
 
     elapsed = time.perf_counter() - start
     current, peak = tracemalloc.get_traced_memory()
@@ -125,7 +146,12 @@ def _run_single(
     return {
         "jump_order": jump_order,
         "jump_time_graining": jump_time_graining,
+        "jump_kernel_cutoff": jump_kernel_cutoff,
+        "jump_kernel_zero_cutoff": jump_kernel_zero_cutoff,
         "s2_point_count": _s2_point_count(t2_axis, jump_time_graining),
+        "used_s2_points": used_s2_points,
+        "skipped_jumps": skipped_jumps,
+        "max_remainder_change": max_remainder_change,
         "nt": nt,
         "nt2": nt2,
         "dt": dt,
@@ -142,13 +168,18 @@ def _run_single(
 
 def _print_table(results: list[dict[str, Any]]) -> None:
     print(
-        "jump  grain  s2pts  args  stride  storage_MB  elapsed_s  trace_peak_MB  max_RSS_MB  checksum"
+        "jump  grain  cutoff  zero  s2pts  used  skip  rem_dR  args  stride  storage_MB  elapsed_s  trace_peak_MB  max_RSS_MB  checksum"
     )
     for result in results:
         print(
             f"{result['jump_order']:>4}  "
             f"{result['jump_time_graining']:>5}  "
+            f"{result['jump_kernel_cutoff']:>6.1e}  "
+            f"{result['jump_kernel_zero_cutoff']:>4.1e}  "
             f"{result['s2_point_count']:>5}  "
+            f"{result['used_s2_points']:>4}  "
+            f"{result['skipped_jumps']:>4}  "
+            f"{result['max_remainder_change']:>6.1e}  "
             f"{result['storage_arguments']:>4}  "
             f"{result['storage_stride']:>6}  "
             f"{result['storage_data_size_mb']:>10.3f}  "
@@ -165,6 +196,8 @@ def main() -> None:
     parser.add_argument("--nt2", type=int, default=8)
     parser.add_argument("--dt", type=float, default=10.0)
     parser.add_argument("--jump-time-graining", type=int, default=1)
+    parser.add_argument("--jump-kernel-cutoff", type=float, default=0.0)
+    parser.add_argument("--jump-kernel-zero-cutoff", type=float, default=0.0)
     parser.add_argument("--single-jump-order", type=int, choices=(0, 1))
     args = parser.parse_args()
 
@@ -177,6 +210,8 @@ def main() -> None:
                     args.nt2,
                     args.dt,
                     args.jump_time_graining,
+                    args.jump_kernel_cutoff,
+                    args.jump_kernel_zero_cutoff,
                 )
             )
         )
@@ -197,6 +232,10 @@ def main() -> None:
             str(args.dt),
             "--jump-time-graining",
             str(args.jump_time_graining),
+            "--jump-kernel-cutoff",
+            str(args.jump_kernel_cutoff),
+            "--jump-kernel-zero-cutoff",
+            str(args.jump_kernel_zero_cutoff),
         ]
         completed = subprocess.run(
             command,

--- a/quantarhei/builders/modes.py
+++ b/quantarhei/builders/modes.py
@@ -182,10 +182,10 @@ class Mode(UnitsManaged, Saveable, OpenSystem):
         >>> mol = qr.TestMolecule("two-levels-1-mode")
         >>> mod = mol.get_Mode(0)
 
-        This function is deprecated and it throws a warning text when it is run
+        This function is deprecated and it raises a deprecation warning when
+        it is run
 
-        >>> mod.set_frequency(1, 1.3) # doctest: +ELLIPSIS
-        function  <function Mode.set_frequency at ...>  is deprecated
+        >>> mod.set_frequency(1, 1.3)
 
         >>> mod.get_energy(1)
         1.3
@@ -349,10 +349,10 @@ class Mode(UnitsManaged, Saveable, OpenSystem):
         >>> mod = mol.get_Mode(0)
         >>> mod.set_energy(1, 1.3)
 
-        This function is deprecated and it throws a warning text when it is run
+        This function is deprecated and it raises a deprecation warning when
+        it is run
 
-        >>> mod.get_frequency(1) # doctest: +ELLIPSIS
-        function  <function Mode.get_frequency at ...>  is deprecated
+        >>> mod.get_frequency(1)
         1.3
 
         """

--- a/quantarhei/builders/opensystem.py
+++ b/quantarhei/builders/opensystem.py
@@ -441,10 +441,12 @@ class OpenSystem:
 
         return WPM
 
-    def get_lineshape_functions(self, config: dict | int | None = None) -> Any:
+    def get_lineshape_functions(
+        self, config: dict | int | None = None, timeaxis: Any = None
+    ) -> Any:
         """Returns lineshape functions defined for this system"""
         sbi = self.get_SystemBathInteraction()
-        return sbi.get_goft_storage(config=config)
+        return sbi.get_goft_storage(config=config, timeaxis=timeaxis)
 
     def map_lineshape_to_states(self, mpx: numpy.ndarray) -> numpy.ndarray:
         """Maps the participation matrix on g(t) functions storage

--- a/quantarhei/builders/opensystem.py
+++ b/quantarhei/builders/opensystem.py
@@ -9,6 +9,7 @@ from ..core.dfunction import DFunction
 from ..core.managers import Manager, eigenbasis_of, energy_units
 from ..core.triangle import triangle
 from ..core.units import c_int, eps0_int, kB_intK
+from ..core.wrappers import deprecated
 from ..qm import ReducedDensityMatrix, SelfAdjointOperator
 from ..qm.hilbertspace.hamiltonian import Hamiltonian
 from ..qm.liouvillespace.heom import KTHierarchy, KTHierarchyPropagator
@@ -1065,13 +1066,17 @@ class OpenSystem:
 
         raise Exception("Rate matrix theory not implemented")
 
+    @deprecated(alternative="get_RateMatrix(relaxation_theory='Redfield')")
     def get_RedfieldRateMatrix(
         self,
         corr_mat: object = None,
         time_dependent: bool = False,
         relaxation_cutoff_time: float | None = None,
     ) -> object:
-        """Returns Redfield rate matrix"""
+        """Returns Redfield rate matrix.
+
+        Deprecated; use ``get_RateMatrix(relaxation_theory="Redfield")``.
+        """
         return self.get_RateMatrix(
             relaxation_theory="standard_Redfield",
             time_dependent=time_dependent,
@@ -1079,12 +1084,16 @@ class OpenSystem:
             corr_mat=corr_mat,
         )
 
+    @deprecated(alternative="get_RateMatrix(relaxation_theory='Foerster')")
     def get_FoersterRateMatrix(
         self,
         time_dependent: bool = False,
         relaxation_cutoff_time: float | None = None,
     ) -> object:
-        """Returns Förster rate matrix for the open system"""
+        """Returns Förster rate matrix for the open system.
+
+        Deprecated; use ``get_RateMatrix(relaxation_theory="Foerster")``.
+        """
         return self.get_RateMatrix(
             relaxation_theory="standard_Foerster",
             time_dependent=time_dependent,

--- a/quantarhei/builders/opensystem.py
+++ b/quantarhei/builders/opensystem.py
@@ -441,10 +441,10 @@ class OpenSystem:
 
         return WPM
 
-    def get_lineshape_functions(self) -> Any:
+    def get_lineshape_functions(self, config: dict | int | None = None) -> Any:
         """Returns lineshape functions defined for this system"""
         sbi = self.get_SystemBathInteraction()
-        return sbi.get_goft_storage()
+        return sbi.get_goft_storage(config=config)
 
     def map_lineshape_to_states(self, mpx: numpy.ndarray) -> numpy.ndarray:
         """Maps the participation matrix on g(t) functions storage

--- a/quantarhei/builders/opensystem.py
+++ b/quantarhei/builders/opensystem.py
@@ -1000,30 +1000,96 @@ class OpenSystem:
 
         return prop
 
-    # FIXME: There must be a general theory here
-    def get_RedfieldRateMatrix(self, corr_mat: object = None) -> object:
+    def get_RateMatrix(
+        self,
+        relaxation_theory: str | None = None,
+        time_dependent: bool = False,
+        relaxation_cutoff_time: float | None = None,
+        corr_mat: object = None,
+    ) -> object:
+        """Returns a rate matrix corresponding to the system.
+
+        Parameters
+        ----------
+        relaxation_theory : str
+            Relaxation theory used to calculate the rates. Currently supports
+            standard Redfield and standard Foerster aliases.
+
+        time_dependent : bool
+            If ``True``, returns the time-dependent version of the requested
+            rate matrix when available.
+        """
+        from ..qm import (
+            FoersterRateMatrix,
+            RedfieldRateMatrix,
+            TDFoersterRateMatrix,
+            TDRedfieldRateMatrix,
+        )
+
+        if self._built:
+            ham = self.get_Hamiltonian()
+            sbi = self.get_SystemBathInteraction()
+        else:
+            raise Exception("System not built yet")
+
+        theories = dict()
+        theories["standard_Redfield"] = [
+            "standard_Redfield",
+            "stR",
+            "Redfield",
+            "CLME2",
+            "QME",
+        ]
+        theories["standard_Foerster"] = ["standard_Foerster", "stF", "Foerster"]
+
+        if relaxation_theory is None:
+            relaxation_theory = "standard_Redfield"
+
+        if relaxation_theory in theories["standard_Redfield"]:
+            if time_dependent:
+                return TDRedfieldRateMatrix(
+                    ham, sbi, cutoff_time=relaxation_cutoff_time
+                )
+
+            return RedfieldRateMatrix(
+                ham, sbi, cutoff_time=relaxation_cutoff_time, corr_mat=corr_mat
+            )
+
+        if relaxation_theory in theories["standard_Foerster"]:
+            if time_dependent:
+                return TDFoersterRateMatrix(
+                    ham, sbi, cutoff_time=relaxation_cutoff_time
+                )
+
+            return FoersterRateMatrix(ham, sbi, cutoff_time=relaxation_cutoff_time)
+
+        raise Exception("Rate matrix theory not implemented")
+
+    def get_RedfieldRateMatrix(
+        self,
+        corr_mat: object = None,
+        time_dependent: bool = False,
+        relaxation_cutoff_time: float | None = None,
+    ) -> object:
         """Returns Redfield rate matrix"""
-        from ..qm import RedfieldRateMatrix
+        return self.get_RateMatrix(
+            relaxation_theory="standard_Redfield",
+            time_dependent=time_dependent,
+            relaxation_cutoff_time=relaxation_cutoff_time,
+            corr_mat=corr_mat,
+        )
 
-        if self._built:
-            ham = self.get_Hamiltonian()
-            sbi = self.get_SystemBathInteraction()
-        else:
-            raise Exception()
-
-        return RedfieldRateMatrix(ham, sbi, corr_mat=corr_mat)
-
-    def get_FoersterRateMatrix(self) -> object:
+    def get_FoersterRateMatrix(
+        self,
+        time_dependent: bool = False,
+        relaxation_cutoff_time: float | None = None,
+    ) -> object:
         """Returns Förster rate matrix for the open system"""
-        from ..qm import FoersterRateMatrix
-
-        if self._built:
-            ham = self.get_Hamiltonian()
-            sbi = self.get_SystemBathInteraction()
-        else:
-            raise Exception()
-
-        return FoersterRateMatrix(ham, sbi)
+        return self.get_RateMatrix(
+            relaxation_theory="standard_Foerster",
+            time_dependent=time_dependent,
+            relaxation_cutoff_time=relaxation_cutoff_time,
+        )
 
     def get_KTHierarchy(self, depth: int = 2) -> Any:
         """Returns the Kubo-Tanimura hierarchy of an open system"""

--- a/quantarhei/core/valueaxis.py
+++ b/quantarhei/core/valueaxis.py
@@ -230,8 +230,8 @@ class ValueAxis(Saveable):
     def is_equal_to(self, axis: ValueAxis) -> bool:
         """Returns True if the axis is equal to this ValueAxis"""
         return (
-            (self.start == axis.start)
-            and (self.step == axis.step)
+            numpy.isclose(self.start, axis.start)
+            and numpy.isclose(self.step, axis.step)
             and (self.length == axis.length)
         )
 
@@ -241,29 +241,23 @@ class ValueAxis(Saveable):
     def is_extension_of(self, axis: ValueAxis) -> bool:
         """Returns True if the axis is contained in this ValueAxis"""
         ret = True
-        ret = ret and (self.start <= axis.start)
-        ret = ret and (self.step == axis.step)
-        ret = ret and (self.max >= axis.max)
+        ret = ret and (
+            self.start <= axis.start or numpy.isclose(self.start, axis.start)
+        )
+        ret = ret and numpy.isclose(self.step, axis.step)
+        ret = ret and (self.max >= axis.max or numpy.isclose(self.max, axis.max))
 
-        found_one_point = False
-        N = self.length
-        k = 0
-        while (not found_one_point) and (k < N):
-            point = self.data[k]
-            if point in axis.data:
-                found_one_point = True
-            k += 1
-
-        ret = ret and found_one_point
+        offsets = (axis.data - self.start) / self.step
+        ret = ret and numpy.any(numpy.isclose(offsets, numpy.rint(offsets)))
 
         return ret
 
     def is_subsection_of(self, axis: ValueAxis) -> bool:
         """Returns True if the axis contains this ValueAxis"""
         ret = True
-        ret = ret and (self.start in axis.data)
-        ret = ret and (self.step == axis.step)
-        ret = ret and (self.max in axis.data)
+        ret = ret and numpy.isclose(self.step, axis.step)
+        ret = ret and _axis_value_is_in_axis(self.start, axis)
+        ret = ret and _axis_value_is_in_axis(self.max, axis)
 
         return ret
 
@@ -309,9 +303,10 @@ class ValueAxis(Saveable):
         ret = True
 
         Nst = round(self.step / axis.step)
-        ret = ret and (Nst * axis.step == self.step)
-        ret = ret and ((self.start in axis.data) and (self.start < axis.max))
-        ret = ret and (self.max in axis.data)
+        ret = ret and numpy.isclose(Nst * axis.step, self.step)
+        ret = ret and _axis_value_is_in_axis(self.start, axis)
+        ret = ret and (self.start < axis.max or numpy.isclose(self.start, axis.max))
+        ret = ret and _axis_value_is_in_axis(self.max, axis)
 
         return ret
 
@@ -357,9 +352,10 @@ class ValueAxis(Saveable):
         ret = True
 
         Nst = round(axis.step / self.step)
-        ret = ret and (Nst * self.step == axis.step)
-        ret = ret and ((axis.start in self.data) and (axis.start < self.max))
-        ret = ret and (axis.max in self.data)
+        ret = ret and numpy.isclose(Nst * self.step, axis.step)
+        ret = ret and _axis_value_is_in_axis(axis.start, self)
+        ret = ret and (axis.start < self.max or numpy.isclose(axis.start, self.max))
+        ret = ret and _axis_value_is_in_axis(axis.max, self)
 
         return ret
 
@@ -372,3 +368,14 @@ class ValueAxis(Saveable):
         out += "\nstep = " + str(self.step)
 
         return out
+
+
+def _axis_value_is_in_axis(value: float, axis: ValueAxis) -> bool:
+    """Returns True when ``value`` lies on an axis grid point."""
+    if value < axis.min and not numpy.isclose(value, axis.min):
+        return False
+    if value > axis.max and not numpy.isclose(value, axis.max):
+        return False
+
+    nstep = round((value - axis.start) / axis.step)
+    return numpy.isclose(axis.start + nstep * axis.step, value)

--- a/quantarhei/core/wrappers.py
+++ b/quantarhei/core/wrappers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from functools import wraps
 from typing import Any
@@ -8,13 +9,31 @@ from typing import Any
 from .managers import Manager
 
 
-def deprecated(func: Callable[..., Any]) -> Callable[..., Any]:
-    @wraps(func)
-    def wrapper(*arg: Any, **kwargs: Any) -> Any:
-        print("function ", func, " is deprecated")
-        return func(*arg, **kwargs)
+def deprecated(
+    func: Callable[..., Any] | None = None,
+    *,
+    alternative: str | None = None,
+) -> Callable[..., Any]:
+    def decorator(wrapped_func: Callable[..., Any]) -> Callable[..., Any]:
+        message = f"{wrapped_func.__qualname__} is deprecated"
+        if alternative is not None:
+            message = f"{message}; use {alternative} instead"
 
-    return wrapper
+        @wraps(wrapped_func)
+        def wrapper(*arg: Any, **kwargs: Any) -> Any:
+            warnings.warn(
+                message,
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return wrapped_func(*arg, **kwargs)
+
+        return wrapper
+
+    if func is None:
+        return decorator
+
+    return decorator(func)
 
 
 def prevent_basis_context(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/quantarhei/qm/__init__.py
+++ b/quantarhei/qm/__init__.py
@@ -76,6 +76,9 @@ from .liouvillespace.rates.ratematrix import RateMatrix as RateMatrix
 #
 # Rate matrices
 from .liouvillespace.rates.redfieldrates import RedfieldRateMatrix as RedfieldRateMatrix
+from .liouvillespace.rates.tdfoersterrates import (
+    TDFoersterRateMatrix as TDFoersterRateMatrix,
+)
 from .liouvillespace.rates.tdredfieldrates import (
     TDRedfieldRateMatrix as TDRedfieldRateMatrix,
 )
@@ -196,6 +199,7 @@ __all__ = [
     # System-bath interaction
     "SystemBathInteraction",
     # Time-dependent tensors
+    "TDFoersterRateMatrix",
     "TDFoersterRelaxationTensor",
     "TDModRedfieldRelaxationTensor",
     "TDRedfieldFoersterRelaxationTensor",

--- a/quantarhei/qm/corfunctions/functionstorage.py
+++ b/quantarhei/qm/corfunctions/functionstorage.py
@@ -8,6 +8,100 @@ import numpy
 from ...core.time import TimeAxis
 
 
+def _normalize_integrals(integrals: Any) -> list[str]:
+    """Return a stable list of integral-time labels from config metadata."""
+    if integrals is None:
+        return []
+    if isinstance(integrals, str):
+        return [integrals]
+    if isinstance(integrals, set):
+        return sorted(integrals)
+    return list(integrals)
+
+
+def _label_from_terms(terms: list[tuple[int, str]]) -> str:
+    """Build a compact label such as ``t1+t2-s2`` from signed terms."""
+    label = ""
+    for kk, (sign, name) in enumerate(terms):
+        if sign not in (-1, 1):
+            raise ValueError("Only unit signs are supported in time labels")
+        if kk == 0:
+            if sign < 0:
+                label += "-"
+        else:
+            label += "+" if sign > 0 else "-"
+        label += name
+    return label
+
+
+def _parse_time_label(label: str) -> list[tuple[int, str]]:
+    """Parse labels made of variable names joined by ``+`` and ``-`` signs."""
+    terms = []
+    sign = 1
+    token = ""
+    for char in label:
+        if char in "+-":
+            if token:
+                terms.append((sign, token))
+                token = ""
+            sign = 1 if char == "+" else -1
+        elif not char.isspace():
+            token += char
+    if token:
+        terms.append((sign, token))
+    if not terms:
+        raise ValueError("Empty time label")
+    return terms
+
+
+def _generate_time_argument_labels(response_times: dict[str, Any]) -> list[str]:
+    """Generate all supported line-shape-function time arguments.
+
+    The ordinary arguments are all non-empty ordered combinations of response
+    times. Integral variables attached to reset times generate two additional
+    variants for every argument containing their parent: one with the parent
+    replaced by the integration time, and one with it replaced by the remaining
+    interval ``parent-integral``.
+    """
+    labels = []
+    names = list(response_times)
+
+    reset_integrals = {}
+    for name, info in response_times.items():
+        if info.get("reset", False):
+            integrals = _normalize_integrals(info.get("integral", None))
+            if integrals:
+                reset_integrals[name] = integrals
+
+    for length in range(1, len(names) + 1):
+        for combo in combinations(names, length):
+            labels.append("+".join(combo))
+
+            replacement_groups = []
+            for name in combo:
+                variants = [[(1, name)]]
+                for integral in reset_integrals.get(name, []):
+                    variants.append([(1, integral)])
+                    variants.append([(1, name), (-1, integral)])
+                replacement_groups.append(variants)
+
+            generated: list[list[tuple[int, str]]] = [[]]
+            # generated = [[]]
+            for variants in replacement_groups:
+                generated = [
+                    base + variant for base in generated for variant in variants
+                ]
+
+            for terms in generated[1:]:
+                labels.append(_label_from_terms(terms))
+
+    unique_labels = []
+    for label in labels:
+        if label not in unique_labels:
+            unique_labels.append(label)
+    return unique_labels
+
+
 class FunctionStorage:
     """Data storage for discrete representation of correlation functions
     and lineshape functions.
@@ -60,25 +154,14 @@ class FunctionStorage:
         # generate the list of argument combinations
         #
         values = self.config["response_times"]
-        Nf = len(values)  # Total number of elements
-
-        # Generate all M-tuples (1 ≤ M ≤ N) while preserving order
-        all_tuples = [list(combinations(values, M)) for M in range(1, Nf + 1)]
-
-        # Flatten and print results
-        self.time_combination_tuples = []
-        self.time_combination_strings = []
-        for tuples in all_tuples:
-            for t in tuples:
-                self.time_combination_tuples.append(t)
-                tstr = ""
-                kk = 0
-                for x in t:
-                    if kk > 0:
-                        tstr += "+"
-                    tstr += x
-                    kk += 1
-                self.time_combination_strings.append(tstr)
+        if self.config.get("arguments", "auto") == "auto":
+            self.time_combination_strings = _generate_time_argument_labels(values)
+        else:
+            self.time_combination_strings = list(self.config["arguments"])
+        self.time_combination_tuples = [
+            tuple(name for _, name in _parse_time_label(label))
+            for label in self.time_combination_strings
+        ]
 
         if show_config:
             print("\nStorage configuration")
@@ -88,13 +171,18 @@ class FunctionStorage:
         # creating time_index
         #
         time_index: dict[str, int | tuple[int, ...]] = {}
+        variable_index: dict[str, int] = {}
 
         # find all reset times
         reset_times = []
         for rst_key in self.config["response_times"]:
             if self.config["response_times"][rst_key]["reset"]:
                 reset_times.append(rst_key)
-                time_index[rst_key] = -1
+                variable_index[rst_key] = -1
+                for integral in _normalize_integrals(
+                    self.config["response_times"][rst_key].get("integral", None)
+                ):
+                    variable_index[integral] = -1
 
         # find all 1D times
         oned_times = []
@@ -102,7 +190,7 @@ class FunctionStorage:
             if not self.config["response_times"][rst_key]["reset"]:
                 axis = self.config["response_times"][rst_key]["axis"]
                 oned_times.append(rst_key)
-                time_index[rst_key] = axis
+                variable_index[rst_key] = axis
 
         # is the number of 1D times matching the number of submitted time axes?
         if isinstance(timeaxis, TimeAxis):
@@ -118,22 +206,27 @@ class FunctionStorage:
 
         self.oned_times = oned_times
 
-        # find all combinations with 2 or more times and calculate their dimension
-        for tpl, tstr in zip(
-            self.time_combination_tuples, self.time_combination_strings
-        ):
-            if len(tpl) > 1:
-                dim: list[int] = []
-                for tm in tpl:
-                    # if time_index[tm] >= 0:     # we add even -1 to time_index
-                    val_tm = time_index[tm]
-                    dim.append(val_tm if isinstance(val_tm, int) else 0)
-                if len(dim) == 1:
-                    time_index[tstr] = dim[0]
-                elif len(dim) > 1:
-                    time_index[tstr] = tuple(dim)
-                else:
-                    raise Exception("Inconsistent configuration")
+        self.variable_index = variable_index
+        self.time_expressions = {}
+
+        # find all time arguments and calculate their dimension
+        for tstr in self.time_combination_strings:
+            terms = _parse_time_label(tstr)
+            axes = []
+            for _, tm in terms:
+                if tm not in variable_index:
+                    raise Exception("Unknown time variable in storage config: " + tm)
+                axis = variable_index[tm]
+                if axis >= 0 and axis not in axes:
+                    axes.append(axis)
+
+            self.time_expressions[tstr] = terms
+            if len(axes) == 0:
+                time_index[tstr] = -1
+            elif len(axes) == 1:
+                time_index[tstr] = axes[0]
+            else:
+                time_index[tstr] = tuple(axes)
 
         # order time_index
         # Sorting criteria:
@@ -524,75 +617,41 @@ class FunctionStorage:
 
         return ret
 
-    # FIXME: allow multiple reset times
     def create_data(self, reset: dict | None = None) -> None:
         """We create data for all submitted functions"""
         if reset is None:
             reset = {"t2": 0.0}
         tt_matrix = []
-        t2 = reset["t2"]
 
-        t2m = numpy.array([t2])
         _colon_ = slice(None, None, None)
 
         for tm in self.time_index:
-            # list of time axes from the time_index
             dms = self.time_index[tm]
-
-            # handling single variables
             if isinstance(dms, int):
-                if dms == -1:
-                    tt_matrix.append(t2m)
+                axes = [] if dms == -1 else [dms]
+            else:
+                axes = [axis for axis in dms if axis >= 0]
+
+            tt_dim = [self.dim[axis] for axis in axes]
+            if len(tt_dim) == 0:
+                tt = numpy.zeros(1, dtype=numpy.float64)
+            else:
+                tt = numpy.zeros(tt_dim, dtype=numpy.float64)
+
+            for sign, name in self.time_expressions[tm]:
+                axis = self.variable_index[name]
+                if axis == -1:
+                    if name not in reset:
+                        raise Exception("Reset time not specified: " + name)
+                    tt += sign * reset[name]
+                elif len(tt_dim) == 1:
+                    tt += sign * self.ta[axis].data
                 else:
-                    tt_matrix.append(self.ta[dms].data)
+                    index_list: list[slice | None] = [None] * len(tt_dim)
+                    index_list[axes.index(axis)] = _colon_
+                    tt += sign * self.ta[axis].data.__getitem__(tuple(index_list))
 
-            # handling tuples
-            elif isinstance(dms, (tuple, list)):
-                # from tuples we need to eliminate -1
-                # to get the final dimension of the stored representation
-                tt_dim = []
-                _tm_val = self.time_index[tm]
-                assert isinstance(_tm_val, tuple)
-                for elem in _tm_val:
-                    if elem >= 0:
-                        tt_dim.append(self.dim[elem])
-
-                # tt_dim is the final dimension and we allocate space for time variable
-
-                tt = numpy.zeros(tt_dim, dtype=numpy.float32)
-
-                #  now let's go axis by axis
-                dim_needed = 0
-                for ldm in dms:
-                    # if we find -1, we add the corresponding single value (now it is t2)
-                    # We do it like this always, no matter how big is 'tt' (constant can be broadcasted
-                    # automatically)
-                    if ldm == -1:
-                        tt += t2
-
-                    # if it is not -1
-                    else:
-                        # but it is the only dimension available, we have a 1D case
-                        if len(tt_dim) == 1:
-                            tt += self.ta[ldm].data
-
-                        # otherwise we have multi-dimensional case,
-                        # and we have to combine time axes into multi-D matrix
-                        # We have to be aware of which axis we are - this is given by 'ldm' variable
-                        else:
-                            #
-                            # Here we have to figure out how to construct the index for broadcasting
-                            #
-                            index_list: list[slice | None] = [None] * len(tt_dim)
-                            # index_list[ldm] = _colon_
-                            index_list[dim_needed] = _colon_
-                            index = tuple(index_list)
-
-                            tt += self.ta[ldm].data.__getitem__(index)
-
-                            dim_needed += 1
-
-                tt_matrix.append(tt)
+            tt_matrix.append(tt)
 
         #
         # loop over all stored functions

--- a/quantarhei/qm/corfunctions/functionstorage.py
+++ b/quantarhei/qm/corfunctions/functionstorage.py
@@ -492,12 +492,13 @@ class FunctionStorage:
                         sta = start + self.start_dic[j]
                         end = start + self.end_dic[j]
 
-                    if sta + 1 == end:
-                        return self.data[sta]
                     if isinstance(j, int):
                         tpl = self.reshapes[j]
                     else:
                         tpl = self.reshapes_dic[j]
+
+                    if sta + 1 == end and len(tpl) == 0:
+                        return self.data[sta]
 
                     return self.data[sta:end].reshape(tpl)
 
@@ -511,12 +512,13 @@ class FunctionStorage:
                         sta = self.start_dic[j]
                         end = self.end_dic[j]
 
-                    if sta + 1 == end:
-                        return self._data2d[i, sta]
                     if isinstance(j, int):
                         tpl = [self._data2d.shape[0]] + self.reshapes[j]  # type: ignore[misc]
                     else:
                         tpl = [self._data2d.shape[0]] + self.reshapes_dic[j]  # type: ignore[misc]
+
+                    if sta + 1 == end and len(tpl) == 1:
+                        return self._data2d[i, sta]
 
                     return self._data2d[i, sta:end].reshape(tpl)
 
@@ -773,11 +775,22 @@ class FunctionStorage:
 
     def get_reorganization_energies(self) -> numpy.ndarray:
         """Returns the estimate of the reoganization energies of the stored functions"""
-        index = (slice(None, None, None), "t1")
+        label = "t1"
+        axis = self.ta[0]
+        for candidate in self.oned_times:
+            axis_index = self.variable_index[candidate]
+            candidate_axis = self.ta[axis_index]
+            if not numpy.isclose(candidate_axis.data[-1], 0.0):
+                label = candidate
+                axis = candidate_axis
+                break
+
+        index = (slice(None, None, None), label)
         igg = -numpy.imag(self.__getitem__(index))
-        tal = self.ta[0].length - 1
-        # print("t1_max = ", self.ta[0].data[tal])
-        lam = igg[:, tal] / self.ta[0].data[tal]
+        tal = axis.length - 1
+        if numpy.isclose(axis.data[tal], 0.0):
+            return numpy.zeros(igg.shape[0], dtype=igg.dtype)
+        lam = igg[:, tal] / axis.data[tal]
 
         return lam
 

--- a/quantarhei/qm/corfunctions/functionstorage.py
+++ b/quantarhei/qm/corfunctions/functionstorage.py
@@ -218,19 +218,23 @@ class FunctionStorage:
 
         self.variable_index = variable_index
         self.time_expressions = {}
+        self.time_dependencies: dict[str, set[str]] = {}
 
         # find all time arguments and calculate their dimension
         for tstr in self.time_combination_strings:
             terms = _parse_time_label(tstr)
             axes = []
+            dependencies: set[str] = set()
             for _, tm in terms:
                 if tm not in variable_index:
                     raise Exception("Unknown time variable in storage config: " + tm)
+                dependencies.add(tm)
                 axis = variable_index[tm]
                 if axis >= 0 and axis not in axes:
                     axes.append(axis)
 
             self.time_expressions[tstr] = terms
+            self.time_dependencies[tstr] = dependencies
             if len(axes) == 0:
                 time_index[tstr] = -1
             elif len(axes) == 1:
@@ -384,6 +388,8 @@ class FunctionStorage:
 
         # 2D view of the data for fast access
         self._data2d = self.data.reshape((self.N, self.data_stride))
+        self._last_reset_values: dict[str, Any] | None = None
+        self._data_initialized = False
 
         #
         # Here the g(t) functions are stored
@@ -594,6 +600,8 @@ class FunctionStorage:
             if added:
                 self.Nf += 1
 
+        self._data_initialized = False
+
     def _check_and_make_space(self, nn: int) -> None:
         """Check if the required position is outside the allocated mapping
         and if so, make more space.
@@ -627,21 +635,40 @@ class FunctionStorage:
 
         return ret
 
-    def create_data(self, reset: dict | None = None) -> None:
+    def create_data(self, reset: dict | None = None, force: bool = False) -> None:
         """We create data for all submitted functions"""
         if reset is None:
             reset = {"t2": 0.0}
         reset = dict(reset)
+        reset_defaults = getattr(self, "_reset_defaults", {})
         for integral, parent in self.integral_parent.items():
             if integral not in reset:
-                if parent not in reset:
+                if integral in reset_defaults:
+                    reset[integral] = reset_defaults[integral]
+                elif parent not in reset:
                     raise Exception("Parent reset time not specified: " + parent)
-                reset[integral] = reset[parent] / 2.0
+                else:
+                    reset[integral] = reset[parent] / 2.0
+
+        changed_variables = self._changed_reset_variables(reset)
+        if force or not self._data_initialized or self._last_reset_values is None:
+            labels_to_update = list(self.time_index)
+        else:
+            labels_to_update = [
+                label
+                for label in self.time_index
+                if self.time_dependencies[label].intersection(changed_variables)
+            ]
+
+        if not labels_to_update:
+            self._last_reset_values = dict(reset)
+            return
+
         tt_matrix = []
 
         _colon_ = slice(None, None, None)
 
-        for tm in self.time_index:
+        for tm in labels_to_update:
             dms = self.time_index[tm]
             if isinstance(dms, int):
                 axes = [] if dms == -1 else [dms]
@@ -676,8 +703,32 @@ class FunctionStorage:
             func = self.funcs[key]
             # start = key*self.data_stride
 
-            for kk, tm in zip(range(self.Nt), self.time_index):
-                self.__setitem__((key, tm), func(tt_matrix[kk]).reshape(self._N[kk]))
+            for kk, tm in enumerate(labels_to_update):
+                tm_index = self.time_mapping[tm]
+                self.__setitem__(
+                    (key, tm), func(tt_matrix[kk]).reshape(self._N[tm_index])
+                )
+
+        self._last_reset_values = dict(reset)
+        self._data_initialized = True
+
+    def _changed_reset_variables(self, reset: dict) -> set[str]:
+        """Return reset variables whose values differ from the previous call."""
+        if self._last_reset_values is None:
+            return set(reset)
+
+        changed: set[str] = set()
+        for name, value in reset.items():
+            if name not in self._last_reset_values:
+                changed.add(name)
+            elif not numpy.array_equal(value, self._last_reset_values[name]):
+                changed.add(name)
+
+        for name in self._last_reset_values:
+            if name not in reset:
+                changed.add(name)
+
+        return changed
 
     def effective_size(self) -> int:
         """Effective size of the storage. Some stored functions have the same functional form"""

--- a/quantarhei/qm/corfunctions/functionstorage.py
+++ b/quantarhei/qm/corfunctions/functionstorage.py
@@ -86,7 +86,6 @@ def _generate_time_argument_labels(response_times: dict[str, Any]) -> list[str]:
                 replacement_groups.append(variants)
 
             generated: list[list[tuple[int, str]]] = [[]]
-            # generated = [[]]
             for variants in replacement_groups:
                 generated = [
                     base + variant for base in generated for variant in variants
@@ -100,6 +99,18 @@ def _generate_time_argument_labels(response_times: dict[str, Any]) -> list[str]:
         if label not in unique_labels:
             unique_labels.append(label)
     return unique_labels
+
+
+def _default_storage_config(one_jump: bool = False) -> dict[str, Any]:
+    """Return the standard third-order response storage configuration."""
+    t2_integral = {"s2"} if one_jump else None
+    return {
+        "response_times": {
+            "t1": {"reset": False, "integral": None, "axis": 0},
+            "t2": {"reset": True, "integral": t2_integral},
+            "t3": {"reset": False, "integral": None, "axis": 1},
+        }
+    }
 
 
 class FunctionStorage:
@@ -123,7 +134,7 @@ class FunctionStorage:
         timeaxis: Any = None,
         dtype: Any = numpy.complex64,
         show_config: bool = False,
-        config: dict | None = None,
+        config: dict | int | None = None,
     ) -> None:
 
         #
@@ -131,18 +142,15 @@ class FunctionStorage:
         #
         # This dictionary describes what g(t) values will be stored and how
         #
-        if config is None:
-            self.config: dict[str, Any] = {
-                "response_times": {
-                    "t1": {"reset": False, "integral": {"s1"}, "axis": 0},
-                    "t2": {"reset": True, "integral": None},
-                    "t3": {"reset": False, "integral": {"s3"}, "axis": 1},
-                }
-            }  # ,
-            # "t4":{"reset":False,"integral":None,"axis":2}}}
-
-        else:
+        self.config: dict[str, Any]
+        if config is None or config == 0:
+            self.config = _default_storage_config(one_jump=False)
+        elif config == 1:
+            self.config = _default_storage_config(one_jump=True)
+        elif isinstance(config, dict):
             self.config = config
+        else:
+            raise ValueError("FunctionStorage config has to be None, 0, 1, or a dict")
 
         #######################################################################
         #
@@ -175,6 +183,7 @@ class FunctionStorage:
 
         # find all reset times
         reset_times = []
+        self.integral_parent = {}
         for rst_key in self.config["response_times"]:
             if self.config["response_times"][rst_key]["reset"]:
                 reset_times.append(rst_key)
@@ -183,6 +192,7 @@ class FunctionStorage:
                     self.config["response_times"][rst_key].get("integral", None)
                 ):
                     variable_index[integral] = -1
+                    self.integral_parent[integral] = rst_key
 
         # find all 1D times
         oned_times = []
@@ -621,6 +631,12 @@ class FunctionStorage:
         """We create data for all submitted functions"""
         if reset is None:
             reset = {"t2": 0.0}
+        reset = dict(reset)
+        for integral, parent in self.integral_parent.items():
+            if integral not in reset:
+                if parent not in reset:
+                    raise Exception("Parent reset time not specified: " + parent)
+                reset[integral] = reset[parent] / 2.0
         tt_matrix = []
 
         _colon_ = slice(None, None, None)

--- a/quantarhei/qm/liouvillespace/modredfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/modredfieldtensor.py
@@ -4,6 +4,7 @@ import numpy
 
 from ... import COMPLEX
 from ...core.managers import eigenbasis_of, energy_units
+from ...core.wrappers import prevent_basis_context
 
 # import scipy.interpolate as interp
 from ..hilbertspace.hamiltonian import Hamiltonian
@@ -24,6 +25,7 @@ class ModRedfieldRelaxationTensor(RelaxationTensor):
     dim: int
     data: numpy.ndarray
 
+    @prevent_basis_context
     def __init__(
         self,
         ham: Hamiltonian,
@@ -71,13 +73,13 @@ class ModRedfieldRelaxationTensor(RelaxationTensor):
         else:
             self._data_initialized = False
 
+    @prevent_basis_context
     def initialize(self) -> None:
 
         #
         # Tensor data
         #
         Na = self.dim
-        self.data = numpy.zeros((Na, Na, Na, Na), dtype=COMPLEX)
 
         with energy_units("int"):
             HH = self.Hamiltonian
@@ -96,6 +98,11 @@ class ModRedfieldRelaxationTensor(RelaxationTensor):
             )
 
             with eigenbasis_of(HH):
+                cb = self.manager.get_current_basis()
+                self.set_current_basis(cb)
+                self.manager.register_with_basis(cb, self)
+                self.data = numpy.zeros((Na, Na, Na, Na), dtype=COMPLEX)
+
                 #
                 # Transfer rates
                 #

--- a/quantarhei/qm/liouvillespace/rates/tdfoersterrates.py
+++ b/quantarhei/qm/liouvillespace/rates/tdfoersterrates.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import numpy
+import scipy.interpolate as interp
+
+from ....core.time import TimeDependent
+from ...corfunctions.correlationfunctions import c2g
+from ...hilbertspace.hamiltonian import Hamiltonian
+from ...liouvillespace.systembathinteraction import SystemBathInteraction
+
+
+class TDFoersterRateMatrix(TimeDependent):
+    """Time-dependent Förster population relaxation rate matrix.
+
+    The returned data array has shape ``(Nt, N, N)`` and follows the
+    convention ``data[:, a, b]`` is the population transfer rate from state
+    ``b`` to state ``a``. Diagonal elements are depopulation rates.
+    """
+
+    def __init__(
+        self,
+        ham: Hamiltonian,
+        sbi: SystemBathInteraction,
+        initialize: bool = True,
+        cutoff_time: float | None = None,
+    ) -> None:
+
+        if not isinstance(ham, Hamiltonian):
+            raise Exception("First argument must be a Hamiltonian")
+
+        if not isinstance(sbi, SystemBathInteraction):
+            raise Exception("Second argument must be a SystemBathInteraction")
+
+        self._is_initialized = False
+        self._has_cutoff_time = False
+        self.is_time_dependent = True
+
+        if cutoff_time is not None:
+            self.cutoff_time = cutoff_time
+            self._has_cutoff_time = True
+
+        self.ham = ham
+        self.sbi = sbi
+
+        if initialize:
+            self.initialize()
+            self._is_initialized = True
+
+    def initialize(self) -> None:
+        """Calculates time-dependent Förster population rates."""
+        time = self.sbi.TimeAxis
+        assert time is not None, "SystemBathInteraction must have a TimeAxis set"
+
+        tt = time.data
+        Nt = time.length
+        HH = self.ham.data
+        Na = self.ham.dim
+
+        cc = self.sbi.CC
+        assert cc is not None, "SystemBathInteraction must have CC set"
+
+        gt = numpy.zeros((Na, Nt), dtype=numpy.complex64)
+        for ii in range(1, Na):
+            gt[ii, :] = c2g(time, cc.get_coft(ii - 1, ii - 1))
+
+        ll = numpy.zeros(Na)
+        for ii in range(1, Na):
+            ll[ii] = cc.get_reorganization_energy(ii - 1, ii - 1)
+
+        self.data = _td_reference_implementation(Na, Nt, HH, tt, gt, ll, _td_fintegral)
+
+        for bb in range(Na):
+            self.data[:, bb, bb] = -numpy.sum(self.data[:, :, bb], axis=1)
+
+        self._is_initialized = True
+
+
+def _td_reference_implementation(
+    Na: int,
+    Nt: int,
+    HH: numpy.ndarray,
+    tt: numpy.ndarray,
+    gt: numpy.ndarray,
+    ll: numpy.ndarray,
+    fce: Callable[..., numpy.ndarray],
+) -> numpy.ndarray:
+
+    #
+    # Rates between states a and b
+    #
+    KK = numpy.zeros((Nt, Na, Na), dtype=numpy.float64)
+    for a in range(Na):
+        for b in range(Na):
+            if a != b:
+                ed = HH[b, b]  # donor
+                ea = HH[a, a]  # acceptor
+                KK[:, a, b] = (HH[a, b] ** 2) * fce(
+                    tt, gt[a, :], gt[b, :], ed, ea, ll[b]
+                )
+
+    return KK
+
+
+def _td_fintegral(
+    tt: numpy.ndarray,
+    gtd: numpy.ndarray,
+    gta: numpy.ndarray,
+    ed: float,
+    ea: float,
+    ld: float,
+) -> numpy.ndarray:
+    """Time dependent Foerster integral
+
+
+    Parameters
+    ----------
+    tt : numpy array
+        Time
+
+    gtd : numpy array
+        lineshape function of the donor transition
+
+    gta : numpy array
+        lineshape function of the acceptor transition
+
+    ed : float
+        Energy of the donor transition
+
+    ea : float
+        Energy of the acceptor transition
+
+    ld : float
+        Reorganization energy of the donor
+
+    Returns
+    -------
+    ret : float
+        The value of the Foerster integral
+
+    """
+    prod = numpy.exp(-gtd - gta + 1j * ((ed - ea) - 2.0 * ld) * tt)
+
+    preal = numpy.real(prod)
+    pimag = numpy.imag(prod)
+    splr = interp.UnivariateSpline(tt, preal, s=0).antiderivative()(tt)
+    spli = interp.UnivariateSpline(tt, pimag, s=0).antiderivative()(tt)
+    hoft = splr + 1j * spli
+
+    ret = 2.0 * numpy.real(hoft)
+
+    return ret

--- a/quantarhei/qm/liouvillespace/systembathinteraction.py
+++ b/quantarhei/qm/liouvillespace/systembathinteraction.py
@@ -107,6 +107,7 @@ class SystemBathInteraction(Saveable):
         self.sbitype = "Linear_Coupling"
 
         self._has_gg_storage = False
+        self._gg_storage_config: dict | int | None = None
 
         #
         # version with bath correlation functions
@@ -329,7 +330,7 @@ class SystemBathInteraction(Saveable):
         assert self.CC is not None
         return self.CC._cofts[0, :]
 
-    def get_goft_storage(self, config: dict | None = None) -> Any:
+    def get_goft_storage(self, config: dict | int | None = None) -> Any:
         """Returns a lineshape function storage based on correlation functions
 
         The function calculates g(t) fuctions based on the correlation
@@ -343,7 +344,9 @@ class SystemBathInteraction(Saveable):
             it wil produced g(t) for a standard 3rd order response calculation.
 
         """
-        if self._has_gg_storage:
+        if self._has_gg_storage and (
+            config is None or config == self._gg_storage_config
+        ):
             return self.GG
 
         # number of functions
@@ -380,6 +383,7 @@ class SystemBathInteraction(Saveable):
 
         self.GG = gg
         self._has_gg_storage = True
+        self._gg_storage_config = config
 
         return gg
 

--- a/quantarhei/qm/liouvillespace/systembathinteraction.py
+++ b/quantarhei/qm/liouvillespace/systembathinteraction.py
@@ -330,7 +330,9 @@ class SystemBathInteraction(Saveable):
         assert self.CC is not None
         return self.CC._cofts[0, :]
 
-    def get_goft_storage(self, config: dict | int | None = None) -> Any:
+    def get_goft_storage(
+        self, config: dict | int | None = None, timeaxis: Any = None
+    ) -> Any:
         """Returns a lineshape function storage based on correlation functions
 
         The function calculates g(t) fuctions based on the correlation
@@ -344,8 +346,11 @@ class SystemBathInteraction(Saveable):
             it wil produced g(t) for a standard 3rd order response calculation.
 
         """
-        if self._has_gg_storage and (
-            config is None or config == self._gg_storage_config
+        using_default_timeaxis = timeaxis is None
+        if (
+            using_default_timeaxis
+            and self._has_gg_storage
+            and (config is None or config == self._gg_storage_config)
         ):
             return self.GG
 
@@ -357,7 +362,9 @@ class SystemBathInteraction(Saveable):
 
         # we define storage for lineshape functions with prescribed config
         # FIXME: orinally I had Nb here, but that is wrong. Nf also does not work
-        gg = FunctionStorage(Nf, timeaxis=[self.TimeAxis, self.TimeAxis], config=config)
+        if using_default_timeaxis:
+            timeaxis = [self.TimeAxis, self.TimeAxis]
+        gg = FunctionStorage(Nf, timeaxis=timeaxis, config=config)
 
         # create functions to update storage
         fcions = {}
@@ -381,9 +388,10 @@ class SystemBathInteraction(Saveable):
         if Nf != gg.get_number_of_functions():
             raise Exception("Number of functions did not conserve in g(t) calculation")
 
-        self.GG = gg
-        self._has_gg_storage = True
-        self._gg_storage_config = config
+        if using_default_timeaxis:
+            self.GG = gg
+            self._has_gg_storage = True
+            self._gg_storage_config = config
 
         return gg
 

--- a/quantarhei/qm/liouvillespace/tdfoerstertensor.py
+++ b/quantarhei/qm/liouvillespace/tdfoerstertensor.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-
 import numpy
 import numpy.typing
 
 # import matplotlib.pyplot as plt
-import scipy.interpolate as interp
-
 from ...core.managers import energy_units
 from ...core.time import TimeDependent
 from ..corfunctions.correlationfunctions import c2g
 from ..hilbertspace.hamiltonian import Hamiltonian
 from ..liouvillespace.systembathinteraction import SystemBathInteraction
 from .foerstertensor import FoersterRelaxationTensor
+from .rates.tdfoersterrates import _td_fintegral, _td_reference_implementation
 
 
 class TDFoersterRelaxationTensor(FoersterRelaxationTensor, TimeDependent):
@@ -123,79 +120,3 @@ class TDFoersterRelaxationTensor(FoersterRelaxationTensor, TimeDependent):
         ll: numpy.ndarray,
     ) -> numpy.ndarray:
         return _td_reference_implementation(Na, Nt, HH, tt, gt, ll, _td_fintegral)
-
-
-def _td_reference_implementation(
-    Na: int,
-    Nt: int,
-    HH: numpy.ndarray,
-    tt: numpy.ndarray,
-    gt: numpy.ndarray,
-    ll: numpy.ndarray,
-    fce: Callable[..., numpy.ndarray],
-) -> numpy.ndarray:
-
-    #
-    # Rates between states a and b
-    #
-    KK = numpy.zeros((Nt, Na, Na), dtype=numpy.float64)
-    for a in range(Na):
-        for b in range(Na):
-            if a != b:
-                ed = HH[b, b]  # donor
-                ea = HH[a, a]  # acceptor
-                KK[:, a, b] = (HH[a, b] ** 2) * fce(
-                    tt, gt[a, :], gt[b, :], ed, ea, ll[b]
-                )
-
-    return KK
-
-
-def _td_fintegral(
-    tt: numpy.ndarray,
-    gtd: numpy.ndarray,
-    gta: numpy.ndarray,
-    ed: float,
-    ea: float,
-    ld: float,
-) -> numpy.ndarray:
-    """Time dependent Foerster integral
-
-
-    Parameters
-    ----------
-    tt : numpy array
-        Time
-
-    gtd : numpy array
-        lineshape function of the donor transition
-
-    gta : numpy array
-        lineshape function of the acceptor transition
-
-    ed : float
-        Energy of the donor transition
-
-    ea : float
-        Energy of the acceptor transition
-
-    ld : float
-        Reorganization energy of the donor
-
-    Returns
-    -------
-    ret : float
-        The value of the Foerster integral
-
-    """
-    prod = numpy.exp(-gtd - gta + 1j * ((ed - ea) - 2.0 * ld) * tt)
-
-    preal = numpy.real(prod)
-    pimag = numpy.imag(prod)
-    splr = interp.UnivariateSpline(tt, preal, s=0).antiderivative()(tt)
-    spli = interp.UnivariateSpline(tt, pimag, s=0).antiderivative()(tt)
-    hoft = splr + 1j * spli
-
-    ret = 2.0 * numpy.real(hoft)
-
-    return ret

--- a/quantarhei/qm/liouvillespace/tdmodredfieldtensor.py
+++ b/quantarhei/qm/liouvillespace/tdmodredfieldtensor.py
@@ -6,11 +6,11 @@ import numpy
 
 from ... import COMPLEX, REAL
 from ...core.managers import eigenbasis_of, energy_units
-
-# from .rates.foersterrates import FoersterRateMatrix
 from ...core.time import TimeDependent
+from ...core.wrappers import prevent_basis_context
 
 # import scipy.interpolate as interp
+# from .rates.foersterrates import FoersterRateMatrix
 from ..hilbertspace.hamiltonian import Hamiltonian
 from ..liouvillespace.systembathinteraction import SystemBathInteraction
 from .relaxationtensor import RelaxationTensor
@@ -21,6 +21,7 @@ class TDModRedfieldRelaxationTensor(RelaxationTensor, TimeDependent):
 
     dim: int
 
+    @prevent_basis_context
     def __init__(
         self,
         ham: Hamiltonian,
@@ -65,6 +66,7 @@ class TDModRedfieldRelaxationTensor(RelaxationTensor, TimeDependent):
 
         self.is_time_dependent = True
 
+    @prevent_basis_context
     def initialize(self) -> None:
 
         tdep = True
@@ -93,8 +95,10 @@ class TDModRedfieldRelaxationTensor(RelaxationTensor, TimeDependent):
             self.data = numpy.zeros(
                 (timea.length, Na + 1, Na + 1, Na + 1, Na + 1), dtype=COMPLEX
             )
+            self.Iterm = numpy.zeros((timea.length, Na + 1, Na + 1), dtype=COMPLEX)
         else:
             self.data = numpy.zeros((Na + 1, Na + 1, Na + 1, Na + 1), dtype=COMPLEX)
+            self.Iterm = numpy.zeros((Na + 1, Na + 1), dtype=COMPLEX)
 
         with energy_units("int"):
             for ii in range(Na):
@@ -123,6 +127,10 @@ class TDModRedfieldRelaxationTensor(RelaxationTensor, TimeDependent):
             # Transfer rates
             #
             with eigenbasis_of(HH):
+                cb = self.manager.get_current_basis()
+                self.set_current_basis(cb)
+                self.manager.register_with_basis(cb, self)
+
                 for aa in range(self.dim):
                     for bb in range(self.dim):
                         self.Iterm[:, aa, bb] = Iterm[aa, bb, :]

--- a/quantarhei/spectroscopy/pumpprobe.py
+++ b/quantarhei/spectroscopy/pumpprobe.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy
 import scipy
 
-from .. import COMPLEX
+from .. import COMPLEX, signal_TOTL
 from ..builders.aggregates import Aggregate
 from ..builders.molecules import Molecule
 from ..core.dfunction import DFunction
@@ -17,6 +17,7 @@ from ..core.time import TimeAxis
 from ..core.units import convert
 from ..utils import derived_type
 from .mocktwodcalculator import MockTwoDResponseCalculator as MockTwoDSpectrumCalculator
+from .responses import NonLinearResponse
 from .twodcontainer import TwoDSpectrumContainer
 
 
@@ -67,6 +68,26 @@ class PumpProbeSpectrum(DFunction):
             self.data += data
 
     # FIXME: Add function _add_data (if data None = set_data, else add)
+
+
+class _RWAOverrideSystem:
+    """Delegates to a system while overriding the response-backend RWA."""
+
+    def __init__(self, system: Any, rwa: Any, lineshape_timeaxis: Any = None) -> None:
+        self._system = system
+        self._rwa = rwa
+        self._lineshape_timeaxis = lineshape_timeaxis
+
+    def get_RWA_suggestion(self) -> Any:
+        return self._rwa
+
+    def get_lineshape_functions(self, config: dict | int | None = None) -> Any:
+        return self._system.get_lineshape_functions(
+            config=config, timeaxis=self._lineshape_timeaxis
+        )
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._system, name)
 
 
 class PumpProbeSpectrumContainer(TwoDSpectrumContainer):
@@ -340,10 +361,31 @@ class PumpProbeSpectrumCalculator:
         rate_matrix: Any = None,
         effective_hamiltonian: Any = None,
         separate_relax_pwy: bool = True,
+        population_propagator: Any = None,
+        density_matrix_propagator: Any = None,
+        density_matrix_trajectory: Any = None,
+        population_time_axis: Any = None,
+        include_nonsecular_remainder: bool = True,
+        include_remainder: bool = True,
+        dipole_normalization_tol: float = 1.0e-12,
     ) -> None:
 
         self.t2axis = t2axis
         self.t3axis = t3axis
+
+        external_count = sum(
+            item is not None
+            for item in (
+                population_propagator,
+                density_matrix_propagator,
+                density_matrix_trajectory,
+            )
+        )
+        if external_count > 1:
+            raise ValueError(
+                "population_propagator, density_matrix_propagator, and "
+                "density_matrix_trajectory are mutually exclusive"
+            )
 
         if system is not None:
             self.system = copy.deepcopy(system)
@@ -379,6 +421,13 @@ class PumpProbeSpectrumCalculator:
         self.t3s: Any = None
         self.pathways: Any = None
         self.rwa: Any = None
+        self.density_matrix_trajectory: Any = density_matrix_trajectory
+        self.population_propagator: Any = population_propagator
+        self.density_matrix_propagator: Any = density_matrix_propagator
+        self.population_time_axis: Any = population_time_axis
+        self.include_nonsecular_remainder = include_nonsecular_remainder
+        self.include_remainder = include_remainder
+        self.dipole_normalization_tol = dipole_normalization_tol
 
         self.verbose = False
 
@@ -436,6 +485,61 @@ class PumpProbeSpectrumCalculator:
 
     def set_pathways(self, pathways: Any) -> None:
         self.pathways = pathways
+
+    def set_density_matrix_trajectory(
+        self, density_matrix_trajectory: Any, timeaxis: Any = None
+    ) -> None:
+        """Set an externally calculated density-matrix trajectory."""
+        self.density_matrix_trajectory = density_matrix_trajectory
+        self.population_propagator = None
+        self.density_matrix_propagator = None
+        self.population_time_axis = timeaxis
+
+    def set_population_propagator(
+        self, population_propagator: Any, timeaxis: Any = None
+    ) -> None:
+        """Set an externally calculated one-exciton population propagator."""
+        self.population_propagator = population_propagator
+        self.density_matrix_trajectory = None
+        self.density_matrix_propagator = None
+        self.population_time_axis = timeaxis
+
+    def set_density_matrix_propagator(
+        self, density_matrix_propagator: Any, timeaxis: Any = None
+    ) -> None:
+        """Set an externally calculated one-exciton density-matrix propagator."""
+        self.density_matrix_propagator = density_matrix_propagator
+        self.density_matrix_trajectory = None
+        self.population_propagator = None
+        self.population_time_axis = timeaxis
+
+    def set_dynamics(
+        self,
+        density_matrix_trajectory: Any = None,
+        population_propagator: Any = None,
+        density_matrix_propagator: Any = None,
+        timeaxis: Any = None,
+    ) -> None:
+        """Set exactly one external dynamics object for response-backend PP."""
+        dynamics_count = sum(
+            item is not None
+            for item in (
+                density_matrix_trajectory,
+                population_propagator,
+                density_matrix_propagator,
+            )
+        )
+        if dynamics_count != 1:
+            raise ValueError(
+                "Exactly one of density_matrix_trajectory, population_propagator, "
+                "or density_matrix_propagator has to be supplied"
+            )
+        if density_matrix_trajectory is not None:
+            self.set_density_matrix_trajectory(density_matrix_trajectory, timeaxis)
+        elif population_propagator is not None:
+            self.set_population_propagator(population_propagator, timeaxis)
+        else:
+            self.set_density_matrix_propagator(density_matrix_propagator, timeaxis)
 
     def bath_reorg(self, cfm: Any, indx: Any) -> float:
         coft = cfm.cfuncs[cfm.get_index_by_where((indx, indx))]
@@ -532,6 +636,8 @@ class PumpProbeSpectrumCalculator:
         show_progress: bool = False,
         approx: Any = None,
         spec: Any = None,
+        gsb_mode: str = "hole",
+        orientational_averaging: str = "legacy",
     ) -> Any:
         """Calculates all 2D spectra for a system and reduced density matrix
         evolution. The approach assumes no diiference between pathways with
@@ -599,10 +705,25 @@ class PumpProbeSpectrumCalculator:
 
             if approx == "Novoderezhkin":
                 ppspec1 = self.calculate_pathways_rdm_novoderezhkin(
-                    rdm0, rdm, T2, lab, ptol=1.0e-6, spec=spec
+                    rdm0,
+                    rdm,
+                    T2,
+                    lab,
+                    ptol=1.0e-6,
+                    spec=spec,
+                    gsb_mode=gsb_mode,
+                    orientational_averaging=orientational_averaging,
                 )
             else:
-                ppspec1 = self.calculate_pathways_rdm(rdm0, rdm, T2, lab, spec=spec)
+                ppspec1 = self.calculate_pathways_rdm(
+                    rdm0,
+                    rdm,
+                    T2,
+                    lab,
+                    spec=spec,
+                    gsb_mode=gsb_mode,
+                    orientational_averaging=orientational_averaging,
+                )
 
             tcont.set_spectrum(ppspec1, tag=T2)
 
@@ -612,6 +733,294 @@ class PumpProbeSpectrumCalculator:
             )
 
         return tcont
+
+    def _response_backend_trace(self, diagrams: list[str], tau: float, lab: Any) -> Any:
+        """Calculate selected response-backend diagrams as a t3 trace at t1 = 0."""
+        t1axis = TimeAxis(0.0, 1, self.t3axis.step)
+        backend_system = _RWAOverrideSystem(
+            self.system, self.rwa, lineshape_timeaxis=[t1axis, self.t3axis]
+        )
+
+        response = numpy.zeros(self.t3axis.length, dtype=numpy.complex128)
+        for diagram in diagrams:
+            rsp = NonLinearResponse(
+                lab,
+                backend_system,
+                diagram,
+                t1axis,
+                self.t2axis,
+                self.t3axis,
+            )
+            response += numpy.ravel(numpy.asarray(rsp.calculate_matrix(tau)))
+
+        return response
+
+    def _full_dipole_rdm_weight(
+        self, rdm: Any, ii: int, jj: int, tol: float = 1.0e-12
+    ) -> Any:
+        """Return RDM element normalized by the two preparation dipole lengths."""
+        norm_i = numpy.linalg.norm(self.system.DD[ii, 0, :])
+        norm_j = numpy.linalg.norm(self.system.DD[jj, 0, :])
+        norm = norm_i * norm_j
+        if numpy.abs(norm) <= tol:
+            raise ValueError(
+                "Cannot normalize density matrix element by zero transition "
+                "dipole length"
+            )
+        return rdm[ii, jj] / norm
+
+    def _four_dipole_prefactors(self, lab: Any) -> dict[str, Any]:
+        """Return full orientational prefactors used by response functions."""
+        prefactors = {}
+        for key in ("abba", "baba"):
+            prefactors[key] = numpy.einsum(
+                "i,abi->ab", lab.F4eM4, self.system.get_F4d(key)
+            )
+        if self.system.mult > 1:
+            for key in ("fbfaba", "fafbba"):
+                prefactors[key] = numpy.einsum(
+                    "i,fabi->fab", lab.F4eM4, self.system.get_F4d(key)
+                )
+        return prefactors
+
+    def _response_backend_to_pump_probe(
+        self, response: numpy.ndarray, tau: float
+    ) -> Any:
+        """Fourier transform a t1=0 response trace into a pump-probe spectrum."""
+        onepp = PumpProbeSpectrum()
+        onepp.set_axis(self.oa3)
+
+        ppspec = -numpy.asarray(response, dtype=numpy.complex128)
+        ft = numpy.fft.hfft(ppspec) * self.t3axis.step
+        ft = numpy.fft.fftshift(ft)
+        ft = numpy.flipud(ft)
+        Nt = self.t3axis.length
+
+        data = numpy.real(ft[Nt // 2 : Nt + Nt // 2])
+        data = self.oa3.data * data
+
+        onepp._add_data(data)
+        onepp.set_t2(tau)
+        return onepp
+
+    def calculate_all_system_approx_response_backend(
+        self,
+        sys: Any,
+        rdmt: Any = None,
+        lab: Any = None,
+        show_progress: bool = False,
+        spec: Any = None,
+        population_propagator: Any = None,
+        density_matrix_propagator: Any = None,
+        population_time_axis: Any = None,
+        include_nonsecular_remainder: bool = True,
+        include_remainder: bool = True,
+        dipole_normalization_tol: float = 1.0e-12,
+    ) -> Any:
+        """Calculate pump-probe spectra through the modern response backend.
+
+        This method is a pump-probe-like ``t1 = 0`` calculation.  The supplied
+        dynamics can be a reduced-density-matrix trajectory, a one-exciton
+        population propagator, or a one-exciton density-matrix propagator.
+        """
+        if spec is None:
+            spec = ["Full"]
+        if lab is None:
+            raise ValueError("A lab setup has to be supplied")
+        dynamics_count = sum(
+            item is not None
+            for item in (rdmt, population_propagator, density_matrix_propagator)
+        )
+        if dynamics_count != 1:
+            raise ValueError(
+                "Exactly one of rdmt, population_propagator, or "
+                "density_matrix_propagator has to be supplied"
+            )
+        if not numpy.isclose(lab.F4eM4[1:], [0, 0], atol=1e-6).all():
+            message = (
+                "Lab is not set to the magic angle polarization which is"
+                "the only supported measurement setting for this calculation. Set "
+                "polarization angle between first two pulses and the last two to"
+                "54.7356103 deg. and repeat the calculation."
+            )
+            raise OSError(message)
+
+        self.system = copy.deepcopy(sys)
+        if not self.system._diagonalized:
+            self.system.diagonalize()
+
+        t1axis = TimeAxis(0.0, 1, self.t3axis.step)
+        backend_system = _RWAOverrideSystem(
+            self.system, self.rwa, lineshape_timeaxis=[t1axis, self.t3axis]
+        )
+        response_types = []
+        if "Full" in spec or "SE" in spec:
+            response_types.extend(["R1g", "R2g"])
+        if "Full" in spec or "GSB" in spec:
+            response_types.extend(["R3g", "R4g"])
+        if self.system.mult > 1 and ("Full" in spec or "ESA" in spec):
+            response_types.extend(["R1f", "R2f"])
+
+        if population_time_axis is None:
+            population_time_axis = self.t2axis
+        response_kwargs: dict[str, Any] = dict(
+            population_time_axis=population_time_axis
+        )
+        if rdmt is not None:
+            response_kwargs["density_matrix_trajectory"] = rdmt
+            response_kwargs["dipole_normalization_tol"] = dipole_normalization_tol
+        elif population_propagator is not None:
+            response_kwargs["population_propagator"] = population_propagator
+        else:
+            response_kwargs["density_matrix_propagator"] = density_matrix_propagator
+            response_kwargs["include_nonsecular_remainder"] = (
+                include_nonsecular_remainder
+            )
+
+        if include_remainder and rdmt is None:
+            if "Full" in spec or "SE" in spec:
+                response_types.extend(["R1g_scM0g", "R2g_scM0g"])
+            if self.system.mult > 1 and ("Full" in spec or "ESA" in spec):
+                response_types.extend(
+                    ["R1f_scM0g", "R2f_scM0g", "R1f_scM0e", "R2f_scM0e"]
+                )
+
+        responses = [
+            NonLinearResponse(
+                lab,
+                backend_system,
+                diagram,
+                t1axis,
+                self.t2axis,
+                self.t3axis,
+                **response_kwargs,
+            )
+            for diagram in response_types
+        ]
+
+        tcont = PumpProbeSpectrumContainer(t2axis=self.t2axis)
+
+        kk = 0
+        Nk = self.t2axis.length
+        printProgressBar(
+            kk, Nk, prefix="     - Progress:", suffix="Complete", length=50
+        )
+
+        for T2 in self.t2axis.data:
+            if show_progress:
+                print(" - calculating", kk, "of", Nk, "at t2 =", T2, "fs")
+
+            response = numpy.zeros(self.t3axis.length, dtype=numpy.complex128)
+            for rsp in responses:
+                data = numpy.asarray(rsp.calculate_matrix(T2))
+                response += numpy.ravel(data)
+
+            ppspec1 = self._response_backend_to_pump_probe(response, T2)
+            tcont.set_spectrum(ppspec1, tag=T2)
+
+            kk += 1
+            printProgressBar(
+                kk, Nk, prefix="     - Progress:", suffix="Complete", length=50
+            )
+
+        return tcont
+
+    def calculate(
+        self,
+        system: Any = None,
+        lab: Any = None,
+        density_matrix_trajectory: Any = None,
+        population_propagator: Any = None,
+        density_matrix_propagator: Any = None,
+        population_time_axis: Any = None,
+        method: str = "response",
+        show_progress: bool = False,
+        spec: Any = None,
+        include_nonsecular_remainder: bool | None = None,
+        include_remainder: bool | None = None,
+        dipole_normalization_tol: float | None = None,
+        approx: Any = None,
+        gsb_mode: str = "hole",
+        orientational_averaging: str = "legacy",
+    ) -> Any:
+        """Calculate pump-probe spectra with the selected backend.
+
+        Parameters
+        ----------
+        system : Aggregate, optional
+            System to calculate. If omitted, the calculator's stored system is
+            used.
+        lab : LabSetup, optional
+            Laboratory setup. If omitted, the setup supplied to ``bootstrap`` is
+            used.
+        density_matrix_trajectory, population_propagator, density_matrix_propagator
+            Optional external dynamics. If omitted, dynamics previously set by
+            ``set_dynamics`` or one of the specialized setters are used.
+        method : {"response", "legacy"}
+            ``"response"`` uses the modern nonlinear-response backend.
+            ``"legacy"`` uses the old RDM pump-probe implementation.
+        """
+        if system is None:
+            system = self.system
+        if lab is None:
+            lab = self.lab
+        if lab is None:
+            raise ValueError("A lab setup has to be supplied or bootstrapped")
+
+        if population_time_axis is None:
+            population_time_axis = self.population_time_axis
+        if density_matrix_trajectory is None:
+            density_matrix_trajectory = self.density_matrix_trajectory
+        if population_propagator is None:
+            population_propagator = self.population_propagator
+        if density_matrix_propagator is None:
+            density_matrix_propagator = self.density_matrix_propagator
+        if include_nonsecular_remainder is None:
+            include_nonsecular_remainder = self.include_nonsecular_remainder
+        if include_remainder is None:
+            include_remainder = self.include_remainder
+        if dipole_normalization_tol is None:
+            dipole_normalization_tol = self.dipole_normalization_tol
+
+        if method in ("response", "modern"):
+            return self.calculate_all_system_approx_response_backend(
+                system,
+                rdmt=density_matrix_trajectory,
+                lab=lab,
+                show_progress=show_progress,
+                spec=spec,
+                population_propagator=population_propagator,
+                density_matrix_propagator=density_matrix_propagator,
+                population_time_axis=population_time_axis,
+                include_nonsecular_remainder=include_nonsecular_remainder,
+                include_remainder=include_remainder,
+                dipole_normalization_tol=dipole_normalization_tol,
+            )
+
+        if method == "legacy":
+            if density_matrix_trajectory is None:
+                raise ValueError(
+                    "Legacy pump-probe calculation requires density_matrix_trajectory"
+                )
+            if (
+                population_propagator is not None
+                or density_matrix_propagator is not None
+            ):
+                raise ValueError(
+                    "Legacy pump-probe calculation does not accept propagators"
+                )
+            return self.calculate_all_system_approx(
+                system,
+                density_matrix_trajectory,
+                lab,
+                show_progress=show_progress,
+                approx=approx,
+                spec=spec,
+                gsb_mode=gsb_mode,
+                orientational_averaging=orientational_averaging,
+            )
+
+        raise ValueError("method has to be 'response' or 'legacy'")
 
     def calculate_all_system(
         self, sys: Any, eUt: Any, lab: Any, show_progress: bool = False
@@ -1376,6 +1785,8 @@ class PumpProbeSpectrumCalculator:
         lab: Any,
         ptol: float = 1.0e-6,
         spec: Any = None,
+        gsb_mode: str = "hole",
+        orientational_averaging: str = "legacy",
     ) -> Any:
         """Calculate the shape of a Liouville pathway
         so far implemented only for electronic
@@ -1383,6 +1794,12 @@ class PumpProbeSpectrumCalculator:
         """
         if spec is None:
             spec = ["Full"]
+        if gsb_mode not in ("hole", "response"):
+            raise ValueError("gsb_mode has to be 'hole' or 'response'")
+        if orientational_averaging not in ("legacy", "four_dipole"):
+            raise ValueError(
+                "orientational_averaging has to be 'legacy' or 'four_dipole'"
+            )
         onepp = PumpProbeSpectrum()
         onepp.set_axis(self.oa3)
 
@@ -1408,27 +1825,35 @@ class PumpProbeSpectrumCalculator:
         # the eigenbais => self.system.DD[nf,ni,:] would be proper transition
         # dipoles between eigenstates.
         dim = self.system.Nb[1] + self.system.Nb[0]
+        N0 = self.system.Nb[0]
+        N1 = self.system.Nb[1]
+        full_pref = None
+        if orientational_averaging == "four_dipole":
+            full_pref = self._four_dipole_prefactors(lab)
 
         # GSB (Ground state bleach)
         if "Full" in spec or "GSB" in spec:
-            for jj in range(1, dim):
-                pref_GSB = lab.F4eM4[0]
-                pref_GSB *= 2  # There are two pathways leading to the same results R3 and R4 (therefore twice)
-                pref_GSB *= numpy.sum(
-                    numpy.diag(rdm0)
-                )  # The GSB signal is dependent only on the last state
-                # => prefactor can be computed as a sum before
-                pref_GSB *= numpy.dot(
-                    self.system.DD[jj, 0, :], self.system.DD[jj, 0, :]
-                )
+            if gsb_mode == "response":
+                ppspec += self._response_backend_trace(["R3g", "R4g"], tau, lab)
+            else:
+                for jj in range(1, dim):
+                    pref_GSB = lab.F4eM4[0]
+                    pref_GSB *= 2  # There are two pathways leading to the same results R3 and R4 (therefore twice)
+                    pref_GSB *= numpy.sum(
+                        numpy.diag(rdm0)
+                    )  # The GSB signal is dependent only on the last state
+                    # => prefactor can be computed as a sum before
+                    pref_GSB *= numpy.dot(
+                        self.system.DD[jj, 0, :], self.system.DD[jj, 0, :]
+                    )
 
-                om = self.system.HH[jj, jj] - self.system.HH[0, 0] - self.rwa
-                omtau = 0  # during the t2 time bra and ket both in the ground state
+                    om = self.system.HH[jj, jj] - self.system.HH[0, 0] - self.rwa
+                    omtau = 0  # during the t2 time bra and ket both in the ground state
 
-                ft = -1j * om * self.t3axis.data - 1j * omtau * tau
+                    ft = -1j * om * self.t3axis.data - 1j * omtau * tau
 
-                ft -= gt3s[jj, jj]
-                ppspec += pref_GSB * numpy.exp(ft)
+                    ft -= gt3s[jj, jj]
+                    ppspec += pref_GSB * numpy.exp(ft)
 
         # SE
         if "Full" in spec or "SE" in spec:
@@ -1442,14 +1867,25 @@ class PumpProbeSpectrumCalculator:
                     state = [ii, jj]
                     omtau = self.system.HH[ii, ii] - self.system.HH[jj, jj]
 
-                    pref_SE = lab.F4eM4[0]
-                    pref_SE *= 2  # There are two pathways leading to the same results R1 and R2 (therefore twice)
-                    pref_SE *= rdm[
-                        ii, jj
-                    ]  # It should include excitation weighted by evolution
-                    pref_SE *= numpy.dot(
-                        self.system.DD[ii, 0, :], self.system.DD[jj, 0, :]
-                    )
+                    if orientational_averaging == "four_dipole":
+                        assert full_pref is not None
+                        a = ii - N0
+                        b = jj - N0
+                        pref_SE = self._full_dipole_rdm_weight(rdm, ii, jj)
+                        pref_SE *= full_pref["abba"][b, a]
+                        pref_SE += (
+                            self._full_dipole_rdm_weight(rdm, ii, jj)
+                            * full_pref["baba"][b, a]
+                        )
+                    else:
+                        pref_SE = lab.F4eM4[0]
+                        pref_SE *= 2  # There are two pathways leading to the same results R1 and R2 (therefore twice)
+                        pref_SE *= rdm[
+                            ii, jj
+                        ]  # It should include excitation weighted by evolution
+                        pref_SE *= numpy.dot(
+                            self.system.DD[ii, 0, :], self.system.DD[jj, 0, :]
+                        )
 
                     ft = -1j * om * self.t3axis.data - 1j * omtau * tau
 
@@ -1480,14 +1916,26 @@ class PumpProbeSpectrumCalculator:
                         om = self.system.HH[ll, ll] - self.system.HH[jj, jj] - self.rwa
                         omtau = self.system.HH[ii, ii] - self.system.HH[jj, jj]
 
-                        pref_ESA = lab.F4eM4[0]
-                        pref_ESA *= 2  # There are two pathways leading to the same results R1* and R2* (therefore twice)
-                        pref_ESA *= rdm[
-                            ii, jj
-                        ]  # It should include excitation weighted by evolution
-                        pref_ESA *= numpy.dot(
-                            self.system.DD[ll, ii, :], self.system.DD[jj, ll, :]
-                        )
+                        if orientational_averaging == "four_dipole":
+                            assert full_pref is not None
+                            a = ii - N0
+                            b = jj - N0
+                            f = ll - N0 - N1
+                            pref_ESA = self._full_dipole_rdm_weight(rdm, ii, jj)
+                            pref_ESA *= full_pref["fbfaba"][f, b, a]
+                            pref_ESA += (
+                                self._full_dipole_rdm_weight(rdm, ii, jj)
+                                * full_pref["fafbba"][f, b, a]
+                            )
+                        else:
+                            pref_ESA = lab.F4eM4[0]
+                            pref_ESA *= 2  # There are two pathways leading to the same results R1* and R2* (therefore twice)
+                            pref_ESA *= rdm[
+                                ii, jj
+                            ]  # It should include excitation weighted by evolution
+                            pref_ESA *= numpy.dot(
+                                self.system.DD[ll, ii, :], self.system.DD[jj, ll, :]
+                            )
 
                         Fl = ll
                         Ek = jj
@@ -1541,6 +1989,8 @@ class PumpProbeSpectrumCalculator:
         lab: Any,
         ptol: float = 1.0e-6,
         spec: Any = None,
+        gsb_mode: str = "hole",
+        orientational_averaging: str = "legacy",
     ) -> Any:
         """Calculate the shape of a Liouville pathway
         so far implemented only for electronic
@@ -1548,6 +1998,12 @@ class PumpProbeSpectrumCalculator:
         """
         if spec is None:
             spec = ["Full"]
+        if gsb_mode not in ("hole", "response"):
+            raise ValueError("gsb_mode has to be 'hole' or 'response'")
+        if orientational_averaging not in ("legacy", "four_dipole"):
+            raise ValueError(
+                "orientational_averaging has to be 'legacy' or 'four_dipole'"
+            )
         onepp = PumpProbeSpectrum()
         onepp.set_axis(self.oa3)
 
@@ -1577,26 +2033,34 @@ class PumpProbeSpectrumCalculator:
         # the eigenbais => self.system.DD[nf,ni,:] would be proper transition
         # dipoles between eigenstates.
         dim = self.system.Nb[1] + self.system.Nb[0]
+        N0 = self.system.Nb[0]
+        N1 = self.system.Nb[1]
+        full_pref = None
+        if orientational_averaging == "four_dipole":
+            full_pref = self._four_dipole_prefactors(lab)
 
         # GSB (Ground state bleach)
         if "Full" in spec or "GSB" in spec:
-            for jj in range(1, dim):
-                pref_GSB = lab.F4eM4[0]
-                pref_GSB *= 2  # There are two pathways leading to the same results R3 and R4 (therefore twice)
-                pref_GSB *= numpy.sum(
-                    numpy.diag(rdm0)
-                )  # The GSB signal is dependent only on the last state
-                # => prefactor can be computed as a sum before
-                pref_GSB *= numpy.dot(
-                    self.system.DD[jj, 0, :], self.system.DD[jj, 0, :]
-                )
+            if gsb_mode == "response":
+                ppspec += self._response_backend_trace(["R3g", "R4g"], tau, lab)
+            else:
+                for jj in range(1, dim):
+                    pref_GSB = lab.F4eM4[0]
+                    pref_GSB *= 2  # There are two pathways leading to the same results R3 and R4 (therefore twice)
+                    pref_GSB *= numpy.sum(
+                        numpy.diag(rdm0)
+                    )  # The GSB signal is dependent only on the last state
+                    # => prefactor can be computed as a sum before
+                    pref_GSB *= numpy.dot(
+                        self.system.DD[jj, 0, :], self.system.DD[jj, 0, :]
+                    )
 
-                om = self.system.HH[jj, jj] - self.system.HH[0, 0] - self.rwa
+                    om = self.system.HH[jj, jj] - self.system.HH[0, 0] - self.rwa
 
-                ft = -1j * om * self.t3axis.data
+                    ft = -1j * om * self.t3axis.data
 
-                ft -= gt3s[jj, jj]
-                ppspec += pref_GSB * numpy.exp(ft)
+                    ft -= gt3s[jj, jj]
+                    ppspec += pref_GSB * numpy.exp(ft)
 
         # SE
         if "Full" in spec or "SE" in spec:
@@ -1604,12 +2068,22 @@ class PumpProbeSpectrumCalculator:
                 om = self.system.HH[ii, ii] - self.system.HH[0, 0] - self.rwa
                 state = [ii, ii]
 
-                pref_SE = lab.F4eM4[0]
-                pref_SE *= 2  # There are two pathways leading to the same results R1 and R2 (therefore twice)
-                pref_SE *= rdm[
-                    ii, ii
-                ]  # It should include excitation weighted by evolution
-                pref_SE *= numpy.dot(self.system.DD[ii, 0, :], self.system.DD[ii, 0, :])
+                if orientational_averaging == "four_dipole":
+                    assert full_pref is not None
+                    a = ii - N0
+                    weight = self._full_dipole_rdm_weight(rdm, ii, ii)
+                    pref_SE = weight * (
+                        full_pref["abba"][a, a] + full_pref["baba"][a, a]
+                    )
+                else:
+                    pref_SE = lab.F4eM4[0]
+                    pref_SE *= 2  # There are two pathways leading to the same results R1 and R2 (therefore twice)
+                    pref_SE *= rdm[
+                        ii, ii
+                    ]  # It should include excitation weighted by evolution
+                    pref_SE *= numpy.dot(
+                        self.system.DD[ii, 0, :], self.system.DD[ii, 0, :]
+                    )
 
                 ft = (
                     -1j * om * self.t3axis.data
@@ -1631,14 +2105,23 @@ class PumpProbeSpectrumCalculator:
 
                     om = self.system.HH[ll, ll] - self.system.HH[ii, ii] - self.rwa
 
-                    pref_ESA = lab.F4eM4[0]
-                    pref_ESA *= 2  # There are two pathways leading to the same results R1* and R2* (therefore twice)
-                    pref_ESA *= rdm[
-                        ii, ii
-                    ]  # It should include excitation weighted by evolution
-                    pref_ESA *= numpy.dot(
-                        self.system.DD[ll, ii, :], self.system.DD[ii, ll, :]
-                    )
+                    if orientational_averaging == "four_dipole":
+                        assert full_pref is not None
+                        a = ii - N0
+                        f = ll - N0 - N1
+                        weight = self._full_dipole_rdm_weight(rdm, ii, ii)
+                        pref_ESA = weight * (
+                            full_pref["fbfaba"][f, a, a] + full_pref["fafbba"][f, a, a]
+                        )
+                    else:
+                        pref_ESA = lab.F4eM4[0]
+                        pref_ESA *= 2  # There are two pathways leading to the same results R1* and R2* (therefore twice)
+                        pref_ESA *= rdm[
+                            ii, ii
+                        ]  # It should include excitation weighted by evolution
+                        pref_ESA *= numpy.dot(
+                            self.system.DD[ll, ii, :], self.system.DD[ii, ll, :]
+                        )
 
                     Fl = ll
                     Ek = ii
@@ -1696,8 +2179,12 @@ def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:
     xaxis = twod.xaxis
     dw = xaxis.step
 
-    # real part of the total 2D spectrum
-    tddata = numpy.real(twod.d__data)
+    # real part of the total 2D spectrum or response
+    if hasattr(twod, "d__data"):
+        twod.set_data_flag(signal_TOTL)
+        tddata = numpy.real(twod.d__data)
+    else:
+        tddata = numpy.real(twod.data)
 
     # integration over omega_1 axis
     ppdata = -numpy.sum(tddata, axis=1) * dw

--- a/quantarhei/spectroscopy/pumpprobe.py
+++ b/quantarhei/spectroscopy/pumpprobe.py
@@ -2175,7 +2175,7 @@ def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:
     t2 = twod.get_t2()
     pp.set_t2(t2)
 
-    # time step for integration
+    # frequency step for integration
     xaxis = twod.xaxis
     dw = xaxis.step
 
@@ -2186,8 +2186,8 @@ def calculate_from_2D(twod: Any) -> PumpProbeSpectrum:
     else:
         tddata = numpy.real(twod.data)
 
-    # integration over omega_1 axis
-    ppdata = -numpy.sum(tddata, axis=1) * dw
+    # integration over omega_1 axis with the detection-frequency prefactor
+    ppdata = -twod.yaxis.data * numpy.sum(tddata, axis=1) * dw / (2.0 * numpy.pi)
 
     # setting pump-probe data
     pp.set_data(ppdata)

--- a/quantarhei/spectroscopy/response_implementations.py
+++ b/quantarhei/spectroscopy/response_implementations.py
@@ -44,11 +44,39 @@ def _require_line_shape_arguments(gg: Any, response_name: str) -> None:
         )
 
 
-def _jump_integration_steps(evol: Any) -> int:
-    """Returns requested number of explicit s2 integration points."""
+def _jump_time_metadata(evol: Any) -> dict[str, Any]:
+    """Returns one-jump integration metadata from response evolution data."""
     if isinstance(evol, tuple) and len(evol) > 4 and isinstance(evol[4], dict):
-        return int(evol[4].get("jump_integration_steps", 1))
-    return 1
+        return evol[4]
+    return {}
+
+
+def _single_jump_times(t2: Any, evol: Any) -> numpy.ndarray:
+    """Returns jump times from the population time axis and graining."""
+    t2_value = float(t2)
+    if t2_value == 0.0:
+        return numpy.array([0.0], dtype=numpy.float64)
+
+    metadata = _jump_time_metadata(evol)
+    graining = int(metadata.get("jump_time_graining", 1))
+    axis = metadata.get("jump_time_axis", None)
+
+    if axis is None:
+        return numpy.array([0.5 * t2_value], dtype=numpy.float64)
+
+    try:
+        zero_index = axis.locate(0.0)[0]
+    except Exception:
+        zero_index = 0
+    t2_index = int(metadata.get("jump_time_t2_index", axis.locate(t2_value)[0]))
+
+    indices = list(range(zero_index, t2_index + 1, graining))
+    if not indices or indices[-1] != t2_index:
+        indices.append(t2_index)
+
+    return numpy.asarray(
+        axis.data[indices] - axis.data[zero_index], dtype=numpy.float64
+    )
 
 
 def _evaluate_single_jump_response(
@@ -93,29 +121,26 @@ def _integrate_single_jump_response(
     gg = system.get_lineshape_functions()
     _require_line_shape_arguments(gg, response_name)
 
-    steps = _jump_integration_steps(evol)
-    if steps <= 1 or t2 == 0.0:
+    s2s = _single_jump_times(t2, evol)
+    if len(s2s) == 1 or t2 == 0.0:
         return _evaluate_single_jump_response(
-            response_func, t2, 0.5 * t2, t1, t3, lab, system, evol, KK
+            response_func, t2, s2s[0], t1, t3, lab, system, evol, KK
         )
 
-    s2s = numpy.linspace(0.0, t2, steps)
-    weights = numpy.ones(steps, dtype=numpy.float64)
-    weights[0] = 0.5
-    weights[-1] = 0.5
-
-    ret = None
-    for weight, s2 in zip(weights, s2s):
+    previous_s2 = s2s[0]
+    previous_value = _evaluate_single_jump_response(
+        response_func, t2, previous_s2, t1, t3, lab, system, evol, KK
+    )
+    ret = numpy.zeros_like(previous_value)
+    for s2 in s2s[1:]:
         value = _evaluate_single_jump_response(
             response_func, t2, s2, t1, t3, lab, system, evol, KK
         )
-        if ret is None:
-            ret = weight * value
-        else:
-            ret += weight * value
+        ret += 0.5 * (previous_value + value) * (s2 - previous_s2)
+        previous_s2 = s2
+        previous_value = value
 
-    assert ret is not None
-    return ret / (steps - 1)
+    return ret / float(t2)
 
 
 def R1g(

--- a/quantarhei/spectroscopy/response_implementations.py
+++ b/quantarhei/spectroscopy/response_implementations.py
@@ -51,6 +51,15 @@ def _jump_time_metadata(evol: Any) -> dict[str, Any]:
     return {}
 
 
+def _endpoint_t2_weight(evol: Any, left: int, right: int, default: Any) -> Any:
+    """Returns an externally supplied t2 endpoint weight if available."""
+    metadata = _jump_time_metadata(evol)
+    endpoint = metadata.get("density_matrix_endpoint_t2", None)
+    if endpoint is None:
+        return default
+    return endpoint[left, right]
+
+
 def _single_jump_times(t2: Any, evol: Any) -> numpy.ndarray:
     """Returns jump times from the population time axis and graining."""
     t2_value = float(t2)
@@ -357,8 +366,7 @@ def R1g(
                     dfac[b, a]
                     * Ut1[a, :][:, None]
                     * Ut3[a, :][None, :]
-                    * Ut2[a]
-                    * Ut2[b]
+                    * _endpoint_t2_weight(evol, a, b, Ut2[a] * Ut2[b])
                     * np.exp(
                         -(np.einsum("i,ij", MM[b, a, :], gg[:, "t1"]))[:, None]
                         + (np.einsum("i,ij", MM[b, a, :], gg[:, "t1+t2"]))[:, None]
@@ -443,8 +451,7 @@ def R2g(
                     dfac[b, a]
                     * Ut1[a, :][:, None]
                     * Ut3[b, :][None, :]
-                    * Ut2[a]
-                    * Ut2[b]
+                    * _endpoint_t2_weight(evol, a, b, Ut2[a] * Ut2[b])
                     * np.exp(
                         (np.einsum("i,i", MM[a, b, :], gg[:, "t2"]))[None, None]
                         - (np.einsum("i,ij", MM[b, b, :], gg[:, "t2+t3"]))[None, :]
@@ -703,8 +710,7 @@ def R1f(
                         * dfac[f, b, a]
                         * Ut1[a, :][:, None]
                         * Ut3[b, :][None, :]
-                        * Ut2[a]
-                        * Ut2[b]
+                        * _endpoint_t2_weight(evol, a, b, Ut2[a] * Ut2[b])
                         * np.exp(
                             -(np.einsum("i,ij", MM[a, a, :], gg[:, "t1+t2"]))[:, None]
                             - (np.einsum("i,ij", MM[b, a, :], gg[:, "t1"]))[:, None]
@@ -806,8 +812,7 @@ def R1f_wrong(
                         * dfac[f, b, a]
                         * Ut1[a, :][:, None]
                         * Ut3[b, :][None, :]
-                        * Ut2[a]
-                        * Ut2[b]
+                        * _endpoint_t2_weight(evol, a, b, Ut2[a] * Ut2[b])
                         * np.exp(
                             +(np.einsum("i,ij", MM[a, a, :], gg[:, "t1+t2"]))[:, None]
                             - (np.einsum("i,ij", MM[b, a, :], gg[:, "t1"]))[:, None]
@@ -910,8 +915,7 @@ def R2f(
                         * dfac[f, b, a]
                         * Ut1[a, :][:, None]
                         * Ut3[a, :][None, :]
-                        * Ut2[a]
-                        * Ut2[b]
+                        * _endpoint_t2_weight(evol, a, b, Ut2[a] * Ut2[b])
                         * np.exp(
                             -(np.einsum("i,i", MM[b, b, :], gg[:, "t2"]))[None, None]
                             + (np.einsum("i,i", MM[p, b, :], gg[:, "t2"]))[None, None]
@@ -1024,8 +1028,7 @@ def R2f_wrong(
                         * dfac[f, b, a]
                         * Ut1[a, :][:, None]
                         * Ut3[a, :][None, :]
-                        * Ut2[a]
-                        * Ut2[b]
+                        * _endpoint_t2_weight(evol, a, b, Ut2[a] * Ut2[b])
                         * np.exp(
                             +(np.einsum("i,i", MM[b, b, :], gg[:, "t2"]))[None, None]
                             - (np.einsum("i,i", MM[p, b, :], gg[:, "t2"]))[None, None]

--- a/quantarhei/spectroscopy/response_implementations.py
+++ b/quantarhei/spectroscopy/response_implementations.py
@@ -632,7 +632,7 @@ def R4g(
                         - (np.einsum("i,ij", MM[b, b, :], gg[:, "t3"]))[None, :]
                         - (np.einsum("i,ijk", MM[b, a, :], gg[:, "t1+t2+t3"]))[:, :]
                         - 1j * (En[aa] - En[g] - rwa) * t1[:, None]
-                        - 1j * (En[g] - En[g]) * t2[None, None]
+                        - 1j * (En[g] - En[g]) * t2
                         - 1j * (En[bb] - En[g] - rwa) * t3[None, :]
                     )
                 )
@@ -734,7 +734,7 @@ def R1f(
                                 ]
                             )
                             - 1j * (En[aa] - En[g] - rwa) * t1[:, None]
-                            - 1j * (En[aa] - En[bb]) * t2[None, None]
+                            - 1j * (En[aa] - En[bb]) * t2
                             - 1j * (En[ff] - En[bb] - rwa) * t3[None, :]
                         )
                     )
@@ -836,7 +836,7 @@ def R1f_wrong(
                                 ]
                             )
                             - 1j * (En[aa] - En[g] - rwa) * t1[:, None]
-                            - 1j * (En[aa] - En[bb]) * t2[None, None]
+                            - 1j * (En[aa] - En[bb]) * t2
                             - 1j * (En[ff] - En[bb] - rwa) * t3[None, :]
                         )
                     )
@@ -949,7 +949,7 @@ def R2f(
                                 ]
                             )
                             - 1j * (En[g] - En[aa] + rwa) * t1[:, None]
-                            - 1j * (En[bb] - En[aa]) * t2[None, None]
+                            - 1j * (En[bb] - En[aa]) * t2
                             - 1j * (En[ff] - En[aa] - rwa) * t3[None, :]
                         )
                     )
@@ -1062,7 +1062,7 @@ def R2f_wrong(
                                 ]
                             )
                             - 1j * (En[g] - En[aa] + rwa) * t1[:, None]
-                            - 1j * (En[bb] - En[aa]) * t2[None, None]
+                            - 1j * (En[bb] - En[aa]) * t2
                             - 1j * (En[ff] - En[aa] - rwa) * t3[None, :]
                         )
                     )

--- a/quantarhei/spectroscopy/response_implementations.py
+++ b/quantarhei/spectroscopy/response_implementations.py
@@ -6,6 +6,43 @@ import numpy
 
 from .. import COMPLEX
 
+ONE_JUMP_LINE_SHAPE_ARGUMENTS = (
+    "t1",
+    "t2",
+    "s2",
+    "t2-s2",
+    "t3",
+    "t1+t2",
+    "t1+s2",
+    "t1+t2-s2",
+    "t1+t3",
+    "t2+t3",
+    "s2+t3",
+    "t2-s2+t3",
+    "t1+t2+t3",
+    "t1+s2+t3",
+    "t1+t2-s2+t3",
+)
+
+
+def _require_line_shape_arguments(gg: Any, response_name: str) -> None:
+    """Checks that line-shape storage has all one-jump response arguments."""
+    if not hasattr(gg, "time_mapping"):
+        raise Exception(
+            response_name
+            + " requires FunctionStorage with one-jump line-shape arguments."
+        )
+
+    missing = [
+        label for label in ONE_JUMP_LINE_SHAPE_ARGUMENTS if label not in gg.time_mapping
+    ]
+    if missing:
+        raise Exception(
+            response_name
+            + " requires FunctionStorage(config=1); missing labels: "
+            + ", ".join(missing)
+        )
+
 
 def R1g(
     t2: Any,
@@ -1324,6 +1361,95 @@ def R2f_scM0e(
     return np.transpose(ret)
 
 
+def R1g_scM1g(
+    t2: Any,
+    t1: numpy.ndarray,
+    t3: numpy.ndarray,
+    lab: Any,
+    system: Any,
+    evol: Any,
+    KK: Any,
+) -> numpy.ndarray:
+    """Single-jump transfer version of ``R1g_scM0g``.
+
+    This currently uses the same formula as the remainder pathway.  The
+    separate implementation exists so it can be replaced by the explicit
+    one-jump response formula without changing calculator bookkeeping.
+    """
+    _require_line_shape_arguments(system.get_lineshape_functions(), "R1g_scM1g")
+    return R1g_scM0g(t2, t1, t3, lab, system, evol, KK)
+
+
+def R2g_scM1g(
+    t2: Any,
+    t1: numpy.ndarray,
+    t3: numpy.ndarray,
+    lab: Any,
+    system: Any,
+    evol: Any,
+    KK: Any,
+) -> numpy.ndarray:
+    """Single-jump transfer version of ``R2g_scM0g``."""
+    _require_line_shape_arguments(system.get_lineshape_functions(), "R2g_scM1g")
+    return R2g_scM0g(t2, t1, t3, lab, system, evol, KK)
+
+
+def R1f_scM1g(
+    t2: Any,
+    t1: numpy.ndarray,
+    t3: numpy.ndarray,
+    lab: Any,
+    system: Any,
+    evol: Any,
+    KK: Any,
+) -> numpy.ndarray:
+    """Single-jump transfer version of ``R1f_scM0g``."""
+    _require_line_shape_arguments(system.get_lineshape_functions(), "R1f_scM1g")
+    return R1f_scM0g(t2, t1, t3, lab, system, evol, KK)
+
+
+def R2f_scM1g(
+    t2: Any,
+    t1: numpy.ndarray,
+    t3: numpy.ndarray,
+    lab: Any,
+    system: Any,
+    evol: Any,
+    KK: Any,
+) -> numpy.ndarray:
+    """Single-jump transfer version of ``R2f_scM0g``."""
+    _require_line_shape_arguments(system.get_lineshape_functions(), "R2f_scM1g")
+    return R2f_scM0g(t2, t1, t3, lab, system, evol, KK)
+
+
+def R1f_scM1e(
+    t2: Any,
+    t1: numpy.ndarray,
+    t3: numpy.ndarray,
+    lab: Any,
+    system: Any,
+    evol: Any,
+    KK: Any,
+) -> numpy.ndarray:
+    """Single-jump transfer version of ``R1f_scM0e``."""
+    _require_line_shape_arguments(system.get_lineshape_functions(), "R1f_scM1e")
+    return R1f_scM0e(t2, t1, t3, lab, system, evol, KK)
+
+
+def R2f_scM1e(
+    t2: Any,
+    t1: numpy.ndarray,
+    t3: numpy.ndarray,
+    lab: Any,
+    system: Any,
+    evol: Any,
+    KK: Any,
+) -> numpy.ndarray:
+    """Single-jump transfer version of ``R2f_scM0e``."""
+    _require_line_shape_arguments(system.get_lineshape_functions(), "R2f_scM1e")
+    return R2f_scM0e(t2, t1, t3, lab, system, evol, KK)
+
+
 #
 # REGISTRATION CODE
 #
@@ -1342,6 +1468,12 @@ dc["R1f_scM0g"] = R1f_scM0g
 dc["R2f_scM0g"] = R2f_scM0g
 dc["R1f_scM0e"] = R1f_scM0e
 dc["R2f_scM0e"] = R2f_scM0e
+dc["R1g_scM1g"] = R1g_scM1g
+dc["R2g_scM1g"] = R2g_scM1g
+dc["R1f_scM1g"] = R1f_scM1g
+dc["R2f_scM1g"] = R2f_scM1g
+dc["R1f_scM1e"] = R1f_scM1e
+dc["R2f_scM1e"] = R2f_scM1e
 
 
 def get_implementation(name: str) -> Any:

--- a/quantarhei/spectroscopy/response_implementations.py
+++ b/quantarhei/spectroscopy/response_implementations.py
@@ -44,6 +44,80 @@ def _require_line_shape_arguments(gg: Any, response_name: str) -> None:
         )
 
 
+def _jump_integration_steps(evol: Any) -> int:
+    """Returns requested number of explicit s2 integration points."""
+    if isinstance(evol, tuple) and len(evol) > 4 and isinstance(evol[4], dict):
+        return int(evol[4].get("jump_integration_steps", 1))
+    return 1
+
+
+def _evaluate_single_jump_response(
+    response_func: Any,
+    t2: Any,
+    s2: Any,
+    t1: numpy.ndarray,
+    t3: numpy.ndarray,
+    lab: Any,
+    system: Any,
+    evol: Any,
+    KK: Any,
+) -> numpy.ndarray:
+    """Evaluates a placeholder one-jump response with a fixed jump time."""
+    gg = system.get_lineshape_functions()
+    old_defaults = getattr(gg, "_reset_defaults", None)
+    reset_defaults = dict(old_defaults) if isinstance(old_defaults, dict) else {}
+    reset_defaults["s2"] = s2
+    gg._reset_defaults = reset_defaults
+
+    try:
+        return response_func(t2, t1, t3, lab, system, evol, KK)
+    finally:
+        if old_defaults is None:
+            del gg._reset_defaults
+        else:
+            gg._reset_defaults = old_defaults
+
+
+def _integrate_single_jump_response(
+    response_func: Any,
+    response_name: str,
+    t2: Any,
+    t1: numpy.ndarray,
+    t3: numpy.ndarray,
+    lab: Any,
+    system: Any,
+    evol: Any,
+    KK: Any,
+) -> numpy.ndarray:
+    """Integrates a placeholder one-jump response over the jump time ``s2``."""
+    gg = system.get_lineshape_functions()
+    _require_line_shape_arguments(gg, response_name)
+
+    steps = _jump_integration_steps(evol)
+    if steps <= 1 or t2 == 0.0:
+        return _evaluate_single_jump_response(
+            response_func, t2, 0.5 * t2, t1, t3, lab, system, evol, KK
+        )
+
+    s2s = numpy.linspace(0.0, t2, steps)
+    weights = numpy.ones(steps, dtype=numpy.float64)
+    weights[0] = 0.5
+    weights[-1] = 0.5
+
+    ret = None
+    for weight, s2 in zip(weights, s2s):
+        value = _evaluate_single_jump_response(
+            response_func, t2, s2, t1, t3, lab, system, evol, KK
+        )
+        if ret is None:
+            ret = weight * value
+        else:
+            ret += weight * value
+
+    assert ret is not None
+    return ret / (steps - 1)
+
+
 def R1g(
     t2: Any,
     t1: numpy.ndarray,
@@ -1376,8 +1450,9 @@ def R1g_scM1g(
     separate implementation exists so it can be replaced by the explicit
     one-jump response formula without changing calculator bookkeeping.
     """
-    _require_line_shape_arguments(system.get_lineshape_functions(), "R1g_scM1g")
-    return R1g_scM0g(t2, t1, t3, lab, system, evol, KK)
+    return _integrate_single_jump_response(
+        R1g_scM0g, "R1g_scM1g", t2, t1, t3, lab, system, evol, KK
+    )
 
 
 def R2g_scM1g(
@@ -1390,8 +1465,9 @@ def R2g_scM1g(
     KK: Any,
 ) -> numpy.ndarray:
     """Single-jump transfer version of ``R2g_scM0g``."""
-    _require_line_shape_arguments(system.get_lineshape_functions(), "R2g_scM1g")
-    return R2g_scM0g(t2, t1, t3, lab, system, evol, KK)
+    return _integrate_single_jump_response(
+        R2g_scM0g, "R2g_scM1g", t2, t1, t3, lab, system, evol, KK
+    )
 
 
 def R1f_scM1g(
@@ -1404,8 +1480,9 @@ def R1f_scM1g(
     KK: Any,
 ) -> numpy.ndarray:
     """Single-jump transfer version of ``R1f_scM0g``."""
-    _require_line_shape_arguments(system.get_lineshape_functions(), "R1f_scM1g")
-    return R1f_scM0g(t2, t1, t3, lab, system, evol, KK)
+    return _integrate_single_jump_response(
+        R1f_scM0g, "R1f_scM1g", t2, t1, t3, lab, system, evol, KK
+    )
 
 
 def R2f_scM1g(
@@ -1418,8 +1495,9 @@ def R2f_scM1g(
     KK: Any,
 ) -> numpy.ndarray:
     """Single-jump transfer version of ``R2f_scM0g``."""
-    _require_line_shape_arguments(system.get_lineshape_functions(), "R2f_scM1g")
-    return R2f_scM0g(t2, t1, t3, lab, system, evol, KK)
+    return _integrate_single_jump_response(
+        R2f_scM0g, "R2f_scM1g", t2, t1, t3, lab, system, evol, KK
+    )
 
 
 def R1f_scM1e(
@@ -1432,8 +1510,9 @@ def R1f_scM1e(
     KK: Any,
 ) -> numpy.ndarray:
     """Single-jump transfer version of ``R1f_scM0e``."""
-    _require_line_shape_arguments(system.get_lineshape_functions(), "R1f_scM1e")
-    return R1f_scM0e(t2, t1, t3, lab, system, evol, KK)
+    return _integrate_single_jump_response(
+        R1f_scM0e, "R1f_scM1e", t2, t1, t3, lab, system, evol, KK
+    )
 
 
 def R2f_scM1e(
@@ -1446,8 +1525,9 @@ def R2f_scM1e(
     KK: Any,
 ) -> numpy.ndarray:
     """Single-jump transfer version of ``R2f_scM0e``."""
-    _require_line_shape_arguments(system.get_lineshape_functions(), "R2f_scM1e")
-    return R2f_scM0e(t2, t1, t3, lab, system, evol, KK)
+    return _integrate_single_jump_response(
+        R2f_scM0e, "R2f_scM1e", t2, t1, t3, lab, system, evol, KK
+    )
 
 
 #

--- a/quantarhei/spectroscopy/response_implementations.py
+++ b/quantarhei/spectroscopy/response_implementations.py
@@ -79,6 +79,119 @@ def _single_jump_times(t2: Any, evol: Any) -> numpy.ndarray:
     )
 
 
+def _single_jump_transfer_matrix(t2: Any, s2: Any, evol: Any, KK: Any) -> Any:
+    """Returns the one-jump transfer matrix density for a fixed jump time."""
+    metadata = _jump_time_metadata(evol)
+    axis = metadata.get("jump_time_axis", None)
+    U0 = metadata.get("jump_zero_propagator", None)
+    if axis is None or U0 is None or KK is None:
+        return evol[3]
+
+    zero_index = int(metadata.get("jump_time_zero_index", 0))
+    t2_index = int(metadata.get("jump_time_t2_index", axis.locate(float(t2))[0]))
+    s2_index = axis.locate(axis.data[zero_index] + float(s2))[0]
+
+    rates = numpy.asarray(KK)
+    if len(rates.shape) == 2:
+        K_at_s2 = rates
+    elif len(rates.shape) == 3:
+        K_at_s2 = rates[min(s2_index, rates.shape[0] - 1)]
+    else:
+        return evol[3]
+
+    transfer = numpy.zeros_like(K_at_s2)
+    for final in range(K_at_s2.shape[0]):
+        if U0[final, s2_index] == 0.0:
+            final_survival = 0.0
+        else:
+            final_survival = U0[final, t2_index] / U0[final, s2_index]
+        for initial in range(K_at_s2.shape[1]):
+            if final != initial:
+                transfer[final, initial] = (
+                    K_at_s2[final, initial] * final_survival * U0[initial, s2_index]
+                )
+
+    return transfer
+
+
+def _truncate_single_jump_times(
+    t2: Any, s2s: numpy.ndarray, transfers: list[Any], evol: Any
+) -> tuple[numpy.ndarray, list[Any]]:
+    """Drop s2 points whose one-jump kernel is negligible."""
+    metadata = _jump_time_metadata(evol)
+    cutoff = float(metadata.get("jump_kernel_cutoff", 0.0))
+    if cutoff <= 0.0 or len(s2s) <= 2:
+        return s2s, transfers
+
+    norms = numpy.asarray(
+        [numpy.max(numpy.abs(transfer)) for transfer in transfers],
+        dtype=numpy.float64,
+    )
+    max_norm = float(numpy.max(norms))
+    if max_norm == 0.0:
+        return numpy.array([0.0, float(t2)], dtype=numpy.float64), [
+            transfers[0],
+            transfers[-1],
+        ]
+
+    active = numpy.where(norms >= cutoff * max_norm)[0]
+    if len(active) == 0:
+        return numpy.array([0.0, float(t2)], dtype=numpy.float64), [
+            transfers[0],
+            transfers[-1],
+        ]
+
+    first = max(0, int(active[0]) - 1)
+    last = min(len(s2s) - 1, int(active[-1]) + 1)
+    return s2s[first : last + 1], transfers[first : last + 1]
+
+
+def _single_jump_kernel_diagnostics(
+    s2s: numpy.ndarray, transfers: list[Any], used_points: int, skipped: bool
+) -> dict[str, Any]:
+    """Return diagnostic information about the one-jump kernel."""
+    if len(transfers) == 0:
+        max_norm = 0.0
+        integral_norm = 0.0
+    else:
+        norms = numpy.asarray(
+            [numpy.max(numpy.abs(transfer)) for transfer in transfers],
+            dtype=numpy.float64,
+        )
+        max_norm = float(numpy.max(norms))
+        if len(norms) > 1:
+            integral_norm = float(numpy.trapz(norms, s2s))
+        else:
+            integral_norm = 0.0
+
+    return {
+        "candidate_points": len(s2s),
+        "used_points": int(used_points),
+        "max_kernel_norm": max_norm,
+        "integrated_kernel_norm": integral_norm,
+        "skipped": skipped,
+    }
+
+
+def _set_single_jump_diagnostics(
+    evol: Any, response_name: str, diagnostics: dict[str, Any]
+) -> None:
+    """Store one-jump diagnostics in response evolution metadata."""
+    metadata = _jump_time_metadata(evol)
+    all_diagnostics = metadata.get("jump_diagnostics", {})
+    all_diagnostics[response_name] = diagnostics
+    metadata["jump_diagnostics"] = all_diagnostics
+
+
+def _replace_transfer_matrix(evol: Any, transfer_matrix: Any) -> Any:
+    """Return response evolution data with a fixed transfer matrix."""
+    if isinstance(evol, tuple) and len(evol) > 4:
+        return evol[:3] + (transfer_matrix,) + evol[4:]
+    if isinstance(evol, tuple) and len(evol) == 4:
+        return evol[:3] + (transfer_matrix,)
+    return evol
+
+
 def _evaluate_single_jump_response(
     response_func: Any,
     t2: Any,
@@ -89,16 +202,21 @@ def _evaluate_single_jump_response(
     system: Any,
     evol: Any,
     KK: Any,
+    transfer_matrix: Any = None,
 ) -> numpy.ndarray:
     """Evaluates a placeholder one-jump response with a fixed jump time."""
     gg = system.get_lineshape_functions()
+    if transfer_matrix is None:
+        transfer_matrix = _single_jump_transfer_matrix(t2, s2, evol, KK)
+    evol_at_s2 = _replace_transfer_matrix(evol, transfer_matrix)
+
     old_defaults = getattr(gg, "_reset_defaults", None)
     reset_defaults = dict(old_defaults) if isinstance(old_defaults, dict) else {}
     reset_defaults["s2"] = s2
     gg._reset_defaults = reset_defaults
 
     try:
-        return response_func(t2, t1, t3, lab, system, evol, KK)
+        return response_func(t2, t1, t3, lab, system, evol_at_s2, KK)
     finally:
         if old_defaults is None:
             del gg._reset_defaults
@@ -122,25 +240,59 @@ def _integrate_single_jump_response(
     _require_line_shape_arguments(gg, response_name)
 
     s2s = _single_jump_times(t2, evol)
-    if len(s2s) == 1 or t2 == 0.0:
+    if t2 == 0.0:
+        _set_single_jump_diagnostics(
+            evol,
+            response_name,
+            _single_jump_kernel_diagnostics(s2s, [], 0, skipped=True),
+        )
+        return numpy.zeros((len(t3), len(t1)), dtype=COMPLEX)
+    transfers = [_single_jump_transfer_matrix(t2, s2, evol, KK) for s2 in s2s]
+    zero_cutoff = float(_jump_time_metadata(evol).get("jump_kernel_zero_cutoff", 0.0))
+    original_s2s = s2s
+    original_transfers = transfers
+    if zero_cutoff > 0.0:
+        max_norm = max(
+            (float(numpy.max(numpy.abs(transfer))) for transfer in transfers),
+            default=0.0,
+        )
+        if max_norm <= zero_cutoff:
+            _set_single_jump_diagnostics(
+                evol,
+                response_name,
+                _single_jump_kernel_diagnostics(
+                    original_s2s, original_transfers, 0, skipped=True
+                ),
+            )
+            return numpy.zeros((len(t3), len(t1)), dtype=COMPLEX)
+
+    s2s, transfers = _truncate_single_jump_times(t2, s2s, transfers, evol)
+    _set_single_jump_diagnostics(
+        evol,
+        response_name,
+        _single_jump_kernel_diagnostics(
+            original_s2s, original_transfers, len(s2s), skipped=False
+        ),
+    )
+    if len(s2s) == 1:
         return _evaluate_single_jump_response(
-            response_func, t2, s2s[0], t1, t3, lab, system, evol, KK
+            response_func, t2, s2s[0], t1, t3, lab, system, evol, KK, transfers[0]
         )
 
     previous_s2 = s2s[0]
     previous_value = _evaluate_single_jump_response(
-        response_func, t2, previous_s2, t1, t3, lab, system, evol, KK
+        response_func, t2, previous_s2, t1, t3, lab, system, evol, KK, transfers[0]
     )
     ret = numpy.zeros_like(previous_value)
-    for s2 in s2s[1:]:
+    for s2, transfer in zip(s2s[1:], transfers[1:]):
         value = _evaluate_single_jump_response(
-            response_func, t2, s2, t1, t3, lab, system, evol, KK
+            response_func, t2, s2, t1, t3, lab, system, evol, KK, transfer
         )
         ret += 0.5 * (previous_value + value) * (s2 - previous_s2)
         previous_s2 = s2
         previous_value = value
 
-    return ret / float(t2)
+    return ret
 
 
 def R1g(

--- a/quantarhei/spectroscopy/response_implementations.py
+++ b/quantarhei/spectroscopy/response_implementations.py
@@ -67,6 +67,8 @@ def R1g(
                 # ret += Ut1[a,:][:,None]*Ut3[a,:][None,:]*\
                 ret += (
                     dfac[b, a]
+                    * Ut1[a, :][:, None]
+                    * Ut3[a, :][None, :]
                     * Ut2[a]
                     * Ut2[b]
                     * np.exp(
@@ -151,6 +153,8 @@ def R2g(
                 # ret += Ut1[a,:][:,None]*Ut3[b,:][None,:]*\
                 ret += (
                     dfac[b, a]
+                    * Ut1[a, :][:, None]
+                    * Ut3[b, :][None, :]
                     * Ut2[a]
                     * Ut2[b]
                     * np.exp(
@@ -234,18 +238,31 @@ def R3g(
                 b = bb - 1
 
                 # ret += Ut1[a,:][:,None]*Ut3[b,:][None,:]*\
-                ret += dfac[b, a] * np.exp(
-                    -(np.einsum("i,ij", MM[b, b, :], gg[:, "t3"]))[None, :]
-                    + np.conj((np.einsum("i,i", MM[b, a, :], gg[:, "t2"]))[None, None])
-                    - np.conj((np.einsum("i,ij", MM[a, a, :], gg[:, "t1"]))[:, None])
-                    - np.conj((np.einsum("i,ij", MM[a, b, :], gg[:, "t1+t2"]))[:, None])
-                    - np.conj((np.einsum("i,ij", MM[b, a, :], gg[:, "t2+t3"]))[None, :])
-                    + np.conj(
-                        (np.einsum("i,ijk", MM[a, b, :], gg[:, "t1+t2+t3"]))[:, :]
+                ret += (
+                    dfac[b, a]
+                    * Ut1[a, :][:, None]
+                    * Ut3[b, :][None, :]
+                    * np.exp(
+                        -(np.einsum("i,ij", MM[b, b, :], gg[:, "t3"]))[None, :]
+                        + np.conj(
+                            (np.einsum("i,i", MM[b, a, :], gg[:, "t2"]))[None, None]
+                        )
+                        - np.conj(
+                            (np.einsum("i,ij", MM[a, a, :], gg[:, "t1"]))[:, None]
+                        )
+                        - np.conj(
+                            (np.einsum("i,ij", MM[a, b, :], gg[:, "t1+t2"]))[:, None]
+                        )
+                        - np.conj(
+                            (np.einsum("i,ij", MM[b, a, :], gg[:, "t2+t3"]))[None, :]
+                        )
+                        + np.conj(
+                            (np.einsum("i,ijk", MM[a, b, :], gg[:, "t1+t2+t3"]))[:, :]
+                        )
+                        - 1j * (En[g] - En[aa] + rwa) * t1[:, None]
+                        - 1j * (En[g] - En[g]) * t2
+                        - 1j * (En[bb] - En[g] - rwa) * t3[None, :]
                     )
-                    - 1j * (En[g] - En[aa] + rwa) * t1[:, None]
-                    - 1j * (En[g] - En[g]) * t2
-                    - 1j * (En[bb] - En[g] - rwa) * t3[None, :]
                 )
 
     return np.transpose(ret)
@@ -308,16 +325,21 @@ def R4g(
                 b = bb - 1
 
                 # ret += Ut1[a,:][:,None]*Ut3[b,:][None,:]*\
-                ret += dfac[b, a] * np.exp(
-                    -(np.einsum("i,i", MM[b, a, :], gg[:, "t2"]))[None, None]
-                    - (np.einsum("i,ij", MM[a, a, :], gg[:, "t1"]))[:, None]
-                    + (np.einsum("i,ij", MM[b, a, :], gg[:, "t1+t2"]))[:, None]
-                    + (np.einsum("i,ij", MM[b, a, :], gg[:, "t2+t3"]))[None, :]
-                    - (np.einsum("i,ij", MM[b, b, :], gg[:, "t3"]))[None, :]
-                    - (np.einsum("i,ijk", MM[b, a, :], gg[:, "t1+t2+t3"]))[:, :]
-                    - 1j * (En[aa] - En[g] - rwa) * t1[:, None]
-                    - 1j * (En[g] - En[g]) * t2[None, None]
-                    - 1j * (En[bb] - En[g] - rwa) * t3[None, :]
+                ret += (
+                    dfac[b, a]
+                    * Ut1[a, :][:, None]
+                    * Ut3[b, :][None, :]
+                    * np.exp(
+                        -(np.einsum("i,i", MM[b, a, :], gg[:, "t2"]))[None, None]
+                        - (np.einsum("i,ij", MM[a, a, :], gg[:, "t1"]))[:, None]
+                        + (np.einsum("i,ij", MM[b, a, :], gg[:, "t1+t2"]))[:, None]
+                        + (np.einsum("i,ij", MM[b, a, :], gg[:, "t2+t3"]))[None, :]
+                        - (np.einsum("i,ij", MM[b, b, :], gg[:, "t3"]))[None, :]
+                        - (np.einsum("i,ijk", MM[b, a, :], gg[:, "t1+t2+t3"]))[:, :]
+                        - 1j * (En[aa] - En[g] - rwa) * t1[:, None]
+                        - 1j * (En[g] - En[g]) * t2[None, None]
+                        - 1j * (En[bb] - En[g] - rwa) * t3[None, :]
+                    )
                 )
 
     return np.transpose(ret)
@@ -391,6 +413,8 @@ def R1f(
                     ret += (
                         -1.0
                         * dfac[f, b, a]
+                        * Ut1[a, :][:, None]
+                        * Ut3[b, :][None, :]
                         * Ut2[a]
                         * Ut2[b]
                         * np.exp(
@@ -492,6 +516,8 @@ def R1f_wrong(
                     ret += (
                         -1.0
                         * dfac[f, b, a]
+                        * Ut1[a, :][:, None]
+                        * Ut3[b, :][None, :]
                         * Ut2[a]
                         * Ut2[b]
                         * np.exp(
@@ -594,6 +620,8 @@ def R2f(
                     ret += (
                         -1.0
                         * dfac[f, b, a]
+                        * Ut1[a, :][:, None]
+                        * Ut3[a, :][None, :]
                         * Ut2[a]
                         * Ut2[b]
                         * np.exp(
@@ -706,6 +734,8 @@ def R2f_wrong(
                     ret += (
                         -1.0
                         * dfac[f, b, a]
+                        * Ut1[a, :][:, None]
+                        * Ut3[a, :][None, :]
                         * Ut2[a]
                         * Ut2[b]
                         * np.exp(
@@ -810,6 +840,8 @@ def R1g_scM0g(
                     # ret += Ut1[a,:][:,None]*Ut3[b,:][None,:]*\
                     ret += (
                         dfac[b, a]
+                        * Ut1[a, :][:, None]
+                        * Ut3[b, :][None, :]
                         * Ut2[b, a]
                         * np.exp(
                             -(np.einsum("i,ij", MM[a, a, :], gg[:, "t1"]))[:, None]
@@ -883,6 +915,8 @@ def R2g_scM0g(
                     # ret += Ut1[a,:][:,None]*Ut3[b,:][None,:]*\
                     ret += (
                         dfac[b, a]
+                        * Ut1[a, :][:, None]
+                        * Ut3[b, :][None, :]
                         * Ut2[b, a]
                         * np.exp(
                             -np.conj(
@@ -966,6 +1000,8 @@ def R1f_scM0g(
                         ret += (
                             (-1.0)
                             * dfac[f, a, b]
+                            * Ut1[a, :][:, None]
+                            * Ut3[b, :][None, :]
                             * Ut2[b, a]
                             * np.exp(
                                 -(np.einsum("i,ij", MM[a, a, :], gg[:, "t1"]))[:, None]
@@ -1057,6 +1093,8 @@ def R2f_scM0g(
                         ret += (
                             (-1.0)
                             * dfac[f, a, b]
+                            * Ut1[a, :][:, None]
+                            * Ut3[b, :][None, :]
                             * Ut2[b, a]
                             * np.exp(
                                 -np.conj(
@@ -1157,6 +1195,8 @@ def R1f_scM0e(
                         ret += (
                             (-1.0)
                             * dfac[f, a, b]
+                            * Ut1[a, :][:, None]
+                            * Ut3[b, :][None, :]
                             * Ut2[b, a]
                             * np.exp(
                                 -(np.einsum("i,ij", MM[a, a, :], gg[:, "t1"]))[:, None]
@@ -1251,6 +1291,8 @@ def R2f_scM0e(
                         ret += (
                             (-1.0)
                             * dfac[f, a, b]
+                            * Ut1[a, :][:, None]
+                            * Ut3[b, :][None, :]
                             * Ut2[b, a]
                             * np.exp(
                                 -np.conj(

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -276,6 +276,8 @@ class NonLinearResponse:
         relaxation_cutoff_time: float | None = None,
         rate_matrix_options: dict[str, Any] | None = None,
         population_time_axis: Any = None,
+        population_propagator: Any = None,
+        population_dynamics_mode: str | None = None,
         jump_time_graining: int = 1,
         jump_kernel_cutoff: float = 0.0,
         jump_kernel_zero_cutoff: float = 0.0,
@@ -303,7 +305,15 @@ class NonLinearResponse:
         self.t1s = t1s
         self.t2s = t2s
         self.t3s = t3s
+        if population_dynamics_mode is None:
+            population_dynamics_mode = (
+                "full_conditional"
+                if population_propagator is not None
+                else "jump_decomposition"
+            )
+
         self.population_time_axis = population_time_axis
+        self.population_dynamics_mode = population_dynamics_mode
         self.jump_time_graining = jump_time_graining
         self.jump_kernel_cutoff = jump_kernel_cutoff
         self.jump_kernel_zero_cutoff = jump_kernel_zero_cutoff
@@ -321,6 +331,22 @@ class NonLinearResponse:
         self.Utransfer_t2: numpy.ndarray
         self.diagnostics: dict[str, Any] = {}
         self._previous_response_matrix: numpy.ndarray | None = None
+
+        if population_propagator is not None and (
+            rate_matrix is not None or relaxation_theory is not None
+        ):
+            raise ValueError(
+                "population_propagator cannot be combined with rate_matrix "
+                "or relaxation_theory"
+            )
+
+        if population_propagator is not None:
+            self.set_population_propagator(
+                population_propagator,
+                population_time_axis=population_time_axis,
+                mode=population_dynamics_mode,
+            )
+            return
 
         if rate_matrix is not None:
             KK = get_single_exciton_rate_matrix(system, rate_matrix)
@@ -466,6 +492,8 @@ class NonLinearResponse:
 
     def _get_jump_expansion_order(self) -> int:
         """Returns the highest explicit jump order to calculate."""
+        if self.population_dynamics_mode != "jump_decomposition":
+            return 0
         return 1 if self._uses_single_jump_storage() else 0
 
     def _get_transfer_matrix(self, t2i: int) -> numpy.ndarray:
@@ -484,6 +512,91 @@ class NonLinearResponse:
         for jump in jumps:
             jump_sum += jump
         return self.Uee - jump_sum
+
+    def _population_propagator_data(self, population_propagator: Any) -> numpy.ndarray:
+        """Returns population propagator data in ``(N, N, Nt)`` order."""
+        data = numpy.asarray(
+            population_propagator.data
+            if hasattr(population_propagator, "data")
+            else population_propagator
+        )
+        if len(data.shape) != 3:
+            raise Exception("Population propagator has to be an array of rank 3")
+
+        dim = self.sys.Nb[1]
+        if data.shape[0] == dim and data.shape[1] == dim:
+            return data.astype(REAL, copy=False)
+        if data.shape[1] == dim and data.shape[2] == dim:
+            return numpy.transpose(data, (1, 2, 0)).astype(REAL, copy=False)
+
+        raise Exception(
+            "Population propagator has to have shape (N, N, Nt) "
+            "or (Nt, N, N), where N is the number of single-exciton states"
+        )
+
+    def set_population_propagator(
+        self,
+        population_propagator: Any,
+        population_time_axis: Any = None,
+        mode: str = "full_conditional",
+    ) -> None:
+        """Set an externally calculated one-exciton population propagator.
+
+        The ``full_conditional`` mode classifies the supplied conditional
+        propagator by endpoints: diagonal elements weight the ordinary
+        no-transfer response expressions, and off-diagonal elements weight the
+        transfer/remainder response expressions.  No jump-order information is
+        inferred from this propagator.
+        """
+        if mode != "full_conditional":
+            raise ValueError(
+                "External population propagators currently support only "
+                "population_dynamics_mode='full_conditional'"
+            )
+
+        if population_time_axis is None:
+            population_time_axis = self.population_time_axis
+        if population_time_axis is None:
+            population_time_axis = self.t2s
+        self.population_time_axis = population_time_axis
+        self.population_dynamics_mode = mode
+
+        if not self.t2s.is_subset_of(population_time_axis):
+            raise Exception("t2 TimeAxis is not compatible with population dynamics")
+
+        Ufull = self._population_propagator_data(population_propagator)
+        dim = Ufull.shape[0]
+        if Ufull.shape[2] != population_time_axis.length:
+            raise Exception(
+                "Population propagator time dimension has to match the "
+                "population TimeAxis length"
+            )
+
+        it2 = _axis_indices(self.t2s, population_time_axis)
+
+        self.KK = numpy.zeros((dim, dim), dtype=REAL)
+        self.U0_t1 = numpy.ones((dim, self.t1s.length), dtype=REAL)
+        self.U0_t3 = numpy.ones((dim, self.t3s.length), dtype=REAL)
+        self.U0_t2 = numpy.ones((dim, self.t2s.length), dtype=REAL)
+        self.U0_population = numpy.ones((dim, population_time_axis.length), dtype=REAL)
+
+        Udiag_full = numpy.zeros_like(Ufull)
+        for ii in range(population_time_axis.length):
+            diag = numpy.diag(Ufull[:, :, ii])
+            if numpy.any(diag < -1.0e-12):
+                raise Exception("Population propagator diagonal cannot be negative")
+            Udiag_full[:, :, ii] = numpy.diag(diag)
+
+        self.Uee = Ufull[:, :, it2]
+        self.U1_t2 = Udiag_full[:, :, it2]
+        for ii in range(self.t2s.length):
+            diag = numpy.maximum(numpy.diag(self.U1_t2[:, :, ii]), 0.0)
+            self.U0_t2[:, ii] = numpy.sqrt(diag)
+
+        self.Usingle_t2 = numpy.zeros_like(self.Uee)
+        self.Ujump_t2 = (self.U1_t2,)
+        self.Uremainder_t2 = self.Uee - self.U1_t2
+        self.Utransfer_t2 = self.Uremainder_t2
 
     def set_rate_matrix(
         self, KK: numpy.ndarray, population_time_axis: Any = None

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -276,6 +276,7 @@ class NonLinearResponse:
         relaxation_cutoff_time: float | None = None,
         rate_matrix_options: dict[str, Any] | None = None,
         population_time_axis: Any = None,
+        jump_integration_steps: int = 1,
     ) -> None:
 
         # info about pulse polarizations
@@ -301,6 +302,18 @@ class NonLinearResponse:
         self.t2s = t2s
         self.t3s = t3s
         self.population_time_axis = population_time_axis
+        self.jump_integration_steps = jump_integration_steps
+        self.KK: numpy.ndarray
+        self.U0_t1: numpy.ndarray
+        self.U0_t2: numpy.ndarray
+        self.U0_t3: numpy.ndarray
+        self.U0fe_t3: numpy.ndarray | None = None
+        self.Uee: numpy.ndarray
+        self.U1_t2: numpy.ndarray
+        self.Usingle_t2: numpy.ndarray
+        self.Ujump_t2: tuple[numpy.ndarray, ...]
+        self.Uremainder_t2: numpy.ndarray
+        self.Utransfer_t2: numpy.ndarray
 
         if rate_matrix is not None:
             KK = get_single_exciton_rate_matrix(system, rate_matrix)
@@ -343,7 +356,13 @@ class NonLinearResponse:
         U0t2 = self.U0_t2[:, t2i]
 
         # here we specify evolution matrices
-        evol = (self.U0_t1, self.U0_t3, U0t2, self._get_transfer_matrix(t2i))
+        evol = (
+            self.U0_t1,
+            self.U0_t3,
+            U0t2,
+            self._get_transfer_matrix(t2i),
+            {"jump_integration_steps": self.jump_integration_steps},
+        )
 
         return self.func(
             t2,
@@ -397,7 +416,9 @@ class NonLinearResponse:
             return self.Usingle_t2[:, :, t2i]
         return self.Uremainder_t2[:, :, t2i]
 
-    def _get_remainder_propagator(self, jumps: tuple) -> numpy.ndarray:
+    def _get_remainder_propagator(
+        self, jumps: tuple[numpy.ndarray, ...]
+    ) -> numpy.ndarray:
         """Returns propagation not covered by explicit jump contributions."""
         jump_sum = numpy.zeros_like(self.Uee)
         for jump in jumps:
@@ -515,7 +536,9 @@ class NonLinearResponse:
             # time dependent rate matrix
             for aa in range(dim):
                 if numpy.all(KK[:, aa, aa] <= 0.0):
-                    cumulative = numpy.zeros(population_time_axis.length, dtype=REAL)
+                    cumulative: numpy.ndarray = numpy.zeros(
+                        population_time_axis.length, dtype=REAL
+                    )
                     for ii in range(population_time_axis.length - 1):
                         dt = (
                             population_time_axis.data[ii + 1]

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -22,6 +22,36 @@ from .response_implementations import get_implementation
 """
 
 
+def _rate_matrix_data(rate_matrix: Any) -> numpy.ndarray:
+    """Returns numerical data from a rate matrix object or array."""
+    if hasattr(rate_matrix, "data"):
+        return numpy.asarray(rate_matrix.data)
+    return numpy.asarray(rate_matrix)
+
+
+def get_single_exciton_rate_matrix(system: Any, rate_matrix: Any) -> numpy.ndarray:
+    """Returns the single-exciton block of a rate matrix.
+
+    ``OpenSystem.get_RateMatrix`` returns rates indexed by the full Hamiltonian
+    basis. Response implementations, however, use single-exciton indices
+    shifted to start at zero. If a user already supplies a single-exciton rate
+    matrix, it is returned unchanged.
+    """
+    data = _rate_matrix_data(rate_matrix)
+
+    dim = system.Nb[1]
+    if data.shape[-2:] == (dim, dim):
+        return data
+
+    band1 = system.get_band(1)
+    if len(data.shape) == 2:
+        return data[numpy.ix_(band1, band1)]
+    if len(data.shape) == 3:
+        return data[:, band1, :][:, :, band1]
+
+    raise Exception("Rate matrix has to be an array of rank 2 or 3")
+
+
 class NonLinearResponse:
     """Non-linear response function for a specific Feynman diagram type.
 
@@ -42,7 +72,18 @@ class NonLinearResponse:
     """
 
     def __init__(
-        self, lab: Any, system: Any, diagram: str, t1s: Any, t2s: Any, t3s: Any
+        self,
+        lab: Any,
+        system: Any,
+        diagram: str,
+        t1s: Any,
+        t2s: Any,
+        t3s: Any,
+        rate_matrix: Any = None,
+        relaxation_theory: str | None = None,
+        rate_matrix_time_dependent: bool = False,
+        relaxation_cutoff_time: float | None = None,
+        rate_matrix_options: dict[str, Any] | None = None,
     ) -> None:
 
         # info about pulse polarizations
@@ -65,10 +106,20 @@ class NonLinearResponse:
         self.t2s = t2s
         self.t3s = t3s
 
-        # setting zero rates for the case they are not set from outside
-        KK = numpy.zeros(
-            (system.Nb[1] + system.Nb[0], system.Nb[1] + system.Nb[0]), dtype=REAL
-        )
+        if rate_matrix is not None:
+            KK = get_single_exciton_rate_matrix(system, rate_matrix)
+        elif relaxation_theory is not None:
+            options = {} if rate_matrix_options is None else rate_matrix_options
+            KK = system.get_RateMatrix(
+                relaxation_theory=relaxation_theory,
+                time_dependent=rate_matrix_time_dependent,
+                relaxation_cutoff_time=relaxation_cutoff_time,
+                **options,
+            )
+            KK = get_single_exciton_rate_matrix(system, KK)
+        else:
+            KK = numpy.zeros((system.Nb[1], system.Nb[1]), dtype=REAL)
+
         self.set_rate_matrix(KK)
 
     def calculate_matrix(self, t2: float) -> Any:
@@ -150,7 +201,12 @@ class NonLinearResponse:
         self.U0_t3 = numpy.zeros((dim, self.t3s.length), dtype=REAL)
 
         if dim != self.sys.Ntot:
-            if self.sys.mult == 2:
+            if dim == self.sys.Nb[1]:
+                if self.sys.mult == 2:
+                    self.U0fe_t3 = numpy.zeros(
+                        (self.sys.Nb[2], dim, self.t3s.length), dtype=REAL
+                    )
+            elif self.sys.mult == 2:
                 self.U0fe_t3 = numpy.zeros(
                     (self.sys.Nb[2], dim, self.t3s.length), dtype=REAL
                 )

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -121,6 +121,54 @@ RESPONSE_DIAGRAMS = {
         "transfer": True,
         "transfer_channel": "scM0e",
     },
+    "R1g_scM1g": {
+        "rtype": "NR",
+        "signal": signal_NONR,
+        "process": "SE",
+        "storage_type": "R1g_scM1g",
+        "transfer": True,
+        "transfer_channel": "scM1g",
+    },
+    "R2g_scM1g": {
+        "rtype": "R",
+        "signal": signal_REPH,
+        "process": "SE",
+        "storage_type": "R2g_scM1g",
+        "transfer": True,
+        "transfer_channel": "scM1g",
+    },
+    "R1f_scM1g": {
+        "rtype": "NR",
+        "signal": signal_NONR,
+        "process": "ESA",
+        "storage_type": "R1f_scM1g",
+        "transfer": True,
+        "transfer_channel": "scM1g",
+    },
+    "R2f_scM1g": {
+        "rtype": "R",
+        "signal": signal_REPH,
+        "process": "ESA",
+        "storage_type": "R2f_scM1g",
+        "transfer": True,
+        "transfer_channel": "scM1g",
+    },
+    "R1f_scM1e": {
+        "rtype": "NR",
+        "signal": signal_NONR,
+        "process": "ESA",
+        "storage_type": "R1f_scM1e",
+        "transfer": True,
+        "transfer_channel": "scM1e",
+    },
+    "R2f_scM1e": {
+        "rtype": "R",
+        "signal": signal_REPH,
+        "process": "ESA",
+        "storage_type": "R2f_scM1e",
+        "transfer": True,
+        "transfer_channel": "scM1e",
+    },
 }
 
 
@@ -244,6 +292,7 @@ class NonLinearResponse:
         self.process = self.diagram_info["process"]
         self.storage_type = self.diagram_info["storage_type"]
         self.is_transfer = self.diagram_info["transfer"]
+        self.transfer_channel = self.diagram_info.get("transfer_channel", None)
 
         self.func = get_implementation(self.diag)
 
@@ -294,7 +343,7 @@ class NonLinearResponse:
         U0t2 = self.U0_t2[:, t2i]
 
         # here we specify evolution matrices
-        evol = (self.U0_t1, self.U0_t3, U0t2, self.Uremainder_t2[:, :, t2i])
+        evol = (self.U0_t1, self.U0_t3, U0t2, self._get_transfer_matrix(t2i))
 
         return self.func(
             t2,
@@ -321,9 +370,32 @@ class NonLinearResponse:
         for ii in range(self.t2s.length):
             self.Uee[:, :, ii] = numpy.eye(dim, dtype=REAL)
         self.U1_t2 = self.Uee.copy()
+        self.Usingle_t2 = numpy.zeros_like(self.Uee)
         self.Ujump_t2 = (self.U1_t2,)
         self.Uremainder_t2 = self._get_remainder_propagator(self.Ujump_t2)
         self.Utransfer_t2 = self.Uremainder_t2
+
+    def _uses_single_jump_storage(self) -> bool:
+        """Returns ``True`` when line-shape storage is one-jump-ready."""
+        if not hasattr(self.sys, "get_lineshape_functions"):
+            return False
+        try:
+            gg = self.sys.get_lineshape_functions()
+        except Exception:
+            return False
+        return hasattr(gg, "time_mapping") and "s2" in gg.time_mapping
+
+    def _get_jump_expansion_order(self) -> int:
+        """Returns the highest explicit jump order to calculate."""
+        return 1 if self._uses_single_jump_storage() else 0
+
+    def _get_transfer_matrix(self, t2i: int) -> numpy.ndarray:
+        """Returns transfer propagator for the current response channel."""
+        if self.transfer_channel is not None and self.transfer_channel.startswith(
+            "scM1"
+        ):
+            return self.Usingle_t2[:, :, t2i]
+        return self.Uremainder_t2[:, :, t2i]
 
     def _get_remainder_propagator(self, jumps: tuple) -> numpy.ndarray:
         """Returns propagation not covered by explicit jump contributions."""
@@ -429,9 +501,12 @@ class NonLinearResponse:
             prop = PopulationPropagator(population_time_axis, self.KK)
 
             self.Uee = prop.get_PropagationMatrix(self.t2s)
-            jumps = prop.get_JumpExpansion(self.t2s, max_order=0)
+            jumps = prop.get_JumpExpansion(
+                self.t2s, max_order=self._get_jump_expansion_order()
+            )
 
             self.U1_t2 = jumps[0]
+            self.Usingle_t2 = jumps[1] if len(jumps) > 1 else numpy.zeros_like(self.Uee)
             self.Ujump_t2 = jumps
             self.Uremainder_t2 = self._get_remainder_propagator(jumps)
             self.Utransfer_t2 = self.Uremainder_t2
@@ -459,9 +534,12 @@ class NonLinearResponse:
 
             prop = PopulationPropagator(population_time_axis, self.KK)
             self.Uee = prop.get_PropagationMatrix(self.t2s)
-            jumps = prop.get_JumpExpansion(self.t2s, max_order=0)
+            jumps = prop.get_JumpExpansion(
+                self.t2s, max_order=self._get_jump_expansion_order()
+            )
 
             self.U1_t2 = jumps[0]
+            self.Usingle_t2 = jumps[1] if len(jumps) > 1 else numpy.zeros_like(self.Uee)
             self.Ujump_t2 = jumps
             self.Uremainder_t2 = self._get_remainder_propagator(jumps)
             self.Utransfer_t2 = self.Uremainder_t2

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy
 
-from .. import REAL, signal_NONR, signal_REPH
+from .. import COMPLEX, REAL, signal_NONR, signal_REPH
 from ..core.managers import Manager
 from ..core.time import TimeAxis
 from ..qm.propagators.poppropagator import PopulationPropagator
@@ -277,7 +277,11 @@ class NonLinearResponse:
         rate_matrix_options: dict[str, Any] | None = None,
         population_time_axis: Any = None,
         population_propagator: Any = None,
+        density_matrix_propagator: Any = None,
+        density_matrix_trajectory: Any = None,
         population_dynamics_mode: str | None = None,
+        include_nonsecular_remainder: bool = True,
+        dipole_normalization_tol: float = 1.0e-12,
         jump_time_graining: int = 1,
         jump_kernel_cutoff: float = 0.0,
         jump_kernel_zero_cutoff: float = 0.0,
@@ -309,11 +313,15 @@ class NonLinearResponse:
             population_dynamics_mode = (
                 "full_conditional"
                 if population_propagator is not None
+                or density_matrix_propagator is not None
+                or density_matrix_trajectory is not None
                 else "jump_decomposition"
             )
 
         self.population_time_axis = population_time_axis
         self.population_dynamics_mode = population_dynamics_mode
+        self.include_nonsecular_remainder = include_nonsecular_remainder
+        self.dipole_normalization_tol = dipole_normalization_tol
         self.jump_time_graining = jump_time_graining
         self.jump_kernel_cutoff = jump_kernel_cutoff
         self.jump_kernel_zero_cutoff = jump_kernel_zero_cutoff
@@ -332,13 +340,44 @@ class NonLinearResponse:
         self.diagnostics: dict[str, Any] = {}
         self._previous_response_matrix: numpy.ndarray | None = None
 
-        if population_propagator is not None and (
+        external_count = sum(
+            item is not None
+            for item in (
+                population_propagator,
+                density_matrix_propagator,
+                density_matrix_trajectory,
+            )
+        )
+        if external_count > 1:
+            raise ValueError(
+                "population_propagator, density_matrix_propagator, and "
+                "density_matrix_trajectory are mutually exclusive"
+            )
+        if external_count > 0 and (
             rate_matrix is not None or relaxation_theory is not None
         ):
             raise ValueError(
-                "population_propagator cannot be combined with rate_matrix "
+                "External propagators cannot be combined with rate_matrix "
                 "or relaxation_theory"
             )
+
+        if density_matrix_propagator is not None:
+            self.set_density_matrix_propagator(
+                density_matrix_propagator,
+                population_time_axis=population_time_axis,
+                mode=population_dynamics_mode,
+                include_nonsecular_remainder=include_nonsecular_remainder,
+            )
+            return
+
+        if density_matrix_trajectory is not None:
+            self.set_density_matrix_trajectory(
+                density_matrix_trajectory,
+                population_time_axis=population_time_axis,
+                mode=population_dynamics_mode,
+                dipole_normalization_tol=dipole_normalization_tol,
+            )
+            return
 
         if population_propagator is not None:
             self.set_population_propagator(
@@ -405,6 +444,8 @@ class NonLinearResponse:
             "jump_kernel_cutoff": self.jump_kernel_cutoff,
             "jump_kernel_zero_cutoff": self.jump_kernel_zero_cutoff,
         }
+        if hasattr(self, "Udm_zero_t2"):
+            metadata["density_matrix_endpoint_t2"] = self.Udm_zero_t2[:, :, t2i]
 
         # here we specify evolution matrices
         evol = (
@@ -533,6 +574,215 @@ class NonLinearResponse:
             "Population propagator has to have shape (N, N, Nt) "
             "or (Nt, N, N), where N is the number of single-exciton states"
         )
+
+    def _density_matrix_propagator_data(
+        self, density_matrix_propagator: Any
+    ) -> numpy.ndarray:
+        """Returns density-matrix propagator data in ``(N, N, N, N, Nt)`` order."""
+        data = numpy.asarray(
+            density_matrix_propagator.data
+            if hasattr(density_matrix_propagator, "data")
+            else density_matrix_propagator
+        )
+        if len(data.shape) != 5:
+            raise Exception("Density-matrix propagator has to be an array of rank 5")
+
+        dim = self.sys.Nb[1]
+        if data.shape[:4] == (dim, dim, dim, dim):
+            return data.astype(COMPLEX, copy=False)
+        if data.shape[1:] == (dim, dim, dim, dim):
+            return numpy.transpose(data, (1, 2, 3, 4, 0)).astype(COMPLEX, copy=False)
+
+        raise Exception(
+            "Density-matrix propagator has to have shape (N, N, N, N, Nt) "
+            "or (Nt, N, N, N, N), where N is the number of single-exciton states"
+        )
+
+    def _density_matrix_trajectory_data(
+        self, density_matrix_trajectory: Any
+    ) -> numpy.ndarray:
+        """Returns density-matrix trajectory data in ``(N, N, Nt)`` order."""
+        data = numpy.asarray(
+            density_matrix_trajectory.data
+            if hasattr(density_matrix_trajectory, "data")
+            else density_matrix_trajectory
+        )
+        if len(data.shape) != 3:
+            raise Exception("Density-matrix trajectory has to be an array of rank 3")
+
+        dim = self.sys.Nb[1]
+        if data.shape[0] == dim and data.shape[1] == dim:
+            return data.astype(COMPLEX, copy=False)
+        if data.shape[1] == dim and data.shape[2] == dim:
+            return numpy.transpose(data, (1, 2, 0)).astype(COMPLEX, copy=False)
+
+        band1 = self.sys.get_band(1)
+        if data.shape[0] == self.sys.Ntot and data.shape[1] == self.sys.Ntot:
+            return data[numpy.ix_(band1, band1)].astype(COMPLEX, copy=False)
+        if data.shape[1] == self.sys.Ntot and data.shape[2] == self.sys.Ntot:
+            subset = data[:, band1, :][:, :, band1]
+            return numpy.transpose(subset, (1, 2, 0)).astype(COMPLEX, copy=False)
+
+        raise Exception(
+            "Density-matrix trajectory has to have shape (N, N, Nt), "
+            "(Nt, N, N), or the corresponding full-system shape"
+        )
+
+    def _ground_exciton_dipole_lengths(self) -> numpy.ndarray:
+        """Returns lengths of ground-to-one-exciton transition dipoles."""
+        self.sys.diagonalize()
+        band0 = self.sys.get_band(0)
+        if len(band0) != 1:
+            raise Exception(
+                "Density-matrix trajectory normalization requires one ground state"
+            )
+        ground = band0[0]
+        band1 = self.sys.get_band(1)
+        lengths = numpy.zeros(self.sys.Nb[1], dtype=REAL)
+        for aa, state in enumerate(band1):
+            lengths[aa] = numpy.linalg.norm(self.sys.DD[state, ground, :])
+        return lengths
+
+    def set_density_matrix_trajectory(
+        self,
+        density_matrix_trajectory: Any,
+        population_time_axis: Any = None,
+        mode: str = "full_conditional",
+        dipole_normalization_tol: float = 1.0e-12,
+    ) -> None:
+        """Set an externally propagated RDM trajectory as endpoint weights.
+
+        The trajectory is intended for pump-probe-like calculations with
+        ``t1 = 0``.  It is divided by the lengths of the two transition dipoles
+        that prepared the initial excited-state density matrix.
+        """
+        if mode != "full_conditional":
+            raise ValueError(
+                "Density-matrix trajectories currently support only "
+                "population_dynamics_mode='full_conditional'"
+            )
+        if self.t1s.length != 1 or not numpy.isclose(self.t1s.data[0], 0.0):
+            raise ValueError(
+                "Density-matrix trajectory weighting is only allowed for "
+                "pump-probe-like calculations with t1 = 0"
+            )
+
+        if population_time_axis is None:
+            population_time_axis = self.population_time_axis
+        if population_time_axis is None:
+            population_time_axis = self.t2s
+        self.population_time_axis = population_time_axis
+        self.population_dynamics_mode = mode
+        self.dipole_normalization_tol = dipole_normalization_tol
+
+        if not self.t2s.is_subset_of(population_time_axis):
+            raise Exception("t2 TimeAxis is not compatible with population dynamics")
+
+        rho = self._density_matrix_trajectory_data(density_matrix_trajectory)
+        dim = rho.shape[0]
+        if rho.shape[2] != population_time_axis.length:
+            raise Exception(
+                "Density-matrix trajectory time dimension has to match the "
+                "population TimeAxis length"
+            )
+
+        dipoles = self._ground_exciton_dipole_lengths()
+        norm = dipoles[:, None] * dipoles[None, :]
+        if numpy.any(numpy.abs(norm) <= dipole_normalization_tol):
+            raise ValueError(
+                "Cannot normalize density matrix trajectory by zero transition "
+                "dipole length"
+            )
+
+        weights = rho / norm[:, :, None]
+        it2 = _axis_indices(self.t2s, population_time_axis)
+
+        self.KK = numpy.zeros((dim, dim), dtype=REAL)
+        self.U0_t1 = numpy.ones((dim, self.t1s.length), dtype=REAL)
+        self.U0_t3 = numpy.ones((dim, self.t3s.length), dtype=REAL)
+        self.U0_t2 = numpy.ones((dim, self.t2s.length), dtype=REAL)
+        self.U0_population = numpy.ones((dim, population_time_axis.length), dtype=REAL)
+
+        self.Udm_zero_t2 = weights[:, :, it2]
+        self.Uee = numpy.zeros((dim, dim, self.t2s.length), dtype=COMPLEX)
+        self.U1_t2 = numpy.zeros_like(self.Uee)
+        for ii in range(self.t2s.length):
+            self.U1_t2[:, :, ii] = numpy.diag(numpy.diag(self.Udm_zero_t2[:, :, ii]))
+        self.Usingle_t2 = numpy.zeros_like(self.Uee)
+        self.Ujump_t2 = (self.U1_t2,)
+        self.Uremainder_t2 = numpy.zeros_like(self.Uee)
+        self.Utransfer_t2 = self.Uremainder_t2
+
+    def set_density_matrix_propagator(
+        self,
+        density_matrix_propagator: Any,
+        population_time_axis: Any = None,
+        mode: str = "full_conditional",
+        include_nonsecular_remainder: bool = True,
+    ) -> None:
+        """Set an externally calculated one-exciton RDM superoperator.
+
+        The endpoint-preserving elements ``U[a,b,a,b,t]`` weight ordinary
+        response expressions.  Endpoint-changing elements are collapsed into
+        an endpoint remainder when ``include_nonsecular_remainder`` is true.
+        """
+        if mode != "full_conditional":
+            raise ValueError(
+                "External density-matrix propagators currently support only "
+                "population_dynamics_mode='full_conditional'"
+            )
+
+        if population_time_axis is None:
+            population_time_axis = self.population_time_axis
+        if population_time_axis is None:
+            population_time_axis = self.t2s
+        self.population_time_axis = population_time_axis
+        self.population_dynamics_mode = mode
+        self.include_nonsecular_remainder = include_nonsecular_remainder
+
+        if not self.t2s.is_subset_of(population_time_axis):
+            raise Exception("t2 TimeAxis is not compatible with population dynamics")
+
+        Ufull = self._density_matrix_propagator_data(density_matrix_propagator)
+        dim = Ufull.shape[0]
+        if Ufull.shape[4] != population_time_axis.length:
+            raise Exception(
+                "Density-matrix propagator time dimension has to match the "
+                "population TimeAxis length"
+            )
+
+        it2 = _axis_indices(self.t2s, population_time_axis)
+
+        self.KK = numpy.zeros((dim, dim), dtype=REAL)
+        self.U0_t1 = numpy.ones((dim, self.t1s.length), dtype=REAL)
+        self.U0_t3 = numpy.ones((dim, self.t3s.length), dtype=REAL)
+        self.U0_t2 = numpy.ones((dim, self.t2s.length), dtype=REAL)
+        self.U0_population = numpy.ones((dim, population_time_axis.length), dtype=REAL)
+
+        Uzero = numpy.zeros((dim, dim, population_time_axis.length), dtype=COMPLEX)
+        Uremainder = numpy.zeros_like(Uzero)
+        for aa in range(dim):
+            for bb in range(dim):
+                Uzero[aa, bb, :] = Ufull[aa, bb, aa, bb, :]
+                if include_nonsecular_remainder:
+                    Uremainder[aa, bb, :] = numpy.sum(
+                        Ufull[aa, bb, :, :, :], axis=(0, 1)
+                    )
+                    Uremainder[aa, bb, :] -= Uzero[aa, bb, :]
+
+        self.Udm_zero_t2 = Uzero[:, :, it2]
+        self.Uee = numpy.zeros((dim, dim, self.t2s.length), dtype=COMPLEX)
+        for ii, tindex in enumerate(it2):
+            self.Uee[:, :, ii] = Ufull[:, :, :, :, tindex].trace(axis1=0, axis2=2)
+        self.U1_t2 = numpy.zeros_like(self.Uee)
+        for ii in range(self.t2s.length):
+            self.U1_t2[:, :, ii] = numpy.diag(numpy.diag(self.Udm_zero_t2[:, :, ii]))
+
+        self.U0_t2[:, :] = 1.0
+        self.Usingle_t2 = numpy.zeros_like(self.Uee)
+        self.Ujump_t2 = (self.U1_t2,)
+        self.Uremainder_t2 = Uremainder[:, :, it2]
+        self.Utransfer_t2 = self.Uremainder_t2
 
     def set_population_propagator(
         self,

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -277,6 +277,8 @@ class NonLinearResponse:
         rate_matrix_options: dict[str, Any] | None = None,
         population_time_axis: Any = None,
         jump_time_graining: int = 1,
+        jump_kernel_cutoff: float = 0.0,
+        jump_kernel_zero_cutoff: float = 0.0,
     ) -> None:
 
         # info about pulse polarizations
@@ -303,10 +305,13 @@ class NonLinearResponse:
         self.t3s = t3s
         self.population_time_axis = population_time_axis
         self.jump_time_graining = jump_time_graining
+        self.jump_kernel_cutoff = jump_kernel_cutoff
+        self.jump_kernel_zero_cutoff = jump_kernel_zero_cutoff
         self.KK: numpy.ndarray
         self.U0_t1: numpy.ndarray
         self.U0_t2: numpy.ndarray
         self.U0_t3: numpy.ndarray
+        self.U0_population: numpy.ndarray
         self.U0fe_t3: numpy.ndarray | None = None
         self.Uee: numpy.ndarray
         self.U1_t2: numpy.ndarray
@@ -314,6 +319,8 @@ class NonLinearResponse:
         self.Ujump_t2: tuple[numpy.ndarray, ...]
         self.Uremainder_t2: numpy.ndarray
         self.Utransfer_t2: numpy.ndarray
+        self.diagnostics: dict[str, Any] = {}
+        self._previous_response_matrix: numpy.ndarray | None = None
 
         if rate_matrix is not None:
             KK = get_single_exciton_rate_matrix(system, rate_matrix)
@@ -352,11 +359,26 @@ class NonLinearResponse:
         out = self.t2s.locate(t2)
         t2i = out[0]
         pt2i = t2i
+        pzeroi = 0
         if self.population_time_axis is not None:
+            try:
+                pzeroi = self.population_time_axis.locate(0.0)[0]
+            except Exception:
+                pzeroi = 0
             pt2i = self.population_time_axis.locate(t2)[0]
 
         # population decay factors at t2
         U0t2 = self.U0_t2[:, t2i]
+
+        metadata: dict[str, Any] = {
+            "jump_time_axis": self.population_time_axis,
+            "jump_time_zero_index": pzeroi,
+            "jump_time_t2_index": pt2i,
+            "jump_time_graining": self.jump_time_graining,
+            "jump_zero_propagator": self.U0_population,
+            "jump_kernel_cutoff": self.jump_kernel_cutoff,
+            "jump_kernel_zero_cutoff": self.jump_kernel_zero_cutoff,
+        }
 
         # here we specify evolution matrices
         evol = (
@@ -364,14 +386,10 @@ class NonLinearResponse:
             self.U0_t3,
             U0t2,
             self._get_transfer_matrix(t2i),
-            {
-                "jump_time_axis": self.population_time_axis,
-                "jump_time_t2_index": pt2i,
-                "jump_time_graining": self.jump_time_graining,
-            },
+            metadata,
         )
 
-        return self.func(
+        data = self.func(
             t2,
             self.t1s.data,
             self.t3s.data,
@@ -380,6 +398,40 @@ class NonLinearResponse:
             evol,
             self.KK,
         )
+        self._update_diagnostics(t2, data, metadata)
+        return data
+
+    def _update_diagnostics(
+        self, t2: float, data: numpy.ndarray, metadata: dict[str, Any]
+    ) -> None:
+        """Update response diagnostics after a t2 calculation."""
+        norm = float(numpy.linalg.norm(data))
+        previous_norm = 0.0
+        relative_change = None
+        if self._previous_response_matrix is not None:
+            previous_norm = float(numpy.linalg.norm(self._previous_response_matrix))
+            denom = max(norm, previous_norm, 1.0e-300)
+            relative_change = float(
+                numpy.linalg.norm(data - self._previous_response_matrix) / denom
+            )
+
+        self.diagnostics = {
+            "diagram": self.diag,
+            "t2": float(t2),
+            "response_norm": norm,
+            "previous_response_norm": previous_norm,
+            "relative_change": relative_change,
+            "is_transfer": self.is_transfer,
+            "transfer_channel": self.transfer_channel,
+        }
+        if self.transfer_channel is not None and self.transfer_channel.startswith(
+            "scM0"
+        ):
+            self.diagnostics["remainder_relative_change"] = relative_change
+        if "jump_diagnostics" in metadata:
+            self.diagnostics["jump"] = metadata["jump_diagnostics"].get(self.diag, {})
+
+        self._previous_response_matrix = data.copy()
 
     def set_rwa(self, rwa: float) -> None:
         """Sets rotating wave approximation frequency"""
@@ -391,6 +443,7 @@ class NonLinearResponse:
         self.U0_t1 = numpy.ones((dim, self.t1s.length), dtype=REAL)
         self.U0_t2 = numpy.ones((dim, self.t2s.length), dtype=REAL)
         self.U0_t3 = numpy.ones((dim, self.t3s.length), dtype=REAL)
+        self.U0_population = numpy.ones((dim, self.t2s.length), dtype=REAL)
 
         self.Uee = numpy.zeros((dim, dim, self.t2s.length), dtype=REAL)
         for ii in range(self.t2s.length):
@@ -485,6 +538,7 @@ class NonLinearResponse:
         self.U0_t2 = numpy.zeros((dim, self.t2s.length), dtype=REAL)
         self.U0_t1 = numpy.zeros((dim, self.t1s.length), dtype=REAL)
         self.U0_t3 = numpy.zeros((dim, self.t3s.length), dtype=REAL)
+        self.U0_population = numpy.zeros((dim, population_time_axis.length), dtype=REAL)
 
         it1 = _axis_indices(self.t1s, population_time_axis)
         it2 = _axis_indices(self.t2s, population_time_axis)
@@ -510,10 +564,13 @@ class NonLinearResponse:
             #
             for aa in range(KK.shape[0]):
                 if KK[aa, aa] <= 0.0:
-                    amplitude = numpy.exp(0.5 * KK[aa, aa] * population_time_axis.data)
-                    self.U0_t1[aa, :] = amplitude[it1]
-                    self.U0_t2[aa, :] = amplitude[it2]
-                    self.U0_t3[aa, :] = amplitude[it3]
+                    self.U0_population[aa, :] = numpy.exp(
+                        KK[aa, aa] * population_time_axis.data
+                    )
+                    coherence_amplitude = numpy.sqrt(self.U0_population[aa, :])
+                    self.U0_t1[aa, :] = coherence_amplitude[it1]
+                    self.U0_t2[aa, :] = coherence_amplitude[it2]
+                    self.U0_t3[aa, :] = coherence_amplitude[it3]
                 else:
                     raise Exception("Depopulation rate must be negative.")
 
@@ -553,12 +610,13 @@ class NonLinearResponse:
                         )
                         cumulative[ii + 1] = (
                             cumulative[ii]
-                            + 0.25 * (KK[ii, aa, aa] + KK[ii + 1, aa, aa]) * dt
+                            + 0.5 * (KK[ii, aa, aa] + KK[ii + 1, aa, aa]) * dt
                         )
-                    amplitude = numpy.exp(cumulative)
-                    self.U0_t1[aa, :] = amplitude[it1]
-                    self.U0_t2[aa, :] = amplitude[it2]
-                    self.U0_t3[aa, :] = amplitude[it3]
+                    self.U0_population[aa, :] = numpy.exp(cumulative)
+                    coherence_amplitude = numpy.sqrt(self.U0_population[aa, :])
+                    self.U0_t1[aa, :] = coherence_amplitude[it1]
+                    self.U0_t2[aa, :] = coherence_amplitude[it2]
+                    self.U0_t3[aa, :] = coherence_amplitude[it3]
                 else:
                     raise Exception("Depopulation rate must be negative.")
 

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -276,7 +276,7 @@ class NonLinearResponse:
         relaxation_cutoff_time: float | None = None,
         rate_matrix_options: dict[str, Any] | None = None,
         population_time_axis: Any = None,
-        jump_integration_steps: int = 1,
+        jump_time_graining: int = 1,
     ) -> None:
 
         # info about pulse polarizations
@@ -302,7 +302,7 @@ class NonLinearResponse:
         self.t2s = t2s
         self.t3s = t3s
         self.population_time_axis = population_time_axis
-        self.jump_integration_steps = jump_integration_steps
+        self.jump_time_graining = jump_time_graining
         self.KK: numpy.ndarray
         self.U0_t1: numpy.ndarray
         self.U0_t2: numpy.ndarray
@@ -351,6 +351,9 @@ class NonLinearResponse:
         # identify the index of the present t2 time
         out = self.t2s.locate(t2)
         t2i = out[0]
+        pt2i = t2i
+        if self.population_time_axis is not None:
+            pt2i = self.population_time_axis.locate(t2)[0]
 
         # population decay factors at t2
         U0t2 = self.U0_t2[:, t2i]
@@ -361,7 +364,11 @@ class NonLinearResponse:
             self.U0_t3,
             U0t2,
             self._get_transfer_matrix(t2i),
-            {"jump_integration_steps": self.jump_integration_steps},
+            {
+                "jump_time_axis": self.population_time_axis,
+                "jump_time_t2_index": pt2i,
+                "jump_time_graining": self.jump_time_graining,
+            },
         )
 
         return self.func(

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy
 
-from .. import REAL
+from .. import REAL, signal_NONR, signal_REPH
 from ..core.managers import Manager
 from ..qm.propagators.poppropagator import PopulationPropagator
 from .response_implementations import get_implementation
@@ -20,6 +20,115 @@ from .response_implementations import get_implementation
 
 
 """
+
+
+RESPONSE_DIAGRAMS = {
+    # Ground-state bleach
+    # Corresponds to the GSB calls in the old Aceto/twod22 workflow.
+    "R3g": {
+        "rtype": "R",
+        "signal": signal_REPH,
+        "process": "GSB",
+        "storage_type": "R3g",
+        "transfer": False,
+    },
+    "R4g": {
+        "rtype": "NR",
+        "signal": signal_NONR,
+        "process": "GSB",
+        "storage_type": "R4g",
+        "transfer": False,
+    },
+    # Stimulated emission
+    "R1g": {
+        "rtype": "NR",
+        "signal": signal_NONR,
+        "process": "SE",
+        "storage_type": "R1g",
+        "transfer": False,
+    },
+    "R2g": {
+        "rtype": "R",
+        "signal": signal_REPH,
+        "process": "SE",
+        "storage_type": "R2g",
+        "transfer": False,
+    },
+    # Excited-state absorption.  The modern implementation names these
+    # diagrams R1f/R2f; older storage comments sometimes use R1fs/R2fs.
+    "R1f": {
+        "rtype": "NR",
+        "signal": signal_NONR,
+        "process": "ESA",
+        "storage_type": "R1f",
+        "transfer": False,
+    },
+    "R2f": {
+        "rtype": "R",
+        "signal": signal_REPH,
+        "process": "ESA",
+        "storage_type": "R2f",
+        "transfer": False,
+    },
+    # Relaxation/transfer corrections to SE-like response terms.
+    "R1g_scM0g": {
+        "rtype": "NR",
+        "signal": signal_NONR,
+        "process": "SE",
+        "storage_type": "R1g_scM0g",
+        "transfer": True,
+        "transfer_channel": "scM0g",
+    },
+    "R2g_scM0g": {
+        "rtype": "R",
+        "signal": signal_REPH,
+        "process": "SE",
+        "storage_type": "R2g_scM0g",
+        "transfer": True,
+        "transfer_channel": "scM0g",
+    },
+    # Relaxation/transfer corrections to ESA-like response terms.
+    "R1f_scM0g": {
+        "rtype": "NR",
+        "signal": signal_NONR,
+        "process": "ESA",
+        "storage_type": "R1f_scM0g",
+        "transfer": True,
+        "transfer_channel": "scM0g",
+    },
+    "R2f_scM0g": {
+        "rtype": "R",
+        "signal": signal_REPH,
+        "process": "ESA",
+        "storage_type": "R2f_scM0g",
+        "transfer": True,
+        "transfer_channel": "scM0g",
+    },
+    "R1f_scM0e": {
+        "rtype": "NR",
+        "signal": signal_NONR,
+        "process": "ESA",
+        "storage_type": "R1f_scM0e",
+        "transfer": True,
+        "transfer_channel": "scM0e",
+    },
+    "R2f_scM0e": {
+        "rtype": "R",
+        "signal": signal_REPH,
+        "process": "ESA",
+        "storage_type": "R2f_scM0e",
+        "transfer": True,
+        "transfer_channel": "scM0e",
+    },
+}
+
+
+def get_response_diagram_info(diagram: str) -> dict[str, Any]:
+    """Returns explicit metadata for a nonlinear response diagram."""
+    try:
+        return RESPONSE_DIAGRAMS[diagram].copy()
+    except KeyError:
+        raise Exception("Unknown response diagram: " + diagram)
 
 
 def _rate_matrix_data(rate_matrix: Any) -> numpy.ndarray:
@@ -94,10 +203,12 @@ class NonLinearResponse:
 
         # which response to calculate; the function to calculate the respose
         self.diag = diagram
-        if self.diag in ["R1g", "R4g", "R1f", "R1g_scM0g", "R1f_scM0g", "R1f_scM0e"]:
-            self.rtype = "NR"
-        elif self.diag in ["R2g", "R3g", "R2f", "R2g_scM0g", "R2f_scM0g", "R2f_scM0e"]:
-            self.rtype = "R"
+        self.diagram_info = get_response_diagram_info(self.diag)
+        self.rtype = self.diagram_info["rtype"]
+        self.signal = self.diagram_info["signal"]
+        self.process = self.diagram_info["process"]
+        self.storage_type = self.diagram_info["storage_type"]
+        self.is_transfer = self.diagram_info["transfer"]
 
         self.func = get_implementation(self.diag)
 

--- a/quantarhei/spectroscopy/responses.py
+++ b/quantarhei/spectroscopy/responses.py
@@ -6,6 +6,7 @@ import numpy
 
 from .. import REAL, signal_NONR, signal_REPH
 from ..core.managers import Manager
+from ..core.time import TimeAxis
 from ..qm.propagators.poppropagator import PopulationPropagator
 from .response_implementations import get_implementation
 
@@ -161,6 +162,39 @@ def get_single_exciton_rate_matrix(system: Any, rate_matrix: Any) -> numpy.ndarr
     raise Exception("Rate matrix has to be an array of rank 2 or 3")
 
 
+def get_common_time_axis(*axes: Any) -> Any:
+    """Returns a common zero-start TimeAxis covering all submitted axes."""
+    dt = min(axis.step for axis in axes)
+    tmax = max(axis.max for axis in axes)
+    length = int(numpy.rint(tmax / dt)) + 1
+    return TimeAxis(0.0, length, dt)
+
+
+def validate_2d_time_axes(t1s: Any, t2s: Any, t3s: Any) -> None:
+    """Validates 2D time axes for relaxation-enabled calculations."""
+    if not numpy.isclose(t1s.step, t3s.step):
+        raise Exception("t1 and t3 axes must have the same time step")
+
+    nstep = numpy.rint(t2s.step / t1s.step)
+    if not numpy.isclose(nstep * t1s.step, t2s.step):
+        raise Exception("t2 time step must be a multiple of t1/t3 time step")
+
+
+def _axis_indices(axis: Any, base_axis: Any) -> numpy.ndarray:
+    """Returns integer indices of ``axis`` values on ``base_axis``."""
+    if not axis.is_subset_of(base_axis):
+        raise Exception("TimeAxis is not a subset of the population time axis")
+
+    indices = numpy.rint((axis.data - base_axis.start) / base_axis.step).astype(
+        numpy.int64
+    )
+    times = base_axis.start + indices * base_axis.step
+    if not numpy.allclose(times, axis.data):
+        raise Exception("TimeAxis is not a subset of the population time axis")
+
+    return indices
+
+
 class NonLinearResponse:
     """Non-linear response function for a specific Feynman diagram type.
 
@@ -193,6 +227,7 @@ class NonLinearResponse:
         rate_matrix_time_dependent: bool = False,
         relaxation_cutoff_time: float | None = None,
         rate_matrix_options: dict[str, Any] | None = None,
+        population_time_axis: Any = None,
     ) -> None:
 
         # info about pulse polarizations
@@ -216,6 +251,7 @@ class NonLinearResponse:
         self.t1s = t1s
         self.t2s = t2s
         self.t3s = t3s
+        self.population_time_axis = population_time_axis
 
         if rate_matrix is not None:
             KK = get_single_exciton_rate_matrix(system, rate_matrix)
@@ -229,9 +265,12 @@ class NonLinearResponse:
             )
             KK = get_single_exciton_rate_matrix(system, KK)
         else:
-            KK = numpy.zeros((system.Nb[1], system.Nb[1]), dtype=REAL)
+            KK = None
 
-        self.set_rate_matrix(KK)
+        if KK is None:
+            self._set_identity_dynamics(system.Nb[1])
+        else:
+            self.set_rate_matrix(KK, population_time_axis=population_time_axis)
 
     def calculate_matrix(self, t2: float) -> Any:
         """Calculate the matrix of response values over t1 and t3 times.
@@ -255,7 +294,7 @@ class NonLinearResponse:
         U0t2 = self.U0_t2[:, t2i]
 
         # here we specify evolution matrices
-        evol = (self.U0_t1, self.U0_t3, U0t2, self.Uee[:, :, t2i])
+        evol = (self.U0_t1, self.U0_t3, U0t2, self.Uremainder_t2[:, :, t2i])
 
         return self.func(
             t2,
@@ -271,7 +310,31 @@ class NonLinearResponse:
         """Sets rotating wave approximation frequency"""
         pass  # rwa is set through the system class, at least for now
 
-    def set_rate_matrix(self, KK: numpy.ndarray) -> None:
+    def _set_identity_dynamics(self, dim: int) -> None:
+        """Sets relaxation-free population and coherence dynamics."""
+        self.KK = numpy.zeros((dim, dim), dtype=REAL)
+        self.U0_t1 = numpy.ones((dim, self.t1s.length), dtype=REAL)
+        self.U0_t2 = numpy.ones((dim, self.t2s.length), dtype=REAL)
+        self.U0_t3 = numpy.ones((dim, self.t3s.length), dtype=REAL)
+
+        self.Uee = numpy.zeros((dim, dim, self.t2s.length), dtype=REAL)
+        for ii in range(self.t2s.length):
+            self.Uee[:, :, ii] = numpy.eye(dim, dtype=REAL)
+        self.U1_t2 = self.Uee.copy()
+        self.Ujump_t2 = (self.U1_t2,)
+        self.Uremainder_t2 = self._get_remainder_propagator(self.Ujump_t2)
+        self.Utransfer_t2 = self.Uremainder_t2
+
+    def _get_remainder_propagator(self, jumps: tuple) -> numpy.ndarray:
+        """Returns propagation not covered by explicit jump contributions."""
+        jump_sum = numpy.zeros_like(self.Uee)
+        for jump in jumps:
+            jump_sum += jump
+        return self.Uee - jump_sum
+
+    def set_rate_matrix(
+        self, KK: numpy.ndarray, population_time_axis: Any = None
+    ) -> None:
         """Set the rate matrix and pre-compute the evolution coefficients.
 
         Parameters
@@ -288,6 +351,18 @@ class NonLinearResponse:
             positive.
         """
         KK = numpy.asarray(KK)
+        if population_time_axis is None:
+            population_time_axis = self.population_time_axis
+        if population_time_axis is None:
+            population_time_axis = get_common_time_axis(self.t1s, self.t2s, self.t3s)
+        self.population_time_axis = population_time_axis
+
+        if not self.t1s.is_subset_of(population_time_axis):
+            raise Exception("t1 TimeAxis is not compatible with population dynamics")
+        if not self.t2s.is_subset_of(population_time_axis):
+            raise Exception("t2 TimeAxis is not compatible with population dynamics")
+        if not self.t3s.is_subset_of(population_time_axis):
+            raise Exception("t3 TimeAxis is not compatible with population dynamics")
 
         if len(KK.shape) == 2:
             dim = KK.shape[0]
@@ -297,10 +372,10 @@ class NonLinearResponse:
             dim = KK.shape[1]
             if KK.shape[1] != KK.shape[2]:
                 raise Exception("Square matrix must be submitted")
-            if KK.shape[0] != self.t2s.length:
+            if KK.shape[0] != population_time_axis.length:
                 raise Exception(
                     "Time-dependent rate matrix has to have the same length "
-                    "as the t2 TimeAxis"
+                    "as the population TimeAxis"
                 )
         else:
             raise Exception("Rate matrix has to be an array of rank 2 or 3")
@@ -310,6 +385,10 @@ class NonLinearResponse:
         self.U0_t2 = numpy.zeros((dim, self.t2s.length), dtype=REAL)
         self.U0_t1 = numpy.zeros((dim, self.t1s.length), dtype=REAL)
         self.U0_t3 = numpy.zeros((dim, self.t3s.length), dtype=REAL)
+
+        it1 = _axis_indices(self.t1s, population_time_axis)
+        it2 = _axis_indices(self.t2s, population_time_axis)
+        it3 = _axis_indices(self.t3s, population_time_axis)
 
         if dim != self.sys.Ntot:
             if dim == self.sys.Nb[1]:
@@ -331,9 +410,10 @@ class NonLinearResponse:
             #
             for aa in range(KK.shape[0]):
                 if KK[aa, aa] <= 0.0:
-                    self.U0_t2[aa, :] = numpy.exp(0.5 * KK[aa, aa] * self.t2s.data)
-                    self.U0_t1[aa, :] = 1.0  # numpy.exp(0.5*KK[aa,aa]*self.t1s.data)
-                    self.U0_t3[aa, :] = 1.0  # numpy.exp(0.5*KK[aa,aa]*self.t3s.data)
+                    amplitude = numpy.exp(0.5 * KK[aa, aa] * population_time_axis.data)
+                    self.U0_t1[aa, :] = amplitude[it1]
+                    self.U0_t2[aa, :] = amplitude[it2]
+                    self.U0_t3[aa, :] = amplitude[it3]
                 else:
                     raise Exception("Depopulation rate must be negative.")
 
@@ -346,35 +426,45 @@ class NonLinearResponse:
             #
 
             # FIXME: Make sure it works with all t2s
-            prop = PopulationPropagator(self.t2s, self.KK)
+            prop = PopulationPropagator(population_time_axis, self.KK)
 
             self.Uee = prop.get_PropagationMatrix(self.t2s)
             jumps = prop.get_JumpExpansion(self.t2s, max_order=0)
 
             self.U1_t2 = jumps[0]
+            self.Ujump_t2 = jumps
+            self.Uremainder_t2 = self._get_remainder_propagator(jumps)
+            self.Utransfer_t2 = self.Uremainder_t2
 
         if len(KK.shape) == 3:
             # time dependent rate matrix
             for aa in range(dim):
                 if numpy.all(KK[:, aa, aa] <= 0.0):
-                    cumulative = numpy.zeros(self.t2s.length, dtype=REAL)
-                    for ii in range(self.t2s.length - 1):
-                        dt = self.t2s.data[ii + 1] - self.t2s.data[ii]
+                    cumulative = numpy.zeros(population_time_axis.length, dtype=REAL)
+                    for ii in range(population_time_axis.length - 1):
+                        dt = (
+                            population_time_axis.data[ii + 1]
+                            - population_time_axis.data[ii]
+                        )
                         cumulative[ii + 1] = (
                             cumulative[ii]
                             + 0.25 * (KK[ii, aa, aa] + KK[ii + 1, aa, aa]) * dt
                         )
-                    self.U0_t2[aa, :] = numpy.exp(cumulative)
-                    self.U0_t1[aa, :] = 1.0
-                    self.U0_t3[aa, :] = 1.0
+                    amplitude = numpy.exp(cumulative)
+                    self.U0_t1[aa, :] = amplitude[it1]
+                    self.U0_t2[aa, :] = amplitude[it2]
+                    self.U0_t3[aa, :] = amplitude[it3]
                 else:
                     raise Exception("Depopulation rate must be negative.")
 
-            prop = PopulationPropagator(self.t2s, self.KK)
+            prop = PopulationPropagator(population_time_axis, self.KK)
             self.Uee = prop.get_PropagationMatrix(self.t2s)
             jumps = prop.get_JumpExpansion(self.t2s, max_order=0)
 
             self.U1_t2 = jumps[0]
+            self.Ujump_t2 = jumps
+            self.Uremainder_t2 = self._get_remainder_propagator(jumps)
+            self.Utransfer_t2 = self.Uremainder_t2
 
 
 ###############################################################################

--- a/quantarhei/spectroscopy/twod22.py
+++ b/quantarhei/spectroscopy/twod22.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 # import h5py
 import time
+import warnings
 from typing import IO, Any
 
 import matplotlib.pyplot as plt
@@ -28,6 +29,25 @@ from ..core.units import convert
 from ..qm.propagators.poppropagator import PopulationPropagator
 from ..spectroscopy.responses import get_single_exciton_rate_matrix
 from ..utils import derived_type
+
+
+def _ensure_time_independent_rates(
+    rate_matrix: Any = None, rate_matrix_time_dependent: bool = False
+) -> None:
+    if rate_matrix_time_dependent:
+        raise NotImplementedError(
+            "Time-dependent rate matrices are not implemented in 2D spectrum "
+            "calculations yet."
+        )
+
+    if rate_matrix is not None:
+        data = rate_matrix.data if hasattr(rate_matrix, "data") else rate_matrix
+        if len(numpy.asarray(data).shape) == 3:
+            raise NotImplementedError(
+                "Time-dependent rate matrices are not implemented in 2D spectrum "
+                "calculations yet."
+            )
+
 
 try:
     import aceto.nr3td as nr3td
@@ -873,6 +893,15 @@ class TwoDSpectrumCalculator:
         f_states: Any = None,
         no_transfer: bool = False,
     ) -> None:
+
+        warnings.warn(
+            "TwoDSpectrumCalculator from twod22.py is deprecated; use "
+            "TwoDResponseCalculator from twodcalculator.py instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        _ensure_time_independent_rates(rate_matrix, rate_matrix_time_dependent)
 
         self.t1axis = t1axis
         self.t2axis = t2axis

--- a/quantarhei/spectroscopy/twod22.py
+++ b/quantarhei/spectroscopy/twod22.py
@@ -26,6 +26,7 @@ from ..core.saveable import Saveable
 from ..core.time import TimeAxis
 from ..core.units import convert
 from ..qm.propagators.poppropagator import PopulationPropagator
+from ..spectroscopy.responses import get_single_exciton_rate_matrix
 from ..utils import derived_type
 
 try:
@@ -860,6 +861,10 @@ class TwoDSpectrumCalculator:
         dynamics: str = "secular",
         relaxation_tensor: Any = None,
         rate_matrix: Any = None,
+        relaxation_theory: str | None = None,
+        rate_matrix_time_dependent: bool = False,
+        relaxation_cutoff_time: float | None = None,
+        rate_matrix_options: dict[str, Any] | None = None,
         effective_hamiltonian: Any = None,
         twodtype: str = "2DES",
         gamma_factor: float | None = None,
@@ -894,6 +899,13 @@ class TwoDSpectrumCalculator:
         self._rate_matrix = None
         self._relaxation_hamiltonian = None
         self._has_relaxation_tensor = False
+        self._has_rate_matrix = False
+        self.relaxation_theory = relaxation_theory
+        self.rate_matrix_time_dependent = rate_matrix_time_dependent
+        self.relaxation_cutoff_time = relaxation_cutoff_time
+        self.rate_matrix_options = (
+            {} if rate_matrix_options is None else rate_matrix_options
+        )
         if relaxation_tensor is not None:
             self._relaxation_tensor = relaxation_tensor
             self._has_relaxation_tensor = True
@@ -993,10 +1005,22 @@ class TwoDSpectrumCalculator:
         #
         # Relaxation rates
         #
-        KK_any: Any = agg.get_RedfieldRateMatrix()
+        if self._has_rate_matrix:
+            KK_any = self._rate_matrix
+        else:
+            relaxation_theory = self.relaxation_theory
+            if relaxation_theory is None:
+                relaxation_theory = "standard_Redfield"
+
+            KK_any = agg.get_RateMatrix(
+                relaxation_theory=relaxation_theory,
+                time_dependent=self.rate_matrix_time_dependent,
+                relaxation_cutoff_time=self.relaxation_cutoff_time,
+                **self.rate_matrix_options,
+            )
 
         # relaxation rate in single exciton band
-        Kr = KK_any.data[Ns[0] : Ns[0] + Ns[1], Ns[0] : Ns[0] + Ns[1]]  # *10.0
+        Kr = get_single_exciton_rate_matrix(agg, KK_any)  # *10.0
         # print(1.0/Kr)
 
         self.sys.init_dephasing_rates()

--- a/quantarhei/spectroscopy/twod22.py
+++ b/quantarhei/spectroscopy/twod22.py
@@ -30,25 +30,6 @@ from ..qm.propagators.poppropagator import PopulationPropagator
 from ..spectroscopy.responses import get_single_exciton_rate_matrix
 from ..utils import derived_type
 
-
-def _ensure_time_independent_rates(
-    rate_matrix: Any = None, rate_matrix_time_dependent: bool = False
-) -> None:
-    if rate_matrix_time_dependent:
-        raise NotImplementedError(
-            "Time-dependent rate matrices are not implemented in 2D spectrum "
-            "calculations yet."
-        )
-
-    if rate_matrix is not None:
-        data = rate_matrix.data if hasattr(rate_matrix, "data") else rate_matrix
-        if len(numpy.asarray(data).shape) == 3:
-            raise NotImplementedError(
-                "Time-dependent rate matrices are not implemented in 2D spectrum "
-                "calculations yet."
-            )
-
-
 try:
     import aceto.nr3td as nr3td
     from aceto.band_system import band_system
@@ -901,8 +882,6 @@ class TwoDSpectrumCalculator:
             stacklevel=2,
         )
 
-        _ensure_time_independent_rates(rate_matrix, rate_matrix_time_dependent)
-
         self.t1axis = t1axis
         self.t2axis = t2axis
         self.t3axis = t3axis
@@ -1078,7 +1057,7 @@ class TwoDSpectrumCalculator:
         #
         # Finding population evolution matrix
         #
-        prop = PopulationPropagator(self.t1axis, Kr)
+        prop = PopulationPropagator(self.t2axis, Kr)
         self.Uee = prop.get_PropagationMatrix(self.t2axis)
         jumps = prop.get_JumpExpansion(self.t2axis, max_order=3)
 

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -126,6 +126,7 @@ class TwoDResponseCalculator:
         gamma_factor: float | None = None,
         population_factors: Any = None,
         jump_order: int = 0,
+        jump_integration_steps: int = 1,
     ) -> None:
 
         twodtype = _normalize_twodtype(twodtype)
@@ -140,6 +141,8 @@ class TwoDResponseCalculator:
 
         if jump_order not in (0, 1):
             raise ValueError("2D response jump_order has to be 0 or 1")
+        if jump_integration_steps < 1:
+            raise ValueError("jump_integration_steps has to be a positive integer")
 
         self.t1axis = t1axis
         self.t2axis = t2axis
@@ -148,6 +151,7 @@ class TwoDResponseCalculator:
         self.gamma_factor = gamma_factor
         self.population_factors = population_factors
         self.jump_order = jump_order
+        self.jump_integration_steps = jump_integration_steps
 
         # FIXME: check the compatibility of the axes
 
@@ -167,13 +171,13 @@ class TwoDResponseCalculator:
         self.dynamics = dynamics
 
         # unprotected properties
-        self.data = None
+        self.data: numpy.ndarray | None = None
 
         self.responses: list[Any] = []
 
         self._relaxation_tensor = None
         self._rate_matrix = None
-        self._response_rate_matrix = None
+        self._response_rate_matrix: Any = None
         self._relaxation_hamiltonian = None
         self._population_time_axis = None
         self._has_relaxation_tensor = False
@@ -457,9 +461,10 @@ class TwoDResponseCalculator:
             # Calculating all responses from the system
             #
             self.resp_fcions = []
-            response_kwargs = dict(
+            response_kwargs: dict[str, Any] = dict(
                 rate_matrix=self._response_rate_matrix,
                 population_time_axis=self._population_time_axis,
+                jump_integration_steps=self.jump_integration_steps,
             )
 
             # basic pathways

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -127,6 +127,8 @@ class TwoDResponseCalculator:
         population_factors: Any = None,
         jump_order: int = 0,
         jump_time_graining: int = 1,
+        jump_kernel_cutoff: float = 0.0,
+        jump_kernel_zero_cutoff: float = 0.0,
     ) -> None:
 
         twodtype = _normalize_twodtype(twodtype)
@@ -143,6 +145,10 @@ class TwoDResponseCalculator:
             raise ValueError("2D response jump_order has to be 0 or 1")
         if jump_time_graining < 1:
             raise ValueError("jump_time_graining has to be a positive integer")
+        if jump_kernel_cutoff < 0.0:
+            raise ValueError("jump_kernel_cutoff has to be non-negative")
+        if jump_kernel_zero_cutoff < 0.0:
+            raise ValueError("jump_kernel_zero_cutoff has to be non-negative")
 
         self.t1axis = t1axis
         self.t2axis = t2axis
@@ -152,6 +158,9 @@ class TwoDResponseCalculator:
         self.population_factors = population_factors
         self.jump_order = jump_order
         self.jump_time_graining = jump_time_graining
+        self.jump_kernel_cutoff = jump_kernel_cutoff
+        self.jump_kernel_zero_cutoff = jump_kernel_zero_cutoff
+        self.response_diagnostics: list[dict[str, Any]] = []
 
         # FIXME: check the compatibility of the axes
 
@@ -465,6 +474,8 @@ class TwoDResponseCalculator:
                 rate_matrix=self._response_rate_matrix,
                 population_time_axis=self._population_time_axis,
                 jump_time_graining=self.jump_time_graining,
+                jump_kernel_cutoff=self.jump_kernel_cutoff,
+                jump_kernel_zero_cutoff=self.jump_kernel_zero_cutoff,
             )
 
             # basic pathways
@@ -684,6 +695,7 @@ class TwoDResponseCalculator:
             for resp in self.resp_fcions:
                 if isinstance(resp, NonLinearResponse):
                     data = resp.calculate_matrix(tt2)
+                    self.response_diagnostics.append(dict(resp.diagnostics))
                     response_pieces.append((resp, data))
                     if resp.rtype == "R":
                         if resp.process == "GSB":
@@ -871,6 +883,8 @@ class TwoDResponseCalculator:
         """
         # FIXME: we will later use only one branch below
         from .twodcontainer import TwoDResponseContainer
+
+        self.response_diagnostics = []
 
         # if _have_aceto and self._has_system:
 

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -16,7 +16,11 @@ from ..qm.propagators.poppropagator import PopulationPropagator
 
 # deprecated class
 # This is how we calculate it now
-from ..spectroscopy.responses import LiouvillePathway, NonLinearResponse
+from ..spectroscopy.responses import (
+    LiouvillePathway,
+    NonLinearResponse,
+    get_single_exciton_rate_matrix,
+)
 from ..utils import derived_type
 from .twodresponse import TwoDResponse
 
@@ -54,6 +58,10 @@ class TwoDResponseCalculator:
         dynamics: str = "secular",
         relaxation_tensor: Any = None,
         rate_matrix: Any = None,
+        relaxation_theory: str | None = None,
+        rate_matrix_time_dependent: bool = False,
+        relaxation_cutoff_time: float | None = None,
+        rate_matrix_options: dict[str, Any] | None = None,
         effective_hamiltonian: Any = None,
     ) -> None:
 
@@ -85,9 +93,16 @@ class TwoDResponseCalculator:
 
         self._relaxation_tensor = None
         self._rate_matrix = None
+        self._response_rate_matrix = None
         self._relaxation_hamiltonian = None
         self._has_relaxation_tensor = False
         self._has_rate_matrix = False
+        self.relaxation_theory = relaxation_theory
+        self.rate_matrix_time_dependent = rate_matrix_time_dependent
+        self.relaxation_cutoff_time = relaxation_cutoff_time
+        self.rate_matrix_options = (
+            {} if rate_matrix_options is None else rate_matrix_options
+        )
         if relaxation_tensor is not None:
             self._relaxation_tensor = relaxation_tensor
             self._has_relaxation_tensor = True
@@ -176,18 +191,22 @@ class TwoDResponseCalculator:
                 #
                 # Relaxation rates
                 #
-                if not self._has_rate_matrix:
-                    # FIXME: This is a quick fix to make a zero rate matrix
-                    class hlp:
-                        def __init__(self, N: int) -> None:
-                            self.data: numpy.ndarray = numpy.zeros((N, N), dtype=REAL)
-
-                    KK = hlp(Ns[1])
-                else:
+                if self._has_rate_matrix:
                     KK = self._rate_matrix
+                elif self.relaxation_theory is not None:
+                    KK = sys.get_RateMatrix(
+                        relaxation_theory=self.relaxation_theory,
+                        time_dependent=self.rate_matrix_time_dependent,
+                        relaxation_cutoff_time=self.relaxation_cutoff_time,
+                        **self.rate_matrix_options,
+                    )
+                else:
+                    # FIXME: This is a quick fix to make a zero rate matrix
+                    KK = numpy.zeros((Ns[1], Ns[1]), dtype=REAL)
 
                 # relaxation rate in single exciton band
-                Kr = KK.data[Ns[0] : Ns[0] + Ns[1], Ns[0] : Ns[0] + Ns[1]]  # *10.0
+                Kr = get_single_exciton_rate_matrix(sys, KK)  # *10.0
+                self._response_rate_matrix = Kr
                 # print(1.0/KK.data)
 
                 # FIXME: we need also 2 exciton rates
@@ -337,19 +356,44 @@ class TwoDResponseCalculator:
             # Calculating all responses from the system
             #
             self.resp_fcions = []
+            response_kwargs = dict(rate_matrix=self._response_rate_matrix)
 
             # basic pathways
             Nr1g = NonLinearResponse(
-                self.lab, self.system, "R1g", self.t1axis, self.t2axis, self.t3axis
+                self.lab,
+                self.system,
+                "R1g",
+                self.t1axis,
+                self.t2axis,
+                self.t3axis,
+                **response_kwargs,
             )
             Nr2g = NonLinearResponse(
-                self.lab, self.system, "R2g", self.t1axis, self.t2axis, self.t3axis
+                self.lab,
+                self.system,
+                "R2g",
+                self.t1axis,
+                self.t2axis,
+                self.t3axis,
+                **response_kwargs,
             )
             Nr3g = NonLinearResponse(
-                self.lab, self.system, "R3g", self.t1axis, self.t2axis, self.t3axis
+                self.lab,
+                self.system,
+                "R3g",
+                self.t1axis,
+                self.t2axis,
+                self.t3axis,
+                **response_kwargs,
             )
             Nr4g = NonLinearResponse(
-                self.lab, self.system, "R4g", self.t1axis, self.t2axis, self.t3axis
+                self.lab,
+                self.system,
+                "R4g",
+                self.t1axis,
+                self.t2axis,
+                self.t3axis,
+                **response_kwargs,
             )
 
             self.resp_fcions.append(Nr1g)
@@ -360,10 +404,22 @@ class TwoDResponseCalculator:
             if self.system.mult > 1:
                 # ESA (if mult > 1)
                 Nr1f = NonLinearResponse(
-                    self.lab, self.system, "R1f", self.t1axis, self.t2axis, self.t3axis
+                    self.lab,
+                    self.system,
+                    "R1f",
+                    self.t1axis,
+                    self.t2axis,
+                    self.t3axis,
+                    **response_kwargs,
                 )
                 Nr2f = NonLinearResponse(
-                    self.lab, self.system, "R2f", self.t1axis, self.t2axis, self.t3axis
+                    self.lab,
+                    self.system,
+                    "R2f",
+                    self.t1axis,
+                    self.t2axis,
+                    self.t3axis,
+                    **response_kwargs,
                 )
 
                 self.resp_fcions.append(Nr1f)
@@ -377,6 +433,7 @@ class TwoDResponseCalculator:
                 self.t1axis,
                 self.t2axis,
                 self.t3axis,
+                **response_kwargs,
             )
             Nr2g_scM0g = NonLinearResponse(
                 self.lab,
@@ -385,6 +442,7 @@ class TwoDResponseCalculator:
                 self.t1axis,
                 self.t2axis,
                 self.t3axis,
+                **response_kwargs,
             )
 
             KK = Nr1g_scM0g.KK
@@ -404,6 +462,7 @@ class TwoDResponseCalculator:
                     self.t1axis,
                     self.t2axis,
                     self.t3axis,
+                    **response_kwargs,
                 )
                 Nr2f_scM0g = NonLinearResponse(
                     self.lab,
@@ -412,6 +471,7 @@ class TwoDResponseCalculator:
                     self.t1axis,
                     self.t2axis,
                     self.t3axis,
+                    **response_kwargs,
                 )
                 Nr1f_scM0e = NonLinearResponse(
                     self.lab,
@@ -420,6 +480,7 @@ class TwoDResponseCalculator:
                     self.t1axis,
                     self.t2axis,
                     self.t3axis,
+                    **response_kwargs,
                 )
                 Nr2f_scM0e = NonLinearResponse(
                     self.lab,
@@ -428,6 +489,7 @@ class TwoDResponseCalculator:
                     self.t1axis,
                     self.t2axis,
                     self.t3axis,
+                    **response_kwargs,
                 )
 
                 self.resp_fcions.append(Nr1f_scM0g)

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -25,6 +25,70 @@ from ..utils import derived_type
 from .twodresponse import TwoDResponse
 
 
+def _ensure_time_independent_rates(
+    rate_matrix: Any = None, rate_matrix_time_dependent: bool = False
+) -> None:
+    if rate_matrix_time_dependent:
+        raise NotImplementedError(
+            "Time-dependent rate matrices are not implemented in 2D spectrum "
+            "calculations yet."
+        )
+
+    if rate_matrix is not None:
+        data = rate_matrix.data if hasattr(rate_matrix, "data") else rate_matrix
+        if len(numpy.asarray(data).shape) == 3:
+            raise NotImplementedError(
+                "Time-dependent rate matrices are not implemented in 2D spectrum "
+                "calculations yet."
+            )
+
+
+def _apply_response_window(data: numpy.ndarray) -> numpy.ndarray:
+    """Apply the endpoint half-weight used before Fourier transformation."""
+    ret = data.copy()
+    ret[:, 0] *= 0.5
+    ret[0, :] *= 0.5
+    return ret
+
+
+def _fourier_transform_response(data: numpy.ndarray, signal: str) -> numpy.ndarray:
+    """Transform a time-domain response contribution to a 2D spectrum."""
+    data = _apply_response_window(data)
+
+    if signal == signal_REPH:
+        ftresp = numpy.fft.fft(data, axis=1)
+    elif signal == signal_NONR:
+        ftresp = numpy.fft.ifft(data, axis=1) * data.shape[1]
+    else:
+        raise Exception("Unknown 2D signal type: " + signal)
+
+    ftresp = numpy.fft.ifft(ftresp, axis=0)
+    return numpy.fft.fftshift(ftresp)
+
+
+def _pad_response_data(
+    data: numpy.ndarray, pad: int, window: numpy.ndarray | None = None
+) -> numpy.ndarray:
+    """Pad a response contribution in the same way as the total response."""
+    if window is not None:
+        size = int(len(window) / 2)
+        data = data.copy()
+        data[len(data) - size :, :] *= window[size:, None]
+        data[:, len(data) - size :] *= window[None, size:]
+
+    if pad > 0:
+        data = numpy.hstack((data, numpy.zeros((data.shape[0], pad))))
+        data = numpy.vstack((data, numpy.zeros((pad, data.shape[1]))))
+
+    return data
+
+
+def _normalize_twodtype(twodtype: str) -> str:
+    if twodtype in ["2DES", "F-2DES"]:
+        return twodtype
+    raise Exception("Unknown type of 2D spectrum: " + twodtype)
+
+
 class TwoDResponseCalculator:
     """Calculator of the 2D spectrum
 
@@ -35,6 +99,18 @@ class TwoDResponseCalculator:
 
     Parameters
     ----------
+    twodtype : {"2DES", "F-2DES"}
+        Type of 2D spectrum to calculate. ``"F-2DES"`` currently supports
+        the ``gamma_factor`` fluorescence-detected approximation.
+
+    gamma_factor : float
+        Fluorescence-detected 2D weighting factor. ESA contributions are
+        weighted by ``gamma_factor - 1``.
+
+    population_factors : tuple
+        Reserved for state-resolved fluorescence-detected 2D spectra. This
+        mode is not implemented yet because it requires state-resolved ESA
+        responses.
 
 
     """
@@ -63,11 +139,28 @@ class TwoDResponseCalculator:
         relaxation_cutoff_time: float | None = None,
         rate_matrix_options: dict[str, Any] | None = None,
         effective_hamiltonian: Any = None,
+        twodtype: str = "2DES",
+        gamma_factor: float | None = None,
+        population_factors: Any = None,
     ) -> None:
+
+        _ensure_time_independent_rates(rate_matrix, rate_matrix_time_dependent)
+        twodtype = _normalize_twodtype(twodtype)
+        if twodtype == "F-2DES":
+            if gamma_factor is None and population_factors is None:
+                raise Exception("Not enough parameters for F-2DES")
+            if population_factors is not None:
+                raise NotImplementedError(
+                    "F-2DES with population_factors requires state-resolved "
+                    "ESA responses and is not implemented yet."
+                )
 
         self.t1axis = t1axis
         self.t2axis = t2axis
         self.t3axis = t3axis
+        self.twodtype = twodtype
+        self.gamma_factor = gamma_factor
+        self.population_factors = population_factors
 
         # FIXME: check the compatibility of the axes
 
@@ -127,6 +220,25 @@ class TwoDResponseCalculator:
         self.Uc0: Any = None
 
         self.tc = 0
+
+    def _detection_weight(self, resp: Any) -> float:
+        """Returns the detection weight for a response contribution."""
+        if self.twodtype == "2DES":
+            return 1.0
+
+        if self.twodtype == "F-2DES":
+            if not isinstance(resp, NonLinearResponse):
+                raise NotImplementedError(
+                    "F-2DES requires NonLinearResponse metadata; predefined "
+                    "LiouvillePathway responses are not supported."
+                )
+
+            if self.gamma_factor is not None:
+                if resp.process == "ESA":
+                    return self.gamma_factor - 1.0
+                return 1.0
+
+        raise Exception("Unknown type of 2D spectrum: " + self.twodtype)
 
     def _vprint(self, *args: Any, **kwargs: Any) -> None:
         """Prints a string if the self.verbose attribute is True"""
@@ -350,6 +462,7 @@ class TwoDResponseCalculator:
         resp_Nsewt = numpy.zeros((Nr1, Nr3), dtype=ntype, order=order)
         resp_Resawt = numpy.zeros((Nr1, Nr3), dtype=ntype, order=order)
         resp_Nesawt = numpy.zeros((Nr1, Nr3), dtype=ntype, order=order)
+        response_pieces: list[tuple[Any, numpy.ndarray]] = []
 
         if self._has_system and not self._has_responses:
             #
@@ -506,11 +619,39 @@ class TwoDResponseCalculator:
 
             for resp in self.resp_fcions:
                 if isinstance(resp, NonLinearResponse):
+                    data = resp.calculate_matrix(tt2)
+                    response_pieces.append((resp, data))
                     if resp.rtype == "R":
-                        resp_Rgsb += resp.calculate_matrix(tt2)
+                        if resp.process == "GSB":
+                            resp_Rgsb += data
+                        elif resp.process == "SE":
+                            if resp.is_transfer:
+                                resp_Rsewt += data
+                            else:
+                                resp_Rse += data
+                        elif resp.process == "ESA":
+                            if resp.is_transfer:
+                                resp_Resawt += data
+                            else:
+                                resp_Resa += data
+                        else:
+                            raise Exception("Unknown response process")
 
                     elif resp.rtype == "NR":
-                        resp_Ngsb += resp.calculate_matrix(tt2)
+                        if resp.process == "GSB":
+                            resp_Ngsb += data
+                        elif resp.process == "SE":
+                            if resp.is_transfer:
+                                resp_Nsewt += data
+                            else:
+                                resp_Nse += data
+                        elif resp.process == "ESA":
+                            if resp.is_transfer:
+                                resp_Nesawt += data
+                            else:
+                                resp_Nesa += data
+                        else:
+                            raise Exception("Unknown response process")
 
                     else:
                         raise Exception("Unknown response type")
@@ -518,14 +659,18 @@ class TwoDResponseCalculator:
                 elif isinstance(resp, LiouvillePathway):
                     resp_any: Any = resp
                     if resp.rtype == "R":
-                        resp_Rgsb += resp_any.calculate_matrix(
+                        data = resp_any.calculate_matrix(
                             self.lab, None, tt2, self.t1s, self.t3s, self.rwa
                         )
+                        response_pieces.append((resp, data))
+                        resp_Rgsb += data
 
                     elif resp.rtype == "NR":
-                        resp_Ngsb += resp_any.calculate_matrix(
+                        data = resp_any.calculate_matrix(
                             self.lab, None, tt2, self.t1s, self.t3s, self.rwa
                         )
+                        response_pieces.append((resp, data))
+                        resp_Ngsb += data
                     else:
                         raise Exception("Unknown response type")
 
@@ -536,8 +681,8 @@ class TwoDResponseCalculator:
         #
         # FIXME: discontinue Aceto and remove the sum (and the code above)
         #
-        resp_r = resp_Rgsb  # + resp_Rse + resp_Resa + resp_Rsewt + resp_Resawt
-        resp_n = resp_Ngsb  # + resp_Nse + resp_Nesa + resp_Nsewt + resp_Nesawt
+        resp_r = resp_Rgsb + resp_Rse + resp_Resa + resp_Rsewt + resp_Resawt
+        resp_n = resp_Ngsb + resp_Nse + resp_Nesa + resp_Nsewt + resp_Nesawt
 
         #
         # Calculate corresponding 2D spectrum
@@ -549,6 +694,7 @@ class TwoDResponseCalculator:
         t13Pad = TimeAxis(
             self.t1axis.start, self.t1axis.length + self.pad, self.t1axis.step
         )
+        response_window = None
         if self.pad > 0:
             self._vprint("padding by - " + str(self.pad))
 
@@ -565,17 +711,20 @@ class TwoDResponseCalculator:
             from scipy.signal import windows as sig
 
             window = 20
-            tuc = sig.tukey(window * 2, 1, sym=False)
-            for k in range(len(resp_r)):
-                resp_r[len(resp_r) - window :, k] *= tuc[window:]
-                resp_r[k, len(resp_r) - window :] *= tuc[window:]
-                resp_n[len(resp_n) - window :, k] *= tuc[window:]
-                resp_n[k, len(resp_n) - window :] *= tuc[window:]
+            response_window = sig.tukey(window * 2, 1, sym=False)
 
-            resp_r = numpy.hstack((resp_r, numpy.zeros((resp_r.shape[0], self.pad))))
-            resp_r = numpy.vstack((resp_r, numpy.zeros((self.pad, resp_r.shape[1]))))
-            resp_n = numpy.hstack((resp_n, numpy.zeros((resp_n.shape[0], self.pad))))
-            resp_n = numpy.vstack((resp_n, numpy.zeros((self.pad, resp_n.shape[1]))))
+            resp_r = _pad_response_data(resp_r, self.pad, response_window)
+            resp_n = _pad_response_data(resp_n, self.pad, response_window)
+            resp_Rgsb = _pad_response_data(resp_Rgsb, self.pad, response_window)
+            resp_Ngsb = _pad_response_data(resp_Ngsb, self.pad, response_window)
+            resp_Rse = _pad_response_data(resp_Rse, self.pad, response_window)
+            resp_Nse = _pad_response_data(resp_Nse, self.pad, response_window)
+            resp_Resa = _pad_response_data(resp_Resa, self.pad, response_window)
+            resp_Nesa = _pad_response_data(resp_Nesa, self.pad, response_window)
+            resp_Rsewt = _pad_response_data(resp_Rsewt, self.pad, response_window)
+            resp_Nsewt = _pad_response_data(resp_Nsewt, self.pad, response_window)
+            resp_Resawt = _pad_response_data(resp_Resawt, self.pad, response_window)
+            resp_Nesawt = _pad_response_data(resp_Nesawt, self.pad, response_window)
 
         else:
             onetwod.set_axis_1(self.oa1)
@@ -626,23 +775,23 @@ class TwoDResponseCalculator:
                 nESAWT=resp_Nesawt,
             )
 
-        # FIXME: This only applies when
-        resp_r[:, 0] = resp_r[:, 0] * 0.5
-        resp_n[:, 0] = resp_n[:, 0] * 0.5
-        resp_r[0, :] = resp_r[0, :] * 0.5
-        resp_n[0, :] = resp_n[0, :] * 0.5
+        for resp, data in response_pieces:
+            data = _pad_response_data(data, self.pad, response_window)
 
-        ftresp = numpy.fft.fft(resp_r, axis=1)  # \omega_1
-        ftresp = numpy.fft.ifft(ftresp, axis=0)  # \omega_3
-        reph2D = numpy.fft.fftshift(ftresp)
+            if isinstance(resp, NonLinearResponse):
+                signal = resp.signal
+                dtype = resp.storage_type
+                resolution = "types"
+            elif isinstance(resp, LiouvillePathway):
+                signal = signal_REPH if resp.rtype == "R" else signal_NONR
+                dtype = signal
+                resolution = "signals"
+            else:
+                raise Exception("Unknown response object")
 
-        ftresp = numpy.fft.ifft(resp_n, axis=1) * ftresp.shape[1]  # \omega_1
-        ftresp = numpy.fft.ifft(ftresp, axis=0)  # \omega_3
-        nonr2D = numpy.fft.fftshift(ftresp)
-
-        onetwod.set_resolution("signals")
-        onetwod._add_data(reph2D, dtype=signal_REPH)
-        onetwod._add_data(nonr2D, dtype=signal_NONR)
+            spect_data = _fourier_transform_response(data, signal)
+            spect_data *= self._detection_weight(resp)
+            onetwod._add_data(spect_data, resolution=resolution, dtype=dtype)
 
         onetwod.set_t2(self.t2axis.data[tc])
 

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -5,42 +5,25 @@ from typing import Any, Literal
 
 import numpy
 
-from .. import REAL, signal_NONR, signal_REPH
+from .. import signal_NONR, signal_REPH
 from ..builders.aggregates import Aggregate
 from ..builders.molecules import Molecule
 from ..builders.opensystem import OpenSystem
 from ..core.managers import Manager, energy_units
 from ..core.time import TimeAxis
 from ..implementations.aceto.lab_settings import lab_settings
-from ..qm.propagators.poppropagator import PopulationPropagator
 
 # deprecated class
 # This is how we calculate it now
 from ..spectroscopy.responses import (
     LiouvillePathway,
     NonLinearResponse,
+    get_common_time_axis,
     get_single_exciton_rate_matrix,
+    validate_2d_time_axes,
 )
 from ..utils import derived_type
 from .twodresponse import TwoDResponse
-
-
-def _ensure_time_independent_rates(
-    rate_matrix: Any = None, rate_matrix_time_dependent: bool = False
-) -> None:
-    if rate_matrix_time_dependent:
-        raise NotImplementedError(
-            "Time-dependent rate matrices are not implemented in 2D spectrum "
-            "calculations yet."
-        )
-
-    if rate_matrix is not None:
-        data = rate_matrix.data if hasattr(rate_matrix, "data") else rate_matrix
-        if len(numpy.asarray(data).shape) == 3:
-            raise NotImplementedError(
-                "Time-dependent rate matrices are not implemented in 2D spectrum "
-                "calculations yet."
-            )
 
 
 def _apply_response_window(data: numpy.ndarray) -> numpy.ndarray:
@@ -144,7 +127,6 @@ class TwoDResponseCalculator:
         population_factors: Any = None,
     ) -> None:
 
-        _ensure_time_independent_rates(rate_matrix, rate_matrix_time_dependent)
         twodtype = _normalize_twodtype(twodtype)
         if twodtype == "F-2DES":
             if gamma_factor is None and population_factors is None:
@@ -188,6 +170,7 @@ class TwoDResponseCalculator:
         self._rate_matrix = None
         self._response_rate_matrix = None
         self._relaxation_hamiltonian = None
+        self._population_time_axis = None
         self._has_relaxation_tensor = False
         self._has_rate_matrix = False
         self.relaxation_theory = relaxation_theory
@@ -303,6 +286,15 @@ class TwoDResponseCalculator:
                 #
                 # Relaxation rates
                 #
+                relaxation_requested = (
+                    self._has_rate_matrix or self.relaxation_theory is not None
+                )
+                if relaxation_requested:
+                    validate_2d_time_axes(self.t1axis, self.t2axis, self.t3axis)
+                    self._population_time_axis = get_common_time_axis(
+                        self.t1axis, self.t2axis, self.t3axis
+                    )
+
                 if self._has_rate_matrix:
                     KK = self._rate_matrix
                 elif self.relaxation_theory is not None:
@@ -313,12 +305,15 @@ class TwoDResponseCalculator:
                         **self.rate_matrix_options,
                     )
                 else:
-                    # FIXME: This is a quick fix to make a zero rate matrix
-                    KK = numpy.zeros((Ns[1], Ns[1]), dtype=REAL)
+                    KK = None
 
                 # relaxation rate in single exciton band
-                Kr = get_single_exciton_rate_matrix(sys, KK)  # *10.0
-                self._response_rate_matrix = Kr
+                if KK is None:
+                    Kr = None
+                    self._response_rate_matrix = None
+                else:
+                    Kr = get_single_exciton_rate_matrix(sys, KK)  # *10.0
+                    self._response_rate_matrix = Kr
                 # print(1.0/KK.data)
 
                 # FIXME: we need also 2 exciton rates
@@ -334,19 +329,6 @@ class TwoDResponseCalculator:
                 #
                 #  This section will also be removed - It goes to the new Response class
                 #
-
-                #
-                # Finding population evolution matrix
-                #
-                prop = PopulationPropagator(self.t2axis, Kr)
-                self.Uee = prop.get_PropagationMatrix(self.t2axis)
-                jumps = prop.get_JumpExpansion(self.t2axis, max_order=3)
-
-                # FIXME: Order of transfer is set by hand here
-                # - needs to be moved to some reasonable place
-
-                # Ucor = Uee
-                self.Uc0 = jumps[0]
 
             ###############################################################################
 
@@ -469,7 +451,10 @@ class TwoDResponseCalculator:
             # Calculating all responses from the system
             #
             self.resp_fcions = []
-            response_kwargs = dict(rate_matrix=self._response_rate_matrix)
+            response_kwargs = dict(
+                rate_matrix=self._response_rate_matrix,
+                population_time_axis=self._population_time_axis,
+            )
 
             # basic pathways
             Nr1g = NonLinearResponse(

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -940,6 +940,7 @@ class TwoDResponseCalculator:
                 raise Exception("Unknown response object")
 
             spect_data = _fourier_transform_response(data, signal)
+            spect_data *= data.shape[0] * self.t1axis.step * self.t3axis.step
             spect_data *= self._detection_weight(resp)
             onetwod._add_data(spect_data, resolution=resolution, dtype=dtype)
 

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -122,8 +122,12 @@ class TwoDResponseCalculator:
         relaxation_cutoff_time: float | None = None,
         rate_matrix_options: dict[str, Any] | None = None,
         population_propagator: Any = None,
+        density_matrix_propagator: Any = None,
+        density_matrix_trajectory: Any = None,
         population_time_axis: Any = None,
         population_dynamics_mode: str | None = None,
+        include_nonsecular_remainder: bool = True,
+        dipole_normalization_tol: float = 1.0e-12,
         effective_hamiltonian: Any = None,
         twodtype: str = "2DES",
         gamma_factor: float | None = None,
@@ -156,6 +160,8 @@ class TwoDResponseCalculator:
             population_dynamics_mode = (
                 "full_conditional"
                 if population_propagator is not None
+                or density_matrix_propagator is not None
+                or density_matrix_trajectory is not None
                 else "jump_decomposition"
             )
         if population_dynamics_mode not in ("jump_decomposition", "full_conditional"):
@@ -163,12 +169,36 @@ class TwoDResponseCalculator:
                 "population_dynamics_mode has to be 'jump_decomposition' "
                 "or 'full_conditional'"
             )
-        if population_propagator is not None and (
+        external_count = sum(
+            item is not None
+            for item in (
+                population_propagator,
+                density_matrix_propagator,
+                density_matrix_trajectory,
+            )
+        )
+        if external_count > 1:
+            raise ValueError(
+                "population_propagator, density_matrix_propagator, and "
+                "density_matrix_trajectory are mutually exclusive"
+            )
+        if external_count > 0 and (
             rate_matrix is not None or relaxation_theory is not None
         ):
             raise ValueError(
-                "population_propagator cannot be combined with rate_matrix "
+                "External propagators cannot be combined with rate_matrix "
                 "or relaxation_theory"
+            )
+        if external_count > 0 and jump_order > 0:
+            raise ValueError(
+                "External propagators cannot be combined with jump_order > 0"
+            )
+        if density_matrix_trajectory is not None and (
+            t1axis.length != 1 or not numpy.isclose(t1axis.data[0], 0.0)
+        ):
+            raise ValueError(
+                "density_matrix_trajectory is only allowed for pump-probe-like "
+                "calculations with t1 = 0"
             )
 
         self.t1axis = t1axis
@@ -182,7 +212,11 @@ class TwoDResponseCalculator:
         self.jump_kernel_cutoff = jump_kernel_cutoff
         self.jump_kernel_zero_cutoff = jump_kernel_zero_cutoff
         self.population_propagator = population_propagator
+        self.density_matrix_propagator = density_matrix_propagator
+        self.density_matrix_trajectory = density_matrix_trajectory
         self.population_dynamics_mode = population_dynamics_mode
+        self.include_nonsecular_remainder = include_nonsecular_remainder
+        self.dipole_normalization_tol = dipole_normalization_tol
         self.response_diagnostics: list[dict[str, Any]] = []
 
         # FIXME: check the compatibility of the axes
@@ -331,9 +365,15 @@ class TwoDResponseCalculator:
                     self._has_rate_matrix
                     or self.relaxation_theory is not None
                     or self.population_propagator is not None
+                    or self.density_matrix_propagator is not None
+                    or self.density_matrix_trajectory is not None
                 )
                 if relaxation_requested:
-                    if self.population_propagator is None:
+                    if (
+                        self.population_propagator is None
+                        and self.density_matrix_propagator is None
+                        and self.density_matrix_trajectory is None
+                    ):
                         validate_2d_time_axes(self.t1axis, self.t2axis, self.t3axis)
                         self._population_time_axis = get_common_time_axis(
                             self.t1axis, self.t2axis, self.t3axis
@@ -501,7 +541,11 @@ class TwoDResponseCalculator:
             response_kwargs: dict[str, Any] = dict(
                 rate_matrix=self._response_rate_matrix,
                 population_propagator=self.population_propagator,
+                density_matrix_propagator=self.density_matrix_propagator,
+                density_matrix_trajectory=self.density_matrix_trajectory,
                 population_dynamics_mode=self.population_dynamics_mode,
+                include_nonsecular_remainder=self.include_nonsecular_remainder,
+                dipole_normalization_tol=self.dipole_normalization_tol,
                 population_time_axis=self._population_time_axis,
                 jump_time_graining=self.jump_time_graining,
                 jump_kernel_cutoff=self.jump_kernel_cutoff,

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -126,7 +126,7 @@ class TwoDResponseCalculator:
         gamma_factor: float | None = None,
         population_factors: Any = None,
         jump_order: int = 0,
-        jump_integration_steps: int = 1,
+        jump_time_graining: int = 1,
     ) -> None:
 
         twodtype = _normalize_twodtype(twodtype)
@@ -141,8 +141,8 @@ class TwoDResponseCalculator:
 
         if jump_order not in (0, 1):
             raise ValueError("2D response jump_order has to be 0 or 1")
-        if jump_integration_steps < 1:
-            raise ValueError("jump_integration_steps has to be a positive integer")
+        if jump_time_graining < 1:
+            raise ValueError("jump_time_graining has to be a positive integer")
 
         self.t1axis = t1axis
         self.t2axis = t2axis
@@ -151,7 +151,7 @@ class TwoDResponseCalculator:
         self.gamma_factor = gamma_factor
         self.population_factors = population_factors
         self.jump_order = jump_order
-        self.jump_integration_steps = jump_integration_steps
+        self.jump_time_graining = jump_time_graining
 
         # FIXME: check the compatibility of the axes
 
@@ -464,7 +464,7 @@ class TwoDResponseCalculator:
             response_kwargs: dict[str, Any] = dict(
                 rate_matrix=self._response_rate_matrix,
                 population_time_axis=self._population_time_axis,
-                jump_integration_steps=self.jump_integration_steps,
+                jump_time_graining=self.jump_time_graining,
             )
 
             # basic pathways

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -125,6 +125,7 @@ class TwoDResponseCalculator:
         twodtype: str = "2DES",
         gamma_factor: float | None = None,
         population_factors: Any = None,
+        jump_order: int = 0,
     ) -> None:
 
         twodtype = _normalize_twodtype(twodtype)
@@ -137,12 +138,16 @@ class TwoDResponseCalculator:
                     "ESA responses and is not implemented yet."
                 )
 
+        if jump_order not in (0, 1):
+            raise ValueError("2D response jump_order has to be 0 or 1")
+
         self.t1axis = t1axis
         self.t2axis = t2axis
         self.t3axis = t3axis
         self.twodtype = twodtype
         self.gamma_factor = gamma_factor
         self.population_factors = population_factors
+        self.jump_order = jump_order
 
         # FIXME: check the compatibility of the axes
 
@@ -325,6 +330,7 @@ class TwoDResponseCalculator:
                 sbi = sys.get_SystemBathInteraction()
                 cfm = sbi.CC
                 cfm.create_double_integral()
+                sys.get_lineshape_functions(self.jump_order)
 
                 #
                 #  This section will also be removed - It goes to the new Response class
@@ -551,6 +557,29 @@ class TwoDResponseCalculator:
                 # print("Including relaxation")
                 self.resp_fcions.append(Nr1g_scM0g)
                 self.resp_fcions.append(Nr2g_scM0g)
+                if Nr1g_scM0g._uses_single_jump_storage():
+                    self.resp_fcions.append(
+                        NonLinearResponse(
+                            self.lab,
+                            self.system,
+                            "R1g_scM1g",
+                            self.t1axis,
+                            self.t2axis,
+                            self.t3axis,
+                            **response_kwargs,
+                        )
+                    )
+                    self.resp_fcions.append(
+                        NonLinearResponse(
+                            self.lab,
+                            self.system,
+                            "R2g_scM1g",
+                            self.t1axis,
+                            self.t2axis,
+                            self.t3axis,
+                            **response_kwargs,
+                        )
+                    )
 
             if self.system.mult > 1:
                 Nr1f_scM0g = NonLinearResponse(
@@ -594,6 +623,51 @@ class TwoDResponseCalculator:
                 self.resp_fcions.append(Nr2f_scM0g)
                 self.resp_fcions.append(Nr1f_scM0e)
                 self.resp_fcions.append(Nr2f_scM0e)
+                if Nr1f_scM0g._uses_single_jump_storage():
+                    self.resp_fcions.append(
+                        NonLinearResponse(
+                            self.lab,
+                            self.system,
+                            "R1f_scM1g",
+                            self.t1axis,
+                            self.t2axis,
+                            self.t3axis,
+                            **response_kwargs,
+                        )
+                    )
+                    self.resp_fcions.append(
+                        NonLinearResponse(
+                            self.lab,
+                            self.system,
+                            "R2f_scM1g",
+                            self.t1axis,
+                            self.t2axis,
+                            self.t3axis,
+                            **response_kwargs,
+                        )
+                    )
+                    self.resp_fcions.append(
+                        NonLinearResponse(
+                            self.lab,
+                            self.system,
+                            "R1f_scM1e",
+                            self.t1axis,
+                            self.t2axis,
+                            self.t3axis,
+                            **response_kwargs,
+                        )
+                    )
+                    self.resp_fcions.append(
+                        NonLinearResponse(
+                            self.lab,
+                            self.system,
+                            "R2f_scM1e",
+                            self.t1axis,
+                            self.t2axis,
+                            self.t3axis,
+                            **response_kwargs,
+                        )
+                    )
 
             self._has_responses = True
 

--- a/quantarhei/spectroscopy/twodcalculator.py
+++ b/quantarhei/spectroscopy/twodcalculator.py
@@ -121,6 +121,9 @@ class TwoDResponseCalculator:
         rate_matrix_time_dependent: bool = False,
         relaxation_cutoff_time: float | None = None,
         rate_matrix_options: dict[str, Any] | None = None,
+        population_propagator: Any = None,
+        population_time_axis: Any = None,
+        population_dynamics_mode: str | None = None,
         effective_hamiltonian: Any = None,
         twodtype: str = "2DES",
         gamma_factor: float | None = None,
@@ -149,6 +152,24 @@ class TwoDResponseCalculator:
             raise ValueError("jump_kernel_cutoff has to be non-negative")
         if jump_kernel_zero_cutoff < 0.0:
             raise ValueError("jump_kernel_zero_cutoff has to be non-negative")
+        if population_dynamics_mode is None:
+            population_dynamics_mode = (
+                "full_conditional"
+                if population_propagator is not None
+                else "jump_decomposition"
+            )
+        if population_dynamics_mode not in ("jump_decomposition", "full_conditional"):
+            raise ValueError(
+                "population_dynamics_mode has to be 'jump_decomposition' "
+                "or 'full_conditional'"
+            )
+        if population_propagator is not None and (
+            rate_matrix is not None or relaxation_theory is not None
+        ):
+            raise ValueError(
+                "population_propagator cannot be combined with rate_matrix "
+                "or relaxation_theory"
+            )
 
         self.t1axis = t1axis
         self.t2axis = t2axis
@@ -160,6 +181,8 @@ class TwoDResponseCalculator:
         self.jump_time_graining = jump_time_graining
         self.jump_kernel_cutoff = jump_kernel_cutoff
         self.jump_kernel_zero_cutoff = jump_kernel_zero_cutoff
+        self.population_propagator = population_propagator
+        self.population_dynamics_mode = population_dynamics_mode
         self.response_diagnostics: list[dict[str, Any]] = []
 
         # FIXME: check the compatibility of the axes
@@ -188,7 +211,7 @@ class TwoDResponseCalculator:
         self._rate_matrix = None
         self._response_rate_matrix: Any = None
         self._relaxation_hamiltonian = None
-        self._population_time_axis = None
+        self._population_time_axis = population_time_axis
         self._has_relaxation_tensor = False
         self._has_rate_matrix = False
         self.relaxation_theory = relaxation_theory
@@ -305,13 +328,18 @@ class TwoDResponseCalculator:
                 # Relaxation rates
                 #
                 relaxation_requested = (
-                    self._has_rate_matrix or self.relaxation_theory is not None
+                    self._has_rate_matrix
+                    or self.relaxation_theory is not None
+                    or self.population_propagator is not None
                 )
                 if relaxation_requested:
-                    validate_2d_time_axes(self.t1axis, self.t2axis, self.t3axis)
-                    self._population_time_axis = get_common_time_axis(
-                        self.t1axis, self.t2axis, self.t3axis
-                    )
+                    if self.population_propagator is None:
+                        validate_2d_time_axes(self.t1axis, self.t2axis, self.t3axis)
+                        self._population_time_axis = get_common_time_axis(
+                            self.t1axis, self.t2axis, self.t3axis
+                        )
+                    elif self._population_time_axis is None:
+                        self._population_time_axis = self.t2axis
 
                 if self._has_rate_matrix:
                     KK = self._rate_matrix
@@ -472,6 +500,8 @@ class TwoDResponseCalculator:
             self.resp_fcions = []
             response_kwargs: dict[str, Any] = dict(
                 rate_matrix=self._response_rate_matrix,
+                population_propagator=self.population_propagator,
+                population_dynamics_mode=self.population_dynamics_mode,
                 population_time_axis=self._population_time_axis,
                 jump_time_graining=self.jump_time_graining,
                 jump_kernel_cutoff=self.jump_kernel_cutoff,

--- a/quantarhei/spectroscopy/twodcontainer.py
+++ b/quantarhei/spectroscopy/twodcontainer.py
@@ -320,7 +320,12 @@ class TwoDResponseContainer(Saveable):
         return ven2
 
     def get_PumpProbeSpectrumContainer(self, skip: int = 0) -> Any:
-        """Converts this container into PumpProbeSpectrumContainer"""
+        """Converts this response container into PumpProbeSpectrumContainer.
+
+        Each stored :class:`TwoDResponse` already contains enough spectral
+        information to be projected onto the pump-probe axis.  This method
+        performs that projection for every stored waiting time.
+        """
         from .pumpprobe import PumpProbeSpectrumContainer
 
         k = 0
@@ -339,8 +344,15 @@ class TwoDResponseContainer(Saveable):
             ii += 1
 
         length = len(ppc)
+        if length == 0:
+            raise Exception("No spectra available for pump-probe conversion")
         start = ppc[0].get_t2()
-        step = ppc[1].get_t2() - start
+        if length > 1:
+            step = ppc[1].get_t2() - start
+        elif self.axis is not None:
+            step = self.axis.step
+        else:
+            step = 1.0
 
         naxis = TimeAxis(start, length, step)
         ppcont = PumpProbeSpectrumContainer(t2axis=naxis)
@@ -862,8 +874,15 @@ class TwoDSpectrumContainer(TwoDResponseContainer):
                 ii += 1
 
             length = len(ppc)
+            if length == 0:
+                raise Exception("No spectra available for pump-probe conversion")
             start = ppc[0].get_t2()
-            step = ppc[1].get_t2() - start
+            if length > 1:
+                step = ppc[1].get_t2() - start
+            elif self.axis is not None:
+                step = self.axis.step
+            else:
+                step = 1.0
 
             naxis = TimeAxis(start, length, step)
             ppcont = PumpProbeSpectrumContainer(t2axis=naxis)

--- a/quantarhei/spectroscopy/twodresponse.py
+++ b/quantarhei/spectroscopy/twodresponse.py
@@ -44,6 +44,12 @@ _ptypes = [
     "R2f_scM0g",
     "R1f_scM0e",
     "R2f_scM0e",
+    "R1g_scM1g",
+    "R2g_scM1g",
+    "R1f_scM1g",
+    "R2f_scM1g",
+    "R1f_scM1e",
+    "R2f_scM1e",
     # Older storage names kept readable for backwards compatibility.
     "R1fs",
     "R2fs",
@@ -56,7 +62,7 @@ _ptypes = [
 #
 _processes = dict(
     GSB=["R3g", "R4g"],
-    SE=["R1g", "R2g", "R1g_scM0g", "R2g_scM0g"],
+    SE=["R1g", "R2g", "R1g_scM0g", "R2g_scM0g", "R1g_scM1g", "R2g_scM1g"],
     ESA=[
         "R1f",
         "R2f",
@@ -64,6 +70,10 @@ _processes = dict(
         "R2f_scM0g",
         "R1f_scM0e",
         "R2f_scM0e",
+        "R1f_scM1g",
+        "R2f_scM1g",
+        "R1f_scM1e",
+        "R2f_scM1e",
         "R1fs",
         "R2fs",
     ],
@@ -82,6 +92,9 @@ _signals = {
         "R2g_scM0g",
         "R2f_scM0g",
         "R2f_scM0e",
+        "R2g_scM1g",
+        "R2f_scM1g",
+        "R2f_scM1e",
         "R1fs",
     ],
     signal_NONR: [
@@ -91,6 +104,9 @@ _signals = {
         "R1g_scM0g",
         "R1f_scM0g",
         "R1f_scM0e",
+        "R1g_scM1g",
+        "R1f_scM1g",
+        "R1f_scM1e",
         "R2fs",
     ],
     signal_DC: ["R3fs", "R4fs"],

--- a/quantarhei/spectroscopy/twodresponse.py
+++ b/quantarhei/spectroscopy/twodresponse.py
@@ -28,21 +28,46 @@ from ..core.valueaxis import ValueAxis
 from ..utils.types import check_numpy_array
 from .twodspect import TwoDSpectrum
 
-# FIXME: Check these names
-
 #
 #  Pathway types
 #
-_ptypes = ["R1g", "R2g", "R3g", "R4g", "R1fs", "R2fs", "R3fs", "R4fs"]
+_ptypes = [
+    "R1g",
+    "R2g",
+    "R3g",
+    "R4g",
+    "R1f",
+    "R2f",
+    "R1g_scM0g",
+    "R2g_scM0g",
+    "R1f_scM0g",
+    "R2f_scM0g",
+    "R1f_scM0e",
+    "R2f_scM0e",
+    # Older storage names kept readable for backwards compatibility.
+    "R1fs",
+    "R2fs",
+    "R3fs",
+    "R4fs",
+]
 
 #
 # Processes --- GSB, SE, ESA and DC
 #
 _processes = dict(
-    GSB=[_ptypes[0], _ptypes[1]],
-    SE=[_ptypes[2], _ptypes[3]],
-    ESA=[_ptypes[4], _ptypes[5]],
-    DC=[_ptypes[6], _ptypes[7]],
+    GSB=["R3g", "R4g"],
+    SE=["R1g", "R2g", "R1g_scM0g", "R2g_scM0g"],
+    ESA=[
+        "R1f",
+        "R2f",
+        "R1f_scM0g",
+        "R2f_scM0g",
+        "R1f_scM0e",
+        "R2f_scM0e",
+        "R1fs",
+        "R2fs",
+    ],
+    DC=["R3fs", "R4fs"],
 )
 
 #
@@ -50,9 +75,25 @@ _processes = dict(
 #                      and double coherence (DC)
 #
 _signals = {
-    signal_REPH: [_ptypes[1], _ptypes[2], _ptypes[4]],
-    signal_NONR: [_ptypes[0], _ptypes[3], _ptypes[5]],
-    signal_DC: [_ptypes[6], _ptypes[7]],
+    signal_REPH: [
+        "R2g",
+        "R3g",
+        "R2f",
+        "R2g_scM0g",
+        "R2f_scM0g",
+        "R2f_scM0e",
+        "R1fs",
+    ],
+    signal_NONR: [
+        "R1g",
+        "R4g",
+        "R1f",
+        "R1g_scM0g",
+        "R1f_scM0g",
+        "R1f_scM0e",
+        "R2fs",
+    ],
+    signal_DC: ["R3fs", "R4fs"],
 }
 
 _total = signal_TOTL

--- a/tests/unit/builders/test_opensystem_rates.py
+++ b/tests/unit/builders/test_opensystem_rates.py
@@ -1,0 +1,70 @@
+import unittest
+
+import numpy
+
+import quantarhei as qr
+
+
+def _aggregate():
+    m1 = qr.Molecule(name="Molecule 1", elenergies=[0.0, 1.0])
+    m2 = qr.Molecule(name="Molecule 2", elenergies=[0.0, 1.0])
+
+    time = qr.TimeAxis(0.0, 100, 1.0)
+    params = dict(ftype="OverdampedBrownian", reorg=20, cortime=100, T=300)
+    with qr.energy_units("1/cm"):
+        cf = qr.CorrelationFunction(time, params)
+
+    m1.set_transition_environment((0, 1), cf)
+    m1.position = [0.0, 0.0, 0.0]
+    m1.set_dipole(0, 1, [10.0, 0.0, 0.0])
+
+    m2.set_transition_environment((0, 1), cf)
+    m2.position = [10.0, 0.0, 0.0]
+    m2.set_dipole(0, 1, [10.0, 0.0, 0.0])
+
+    agg = qr.Aggregate(name="TestAgg", molecules=[m1, m2])
+    agg.set_coupling_by_dipole_dipole()
+    agg.build()
+
+    return agg
+
+
+class TestOpenSystemRateMatrix(unittest.TestCase):
+    """Tests for unified OpenSystem rate matrix construction."""
+
+    def setUp(self):
+        self.agg = _aggregate()
+
+    def test_redfield_rate_matrix_aliases(self):
+        """Testing unified Redfield rate matrix construction."""
+        rate_matrix = self.agg.get_RateMatrix(relaxation_theory="Redfield")
+        old_rate_matrix = self.agg.get_RedfieldRateMatrix()
+
+        self.assertIsInstance(rate_matrix, qr.qm.RedfieldRateMatrix)
+        numpy.testing.assert_allclose(rate_matrix.data, old_rate_matrix.data)
+
+    def test_foerster_rate_matrix_aliases(self):
+        """Testing unified Foerster rate matrix construction."""
+        rate_matrix = self.agg.get_RateMatrix(relaxation_theory="Foerster")
+        old_rate_matrix = self.agg.get_FoersterRateMatrix()
+
+        self.assertIsInstance(rate_matrix, qr.qm.FoersterRateMatrix)
+        numpy.testing.assert_allclose(rate_matrix.data, old_rate_matrix.data)
+
+    def test_time_dependent_rate_matrices(self):
+        """Testing unified time-dependent rate matrix construction."""
+        redfield = self.agg.get_RateMatrix(
+            relaxation_theory="Redfield", time_dependent=True
+        )
+        foerster = self.agg.get_RateMatrix(
+            relaxation_theory="Foerster", time_dependent=True
+        )
+
+        self.assertIsInstance(redfield, qr.qm.TDRedfieldRateMatrix)
+        self.assertIsInstance(foerster, qr.qm.TDFoersterRateMatrix)
+        self.assertEqual(redfield.data.shape[0], self.agg.sbi.TimeAxis.length)
+        self.assertEqual(foerster.data.shape[0], self.agg.sbi.TimeAxis.length)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/builders/test_opensystem_rates.py
+++ b/tests/unit/builders/test_opensystem_rates.py
@@ -1,4 +1,5 @@
 import unittest
+import warnings
 
 import numpy
 
@@ -38,17 +39,31 @@ class TestOpenSystemRateMatrix(unittest.TestCase):
     def test_redfield_rate_matrix_aliases(self):
         """Testing unified Redfield rate matrix construction."""
         rate_matrix = self.agg.get_RateMatrix(relaxation_theory="Redfield")
-        old_rate_matrix = self.agg.get_RedfieldRateMatrix()
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            old_rate_matrix = self.agg.get_RedfieldRateMatrix()
 
         self.assertIsInstance(rate_matrix, qr.qm.RedfieldRateMatrix)
+        self.assertTrue(issubclass(warning_list[0].category, DeprecationWarning))
+        self.assertIn(
+            "use get_RateMatrix(relaxation_theory='Redfield') instead",
+            str(warning_list[0].message),
+        )
         numpy.testing.assert_allclose(rate_matrix.data, old_rate_matrix.data)
 
     def test_foerster_rate_matrix_aliases(self):
         """Testing unified Foerster rate matrix construction."""
         rate_matrix = self.agg.get_RateMatrix(relaxation_theory="Foerster")
-        old_rate_matrix = self.agg.get_FoersterRateMatrix()
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            old_rate_matrix = self.agg.get_FoersterRateMatrix()
 
         self.assertIsInstance(rate_matrix, qr.qm.FoersterRateMatrix)
+        self.assertTrue(issubclass(warning_list[0].category, DeprecationWarning))
+        self.assertIn(
+            "use get_RateMatrix(relaxation_theory='Foerster') instead",
+            str(warning_list[0].message),
+        )
         numpy.testing.assert_allclose(rate_matrix.data, old_rate_matrix.data)
 
     def test_time_dependent_rate_matrices(self):

--- a/tests/unit/core/test_wrappers.py
+++ b/tests/unit/core/test_wrappers.py
@@ -1,10 +1,12 @@
 import unittest
+import warnings
 
 import numpy
 
 from quantarhei import CorrelationFunction, Hamiltonian, TimeAxis
 from quantarhei.core.managers import Manager, eigenbasis_of, energy_units
 from quantarhei.core.wrappers import (
+    deprecated,
     enforce_basis_context,
     enforce_energy_units_context,
     prevent_basis_context,
@@ -14,6 +16,39 @@ from quantarhei.core.wrappers import (
 
 class TestWrappers(unittest.TestCase):
     """Test for function wrappers"""
+
+    def test_deprecated_warning(self):
+        """(Wrappers) Testing deprecation warning"""
+
+        @deprecated
+        def func(text):
+            return f"Ahoj {text}"
+
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            self.assertEqual(func("Ciao"), "Ahoj Ciao")
+
+        self.assertEqual(len(warning_list), 1)
+        self.assertTrue(issubclass(warning_list[0].category, DeprecationWarning))
+        self.assertIn("func is deprecated", str(warning_list[0].message))
+
+    def test_deprecated_warning_with_alternative(self):
+        """(Wrappers) Testing deprecation warning with replacement hint"""
+
+        @deprecated(alternative="other_func")
+        def func(text):
+            return f"Ahoj {text}"
+
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter("always")
+            self.assertEqual(func("Ciao"), "Ahoj Ciao")
+
+        self.assertEqual(len(warning_list), 1)
+        self.assertTrue(issubclass(warning_list[0].category, DeprecationWarning))
+        self.assertIn(
+            "func is deprecated; use other_func instead",
+            str(warning_list[0].message),
+        )
 
     def test_eigenbasis_of_prevention(self):
         """(Wrappers) Testing eigenbasis_of context prevention"""

--- a/tests/unit/qm/corfunctions/functionstorage_test.py
+++ b/tests/unit/qm/corfunctions/functionstorage_test.py
@@ -279,3 +279,29 @@ class TestFunctionStorage(unittest.TestCase):
             gg[0, "t1+t2-s2+t3"],
             goft(t1.data[:, None] + 6.0 + t3.data[None, :]),
         )
+
+    def test_function_storage_one_jump_preset(self):
+        """Testing FunctionStorage one-jump preset"""
+        t1 = TimeAxis(0.0, 4, 1.0)
+        t3 = TimeAxis(0.0, 5, 2.0)
+
+        def goft(t):
+            return t + 1.0j * t
+
+        gg0 = FunctionStorage(1, (t1, t3), show_config=False, config=0)
+        self.assertNotIn("s2", gg0.time_mapping)
+
+        gg1 = FunctionStorage(1, (t1, t3), show_config=False, config=1)
+        self.assertIn("s2", gg1.time_mapping)
+        self.assertIn("t2-s2+t3", gg1.time_mapping)
+
+        gg1.set_goft(0, func=goft)
+        gg1.create_data(reset=dict(t2=8.0))
+
+        npt.assert_allclose(gg1[0, "s2"], goft(4.0))
+        npt.assert_allclose(gg1[0, "t2-s2"], goft(4.0))
+        npt.assert_allclose(gg1[0, "t1+t2"], goft(t1.data + 8.0))
+        npt.assert_allclose(
+            gg1[0, "t1+t2+t3"],
+            goft(t1.data[:, None] + 8.0 + t3.data[None, :]),
+        )

--- a/tests/unit/qm/corfunctions/functionstorage_test.py
+++ b/tests/unit/qm/corfunctions/functionstorage_test.py
@@ -206,3 +206,76 @@ class TestFunctionStorage(unittest.TestCase):
                 rtol=1.0e-6,
             )
             print("OK")
+
+    def test_function_storage_integral_time_labels(self):
+        """Testing FunctionStorage labels for one-jump response storage"""
+        t1 = TimeAxis(0.0, 4, 1.0)
+        t3 = TimeAxis(0.0, 5, 2.0)
+
+        config = {
+            "response_times": {
+                "t1": {"reset": False, "integral": None, "axis": 0},
+                "t2": {"reset": True, "integral": {"s2"}},
+                "t3": {"reset": False, "integral": None, "axis": 1},
+            }
+        }
+
+        gg = FunctionStorage(1, (t1, t3), show_config=False, config=config)
+
+        expected = [
+            "t1",
+            "t2",
+            "s2",
+            "t2-s2",
+            "t3",
+            "t1+t2",
+            "t1+s2",
+            "t1+t2-s2",
+            "t1+t3",
+            "t2+t3",
+            "s2+t3",
+            "t2-s2+t3",
+            "t1+t2+t3",
+            "t1+s2+t3",
+            "t1+t2-s2+t3",
+        ]
+
+        for label in expected:
+            self.assertIn(label, gg.time_mapping)
+
+        self.assertEqual(len(gg.time_mapping), len(expected))
+
+    def test_function_storage_integral_time_data(self):
+        """Testing FunctionStorage data for one-jump response storage"""
+        t1 = TimeAxis(0.0, 4, 1.0)
+        t3 = TimeAxis(0.0, 5, 2.0)
+
+        config = {
+            "response_times": {
+                "t1": {"reset": False, "integral": None, "axis": 0},
+                "t2": {"reset": True, "integral": {"s2"}},
+                "t3": {"reset": False, "integral": None, "axis": 1},
+            }
+        }
+
+        def goft(t):
+            return t + 1.0j * t * t
+
+        gg = FunctionStorage(1, (t1, t3), show_config=False, config=config)
+        gg.set_goft(0, func=goft)
+        gg.create_data(reset=dict(t2=10.0, s2=4.0))
+
+        npt.assert_allclose(gg[0, "s2"], goft(4.0))
+        npt.assert_allclose(gg[0, "t2-s2"], goft(6.0))
+        npt.assert_allclose(gg[0, "t1+s2"], goft(t1.data + 4.0))
+        npt.assert_allclose(gg[0, "t1+t2-s2"], goft(t1.data + 6.0))
+        npt.assert_allclose(gg[0, "s2+t3"], goft(4.0 + t3.data))
+        npt.assert_allclose(gg[0, "t2-s2+t3"], goft(6.0 + t3.data))
+        npt.assert_allclose(
+            gg[0, "t1+s2+t3"],
+            goft(t1.data[:, None] + 4.0 + t3.data[None, :]),
+        )
+        npt.assert_allclose(
+            gg[0, "t1+t2-s2+t3"],
+            goft(t1.data[:, None] + 6.0 + t3.data[None, :]),
+        )

--- a/tests/unit/qm/corfunctions/functionstorage_test.py
+++ b/tests/unit/qm/corfunctions/functionstorage_test.py
@@ -305,3 +305,33 @@ class TestFunctionStorage(unittest.TestCase):
             gg1[0, "t1+t2+t3"],
             goft(t1.data[:, None] + 8.0 + t3.data[None, :]),
         )
+
+    def test_function_storage_partial_reset_update(self):
+        """Testing FunctionStorage only updates labels affected by reset changes"""
+        t1 = TimeAxis(0.0, 4, 1.0)
+        t3 = TimeAxis(0.0, 5, 2.0)
+        calls = []
+
+        def goft(t):
+            calls.append(1)
+            return t + 1.0j * t
+
+        gg = FunctionStorage(1, (t1, t3), show_config=False, config=1)
+        gg.set_goft(0, func=goft)
+
+        gg.create_data(reset=dict(t2=8.0, s2=2.0))
+        self.assertEqual(len(calls), len(gg.time_mapping))
+
+        calls.clear()
+        gg.create_data(reset=dict(t2=8.0, s2=3.0))
+        s2_labels = [
+            label for label in gg.time_mapping if "s2" in gg.time_dependencies[label]
+        ]
+        self.assertEqual(len(calls), len(s2_labels))
+
+        npt.assert_allclose(gg[0, "t1+t2"], goft(t1.data + 8.0))
+        npt.assert_allclose(gg[0, "t1+s2"], goft(t1.data + 3.0))
+
+        calls.clear()
+        gg.create_data(reset=dict(t2=8.0, s2=3.0))
+        self.assertEqual(len(calls), 0)

--- a/tests/unit/qm/liouvillespace/rates/test_tdfoersterratematrix.py
+++ b/tests/unit/qm/liouvillespace/rates/test_tdfoersterratematrix.py
@@ -1,0 +1,54 @@
+import unittest
+
+import numpy
+
+from quantarhei import CorrelationFunction, Hamiltonian, TimeAxis, energy_units
+from quantarhei.qm import (
+    Operator,
+    SystemBathInteraction,
+    TDFoersterRateMatrix,
+    TDFoersterRelaxationTensor,
+)
+from quantarhei.qm.corfunctions import CorrelationFunctionMatrix
+
+
+class TestTDFoersterRateMatrix(unittest.TestCase):
+    """Tests for the time-dependent Foerster rate matrix."""
+
+    def setUp(self):
+        time = TimeAxis(0.0, 100, 1.0)
+        with energy_units("1/cm"):
+            params = {
+                "ftype": "OverdampedBrownian",
+                "reorg": 30.0,
+                "T": 300.0,
+                "cortime": 100.0,
+            }
+            cf = CorrelationFunction(time, params)
+
+            self.ham = Hamiltonian(data=[[0.0, 100.0], [100.0, 0.0]])
+
+        cfm = CorrelationFunctionMatrix(time, 2, 1)
+        cfm.set_correlation_function(cf, [(0, 0), (1, 1)])
+
+        k1 = Operator(data=numpy.array([[1.0, 0.0], [0.0, 0.0]]))
+        k2 = Operator(data=numpy.array([[1.0, 0.0], [0.0, 0.0]]))
+        self.sbi = SystemBathInteraction([k1, k2], cfm)
+
+    def test_rate_matrix_matches_relaxation_tensor_population_block(self):
+        """Testing time-dependent Foerster rates against tensor population block."""
+        rate_matrix = TDFoersterRateMatrix(self.ham, self.sbi)
+        tensor = TDFoersterRelaxationTensor(self.ham, self.sbi)
+
+        rates_from_tensor = numpy.zeros_like(rate_matrix.data)
+        for aa in range(self.ham.dim):
+            for bb in range(self.ham.dim):
+                rates_from_tensor[:, aa, bb] = numpy.real(
+                    tensor.data[:, aa, aa, bb, bb]
+                )
+
+        numpy.testing.assert_allclose(rate_matrix.data, rates_from_tensor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/qm/liouvillespace/test_modredfield.py
+++ b/tests/unit/qm/liouvillespace/test_modredfield.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy
+
 """
 *******************************************************************************
 
@@ -19,6 +21,11 @@ from quantarhei import (
     TimeAxis,
     eigenbasis_of,
     energy_units,
+)
+from quantarhei.qm import (
+    ModifiedRedfieldRateMatrix,
+    ModRedfieldRelaxationTensor,
+    TDModRedfieldRelaxationTensor,
 )
 from quantarhei.qm.corfunctions import SpectralDensity
 
@@ -64,38 +71,36 @@ class TestModRedfield(unittest.TestCase):
         self.c_omega_p = sd.at(de, approx="spline")  # interp_data(de)
         self.c_omega_m = sd.at(-de, approx="spline")  # interp_data(-de)
 
-    # def test_comparison_of_rates(self):
-    #     """(REDFIELD) Testing that Redfield tensor and rate matrix are compatible
+    def test_comparison_of_rates(self):
+        """Testing that modified Redfield tensor and rate matrix agree"""
+        dim = self.H1.dim
+        KT = numpy.zeros((dim, dim), dtype=numpy.float64)
 
-    #     """
-    #     tensor = True
-    #     matrix = True
+        RT = ModRedfieldRelaxationTensor(self.H1, self.sbi1)
+        RR = ModifiedRedfieldRateMatrix(self.H1, self.sbi1)
 
-    #     dim = self.H1.dim
-    #     KT = numpy.zeros((dim,dim), dtype=REAL)
-    #     KM = numpy.zeros((dim,dim), dtype=REAL)
+        with eigenbasis_of(self.H1):
+            for n in range(dim):
+                for m in range(dim):
+                    KT[n, m] = numpy.real(RT.data[n, n, m, m])
 
-    #     if tensor:
+        numpy.testing.assert_allclose(KT, RR.data, rtol=1.0e-10, atol=1.0e-12)
 
-    #         RT = ModRedfieldRelaxationTensor(self.H1,self.sbi1)
+    def test_calculation_is_forbidden_in_basis_context(self):
+        """Testing that modified Redfield tensor is not created in basis context"""
+        with self.assertRaises(Exception) as context:
+            with eigenbasis_of(self.H1):
+                ModRedfieldRelaxationTensor(self.H1, self.sbi1)
 
-    #         # rates have to be compared in eigenbasis of the Hamiltonian
-    #         with eigenbasis_of(self.H1):
-    #             for n in range(dim):
-    #                 for m in range(dim):
-    #                     #print(n,m,numpy.real(RT.data[n,n,m,m]))
-    #                     KT[n,m] = numpy.real(RT.data[n,n,m,m])
+        self.assertTrue("MUST NOT be called" in str(context.exception))
 
-    #     if matrix:
+    def test_td_calculation_is_forbidden_in_basis_context(self):
+        """Testing that TD modified Redfield tensor is not created in basis context"""
+        with self.assertRaises(Exception) as context:
+            with eigenbasis_of(self.H1):
+                TDModRedfieldRelaxationTensor(self.H1, self.sbi1, initialize=False)
 
-    #         RR = ModifiedRedfieldRateMatrix(self.H1,self.sbi1) #,self.time)
-
-    #         for n in range(dim):
-    #             for m in range(dim):
-    #                 #print(n,m,numpy.real(RR.data[n,m]))
-    #                 KM[n,m] = numpy.real(RR.data[n,m])
-
-    #     numpy.testing.assert_allclose(KT,KM, rtol=1.0e-10)
+        self.assertTrue("MUST NOT be called" in str(context.exception))
 
     # def test_propagation_in_different_basis(self):
     #     """(REDFIELD) Testing comparison of propagations in different bases

--- a/tests/unit/spectroscopy/pumpprobe_test.py
+++ b/tests/unit/spectroscopy/pumpprobe_test.py
@@ -1,5 +1,6 @@
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy
 import numpy.testing as npt
@@ -23,6 +24,20 @@ from quantarhei.utils.vectors import X
 """
 
 TEST_DIR = Path(__file__).parent
+
+
+class _MagicAngleLab:
+    """Minimal magic-angle lab setup for pump-probe backend tests."""
+
+    F4eM4 = numpy.array([1.0 / 15.0, 0.0, 0.0])
+
+
+def _ground_exciton_dipole_lengths(system):
+    """Return ground-to-one-exciton transition-dipole lengths."""
+    ground = system.get_band(0)[0]
+    return numpy.array(
+        [numpy.linalg.norm(system.DD[state, ground, :]) for state in system.get_band(1)]
+    )
 
 
 def efce_R1g_vec(t2, t1s, t3s, aa):
@@ -89,9 +104,9 @@ def efce_R4g_vec(t2, t1s, t3s, aa):
     )
 
 
-def _reference_pump_probe_aggregate():
+def _reference_pump_probe_aggregate(env_length=400):
     """Small dimer with enough bath data for the pump-probe reference test."""
-    env_axis = qr.TimeAxis(0.0, 400, 5.0)
+    env_axis = qr.TimeAxis(0.0, env_length, 5.0)
     params = {
         "ftype": "OverdampedBrownian",
         "reorg": 40.0,
@@ -396,3 +411,305 @@ class TestPumpProbe(unittest.TestCase):
         npt.assert_allclose(current.axis.data, reference.axis.data)
         npt.assert_allclose(current.data, reference.data, rtol=1.0e-12, atol=1.0e-12)
         self.assertEqual(current.get_t2(), reference.get_t2())
+
+    def test_pump_probe_response_backend_accepts_rdm_trajectory(self):
+        """Pump-probe can be calculated through the nonlinear response backend."""
+        t2_axis = qr.TimeAxis(0.0, 3, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 32, 5.0)
+        agg = _reference_pump_probe_aggregate()
+
+        calc = qr.PumpProbeSpectrumCalculator(t2_axis, t3_axis, system=agg)
+        lab = _MagicAngleLab()
+        with qr.energy_units("1/cm"):
+            calc.bootstrap(rwa=12100.0, lab=lab)
+
+        rdmt = SimpleNamespace()
+        rdmt.data = numpy.zeros((t2_axis.length, agg.Ntot, agg.Ntot))
+        for kk in range(t2_axis.length):
+            rdmt.data[kk, 1, 1] = 0.65 - 0.05 * kk
+            rdmt.data[kk, 2, 2] = 0.30 - 0.03 * kk
+            rdmt.data[kk, 1, 2] = 0.05
+            rdmt.data[kk, 2, 1] = 0.05
+
+        container = calc.calculate_all_system_approx_response_backend(
+            agg, rdmt, lab, spec=["SE", "ESA"]
+        )
+
+        self.assertEqual(set(container.spectra), set(t2_axis.data))
+        for tau in t2_axis.data:
+            spectrum = container.spectra[tau]
+            npt.assert_allclose(spectrum.axis.data, calc.oa3.data)
+            self.assertEqual(spectrum.get_t2(), tau)
+            self.assertTrue(numpy.all(numpy.isfinite(spectrum.data)))
+
+    def test_pump_probe_response_gsb_mode_uses_r3g_r4g(self):
+        """The alternative GSB mode uses unweighted R3g/R4g pathways."""
+        t2_axis = qr.TimeAxis(0.0, 3, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 32, 5.0)
+        agg = _reference_pump_probe_aggregate()
+
+        calc = qr.PumpProbeSpectrumCalculator(t2_axis, t3_axis, system=agg)
+        lab = _MagicAngleLab()
+        with qr.energy_units("1/cm"):
+            calc.bootstrap(rwa=12100.0, lab=lab)
+
+        tau = 20.0
+        rdm0 = numpy.zeros((calc.system.Ntot, calc.system.Ntot))
+        rdm0[1, 1] = 0.65
+        rdm0[2, 2] = 0.35
+        rdm0_other = 2.0 * rdm0
+        rdm = numpy.zeros_like(rdm0)
+
+        direct = calc.calculate_pathways_rdm(
+            rdm0, rdm, tau, lab, spec=["GSB"], gsb_mode="response"
+        )
+        direct_other = calc.calculate_pathways_rdm(
+            rdm0_other, rdm, tau, lab, spec=["GSB"], gsb_mode="response"
+        )
+        backend = calc._response_backend_to_pump_probe(
+            calc._response_backend_trace(["R3g", "R4g"], tau, lab), tau
+        )
+
+        npt.assert_allclose(direct.data, backend.data)
+        npt.assert_allclose(direct_other.data, direct.data)
+
+    def test_pump_probe_four_dipole_averaging_matches_response_backend(self):
+        """Old RDM pump-probe can use the same dipole averaging as responses."""
+        t2_axis = qr.TimeAxis(0.0, 2, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 32, 5.0)
+        agg = _reference_pump_probe_aggregate()
+
+        calc = qr.PumpProbeSpectrumCalculator(t2_axis, t3_axis, system=agg)
+        lab = _MagicAngleLab()
+        with qr.energy_units("1/cm"):
+            calc.bootstrap(rwa=12100.0, lab=lab)
+
+        rdmt = SimpleNamespace()
+        rdmt.data = numpy.zeros((t2_axis.length, agg.Ntot, agg.Ntot))
+        for kk in range(t2_axis.length):
+            rdmt.data[kk, 1, 1] = 0.65 - 0.05 * kk
+            rdmt.data[kk, 2, 2] = 0.30 - 0.03 * kk
+            rdmt.data[kk, 1, 2] = 0.05
+            rdmt.data[kk, 2, 1] = 0.05
+
+        old = calc.calculate_all_system_approx(
+            agg,
+            rdmt,
+            lab,
+            gsb_mode="response",
+            orientational_averaging="four_dipole",
+        )
+        calc.set_density_matrix_trajectory(rdmt)
+        new = calc.calculate(method="response")
+
+        for tau in t2_axis.data:
+            npt.assert_allclose(
+                old.spectra[tau].data, new.spectra[tau].data, rtol=1.0e-7, atol=1.0e-6
+            )
+
+    def test_pump_probe_backend_population_propagator_matches_equivalent_udm(self):
+        """Population propagator route matches equivalent Ueeee endpoint weights."""
+        t2_axis = qr.TimeAxis(0.0, 2, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 32, 5.0)
+        agg = _reference_pump_probe_aggregate()
+
+        calc = qr.PumpProbeSpectrumCalculator(t2_axis, t3_axis, system=agg)
+        lab = _MagicAngleLab()
+        with qr.energy_units("1/cm"):
+            calc.bootstrap(rwa=12100.0, lab=lab)
+
+        Uee = numpy.zeros((agg.Nb[1], agg.Nb[1], t2_axis.length))
+        Uee[0, 0, :] = [0.80, 0.72]
+        Uee[1, 1, :] = [0.70, 0.63]
+
+        Ueeee = numpy.zeros(
+            (agg.Nb[1], agg.Nb[1], agg.Nb[1], agg.Nb[1], t2_axis.length)
+        )
+        for kk in range(t2_axis.length):
+            for aa in range(agg.Nb[1]):
+                for bb in range(agg.Nb[1]):
+                    Ueeee[aa, bb, aa, bb, kk] = numpy.sqrt(
+                        Uee[aa, aa, kk] * Uee[bb, bb, kk]
+                    )
+
+        calc.set_population_propagator(Uee)
+        uee_backend = calc.calculate(method="response")
+        ueeee_backend = calc.calculate_all_system_approx_response_backend(
+            agg, lab=lab, density_matrix_propagator=Ueeee
+        )
+
+        for tau in t2_axis.data:
+            npt.assert_allclose(
+                ueeee_backend.spectra[tau].data,
+                uee_backend.spectra[tau].data,
+                rtol=1.0e-7,
+                atol=1.0e-6,
+            )
+
+    def test_pump_probe_backend_density_matrix_propagator_matches_rdm(self):
+        """Density-matrix propagator route matches RDM endpoint weights."""
+        t2_axis = qr.TimeAxis(0.0, 2, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 32, 5.0)
+        agg = _reference_pump_probe_aggregate()
+
+        calc = qr.PumpProbeSpectrumCalculator(t2_axis, t3_axis, system=agg)
+        lab = _MagicAngleLab()
+        with qr.energy_units("1/cm"):
+            calc.bootstrap(rwa=12100.0, lab=lab)
+
+        rdmt = SimpleNamespace()
+        rdmt.data = numpy.zeros((t2_axis.length, agg.Ntot, agg.Ntot))
+        rdmt.data[:, 1, 1] = [0.65, 0.60]
+        rdmt.data[:, 2, 2] = [0.30, 0.27]
+        rdmt.data[:, 1, 2] = [0.05, 0.04]
+        rdmt.data[:, 2, 1] = [0.05, 0.04]
+
+        lengths = _ground_exciton_dipole_lengths(calc.system)
+        Ueeee = numpy.zeros(
+            (agg.Nb[1], agg.Nb[1], agg.Nb[1], agg.Nb[1], t2_axis.length)
+        )
+        for kk in range(t2_axis.length):
+            for aa in range(agg.Nb[1]):
+                for bb in range(agg.Nb[1]):
+                    Ueeee[aa, bb, aa, bb, kk] = rdmt.data[kk, aa + 1, bb + 1] / (
+                        lengths[aa] * lengths[bb]
+                    )
+
+        rdm_backend = calc.calculate_all_system_approx_response_backend(agg, rdmt, lab)
+        calc.set_density_matrix_propagator(Ueeee)
+        ueeee_backend = calc.calculate(method="response")
+
+        for tau in t2_axis.data:
+            npt.assert_allclose(
+                rdm_backend.spectra[tau].data,
+                ueeee_backend.spectra[tau].data,
+                rtol=1.0e-7,
+                atol=1.0e-6,
+            )
+
+    def test_pump_probe_backend_external_dynamics_are_mutually_exclusive(self):
+        """Modern pump-probe backend accepts exactly one dynamics source."""
+        t2_axis = qr.TimeAxis(0.0, 2, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 32, 5.0)
+        agg = _reference_pump_probe_aggregate()
+
+        calc = qr.PumpProbeSpectrumCalculator(t2_axis, t3_axis, system=agg)
+        lab = _MagicAngleLab()
+        with qr.energy_units("1/cm"):
+            calc.bootstrap(rwa=12100.0, lab=lab)
+
+        rho = numpy.zeros((t2_axis.length, agg.Ntot, agg.Ntot))
+        Uee = numpy.zeros((agg.Nb[1], agg.Nb[1], t2_axis.length))
+
+        with self.assertRaises(ValueError):
+            calc.calculate_all_system_approx_response_backend(agg, lab=lab)
+        with self.assertRaises(ValueError):
+            calc.calculate_all_system_approx_response_backend(
+                agg, rho, lab, population_propagator=Uee
+            )
+
+    def test_pump_probe_calculate_legacy_method(self):
+        """The public calculate method can dispatch to legacy RDM PP."""
+        t2_axis = qr.TimeAxis(0.0, 2, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 32, 5.0)
+        agg = _reference_pump_probe_aggregate()
+
+        calc = qr.PumpProbeSpectrumCalculator(t2_axis, t3_axis, system=agg)
+        lab = _MagicAngleLab()
+        with qr.energy_units("1/cm"):
+            calc.bootstrap(rwa=12100.0, lab=lab)
+
+        rdmt = SimpleNamespace()
+        rdmt.data = numpy.zeros((t2_axis.length, agg.Ntot, agg.Ntot))
+        rdmt.data[:, 1, 1] = [0.65, 0.60]
+        rdmt.data[:, 2, 2] = [0.30, 0.27]
+
+        direct = calc.calculate_all_system_approx(agg, rdmt, lab)
+        calc.set_density_matrix_trajectory(rdmt)
+        via_api = calc.calculate(method="legacy")
+
+        for tau in t2_axis.data:
+            npt.assert_allclose(direct.spectra[tau].data, via_api.spectra[tau].data)
+
+    def test_pump_probe_constructor_dynamics_are_used_by_calculate(self):
+        """Pump-probe dynamics can be supplied in the calculator constructor."""
+        t2_axis = qr.TimeAxis(0.0, 2, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 32, 5.0)
+        agg = _reference_pump_probe_aggregate()
+
+        rdmt = SimpleNamespace()
+        rdmt.data = numpy.zeros((t2_axis.length, agg.Ntot, agg.Ntot))
+        rdmt.data[:, 1, 1] = [0.65, 0.60]
+        rdmt.data[:, 2, 2] = [0.30, 0.27]
+
+        calc = qr.PumpProbeSpectrumCalculator(
+            t2_axis, t3_axis, system=agg, density_matrix_trajectory=rdmt
+        )
+        lab = _MagicAngleLab()
+        with qr.energy_units("1/cm"):
+            calc.bootstrap(rwa=12100.0, lab=lab)
+
+        direct = calc.calculate_all_system_approx_response_backend(agg, rdmt, lab)
+        via_api = calc.calculate()
+
+        for tau in t2_axis.data:
+            npt.assert_allclose(direct.spectra[tau].data, via_api.spectra[tau].data)
+
+        with self.assertRaises(ValueError):
+            qr.PumpProbeSpectrumCalculator(
+                t2_axis,
+                t3_axis,
+                system=agg,
+                density_matrix_trajectory=rdmt,
+                population_propagator=numpy.zeros(
+                    (agg.Nb[1], agg.Nb[1], t2_axis.length)
+                ),
+            )
+
+    @unittest.expectedFailure
+    def test_pump_probe_direct_matches_projected_twod_response(self):
+        """Direct pump-probe should match projection of the full 2D response.
+
+        This is intentionally a finite-t1 2D calculation.  The pump-probe
+        spectrum is then obtained from the TwoDResponseContainer through the
+        projection theorem and compared only at the final 1D spectrum level.
+        """
+        t1_axis = qr.TimeAxis(0.0, 64, 5.0)
+        t2_axis = qr.TimeAxis(0.0, 1, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 64, 5.0)
+        agg = _reference_pump_probe_aggregate(env_length=t1_axis.length)
+        lab = _MagicAngleLab()
+
+        pp_calc = qr.PumpProbeSpectrumCalculator(t2_axis, t3_axis, system=agg)
+        twod_calc = qr.TwoDResponseCalculator(t1_axis, t2_axis, t3_axis, system=agg)
+        with qr.energy_units("1/cm"):
+            pp_calc.bootstrap(rwa=12100.0, lab=lab)
+            twod_calc.bootstrap(rwa=12100.0, pad=0, lab=lab)
+
+        lengths = _ground_exciton_dipole_lengths(pp_calc.system)
+        rdmt = SimpleNamespace()
+        rdmt.data = numpy.zeros((t2_axis.length, agg.Ntot, agg.Ntot))
+        for aa in range(agg.Nb[1]):
+            for bb in range(agg.Nb[1]):
+                rdmt.data[:, aa + 1, bb + 1] = lengths[aa] * lengths[bb]
+
+        direct = pp_calc.calculate_all_system_approx(
+            agg,
+            rdmt,
+            lab,
+            gsb_mode="response",
+            orientational_averaging="four_dipole",
+        )
+        projected = twod_calc.calculate().get_PumpProbeSpectrumContainer()
+
+        for tau in t2_axis.data:
+            npt.assert_allclose(
+                direct.spectra[tau].axis.data,
+                projected.spectra[tau].axis.data,
+            )
+            npt.assert_allclose(
+                direct.spectra[tau].data,
+                projected.spectra[tau].data,
+                rtol=1.0e-7,
+                atol=1.0e-6,
+            )

--- a/tests/unit/spectroscopy/pumpprobe_test.py
+++ b/tests/unit/spectroscopy/pumpprobe_test.py
@@ -366,7 +366,11 @@ class TestPumpProbe(unittest.TestCase):
         twod0.set_axis_1(t1_axis)
         twod0.set_axis_3(t3_axis)
 
-        npt.assert_allclose(twod0.data, twod.data)
+        # The stored reference was generated before 2D FFTs carried explicit
+        # integral factors.  Keep this compatibility scaling until the
+        # reference data are regenerated; then remove this factor.
+        fft_integral_scale = Nt1 * dt1 * dt3
+        npt.assert_allclose(twod0.data * fft_integral_scale, twod.data)
 
     def test_PumpProbe_2(self):
         """Testing basic functions of the TwoDSpectrumCalculator class"""

--- a/tests/unit/spectroscopy/pumpprobe_test.py
+++ b/tests/unit/spectroscopy/pumpprobe_test.py
@@ -1,9 +1,11 @@
 import unittest
 from pathlib import Path
 
+import numpy
 import numpy.testing as npt
 
 import quantarhei as qr
+from quantarhei.spectroscopy.pumpprobe import PumpProbeSpectrum
 from quantarhei.symbolic.cumulant import GFInitiator
 from quantarhei.utils.vectors import X
 
@@ -85,6 +87,141 @@ def efce_R4g_vec(t2, t1s, t3s, aa):
         + aa.gg_t2_t3["ab"]
         - aa.gg_t3["bb"]
     )
+
+
+def _reference_pump_probe_aggregate():
+    """Small dimer with enough bath data for the pump-probe reference test."""
+    env_axis = qr.TimeAxis(0.0, 400, 5.0)
+    params = {
+        "ftype": "OverdampedBrownian",
+        "reorg": 40.0,
+        "cortime": 100.0,
+        "T": 100.0,
+        "matsubara": 20,
+    }
+
+    with qr.energy_units("1/cm"):
+        mol1 = qr.Molecule([0.0, 12000.0])
+        mol2 = qr.Molecule([0.0, 12300.0])
+        cf1 = qr.CorrelationFunction(env_axis, params)
+        cf2 = qr.CorrelationFunction(env_axis, params)
+        mol1.set_transition_environment((0, 1), cf1)
+        mol2.set_transition_environment((0, 1), cf2)
+
+    mol1.set_dipole(0, 1, [1.0, 0.8, 0.8])
+    mol2.set_dipole(0, 1, [0.8, 0.8, 0.0])
+
+    agg = qr.Aggregate(molecules=[mol1, mol2])
+    with qr.energy_units("1/cm"):
+        agg.set_resonance_coupling(0, 1, 100.0)
+
+    agg.build(mult=2, sbi_for_higher_ex=True)
+    agg.diagonalize()
+    return agg
+
+
+def _reference_calculate_pathways_rdm(calc, rdm0, rdm, tau, lab, ptol=1.0e-6):
+    """Copied pump-probe RDM formula used as a regression reference."""
+    onepp = PumpProbeSpectrum()
+    onepp.set_axis(calc.oa3)
+
+    ss = calc.system.SS.copy()
+
+    if calc.goft_matrix is not None:
+        gt3s = calc.goft_matrix
+    else:
+        gt3s = calc._SE_excitonic_gofts(
+            ss, calc.system, tau=0.0, _diag_double_only=True
+        )
+        calc.goft_matrix = gt3s
+    gt3tau = calc._SE_excitonic_gofts(ss, calc.system, tau=tau, _diag_double_only=True)
+
+    ppspec = numpy.zeros(calc.t3axis.length, dtype=numpy.complex128)
+    dim = calc.system.Nb[1] + calc.system.Nb[0]
+
+    for jj in range(1, dim):
+        pref_gsb = lab.F4eM4[0]
+        pref_gsb *= 2
+        pref_gsb *= numpy.sum(numpy.diag(rdm0))
+        pref_gsb *= numpy.dot(calc.system.DD[jj, 0, :], calc.system.DD[jj, 0, :])
+
+        om = calc.system.HH[jj, jj] - calc.system.HH[0, 0] - calc.rwa
+        ft = -1j * om * calc.t3axis.data
+        ft -= gt3s[jj, jj]
+        ppspec += pref_gsb * numpy.exp(ft)
+
+    for ii in range(1, dim):
+        om = calc.system.HH[ii, ii] - calc.system.HH[0, 0] - calc.rwa
+
+        for jj in range(1, dim):
+            if rdm[ii, jj] < ptol:
+                continue
+
+            omtau = calc.system.HH[ii, ii] - calc.system.HH[jj, jj]
+            pref_se = lab.F4eM4[0]
+            pref_se *= 2
+            pref_se *= rdm[ii, jj]
+            pref_se *= numpy.dot(calc.system.DD[ii, 0, :], calc.system.DD[jj, 0, :])
+
+            ft = -1j * om * calc.t3axis.data - 1j * omtau * tau
+            gt1 = gt3tau[ii, ii] - numpy.conj(gt3tau[ii, jj])
+            gt2 = numpy.conj(gt3tau[jj, jj, 0]) - gt3tau[ii, jj, 0]
+            gt3 = numpy.conj(gt3s[jj, ii])
+            ft -= gt1 + gt2 + gt3
+
+            ppspec += pref_se * numpy.exp(ft)
+
+    for ii in range(1, dim):
+        for jj in range(1, dim):
+            if numpy.abs(rdm[ii, jj]) < ptol:
+                continue
+
+            for ll in range(dim, calc.system.Ntot):
+                om = calc.system.HH[ll, ll] - calc.system.HH[jj, jj] - calc.rwa
+                omtau = calc.system.HH[ii, ii] - calc.system.HH[jj, jj]
+
+                pref_esa = lab.F4eM4[0]
+                pref_esa *= 2
+                pref_esa *= rdm[ii, jj]
+                pref_esa *= numpy.dot(
+                    calc.system.DD[ll, ii, :], calc.system.DD[jj, ll, :]
+                )
+
+                fl = ll
+                ek = jj
+                ej = ii
+
+                ft = -1j * om * calc.t3axis.data - 1j * omtau * tau
+                gt1 = gt3s[fl, fl] - gt3s[fl, ek] + gt3s[ej, ek] - gt3s[ej, fl]
+                gt2 = (
+                    gt3tau[ej, ej, 0]
+                    - numpy.conj(gt3tau[ej, ek, 0])
+                    - gt3tau[fl, ej, 0]
+                    + numpy.conj(gt3tau[fl, ek, 0])
+                )
+                gt3 = (
+                    numpy.conj(gt3tau[ek, ek])
+                    - gt3tau[ek, ej]
+                    + gt3tau[fl, ej]
+                    - numpy.conj(gt3tau[fl, ek])
+                )
+                ft -= gt1 + gt2 + gt3
+
+                ppspec -= pref_esa * numpy.exp(ft)
+
+    ppspec = -ppspec
+    ft = numpy.fft.hfft(ppspec) * calc.t3axis.step
+    ft = numpy.fft.fftshift(ft)
+    ft = numpy.flipud(ft)
+    nt = calc.t3axis.length
+
+    data = numpy.real(ft[nt // 2 : nt + nt // 2])
+    data = calc.oa3.data * data
+
+    onepp._add_data(data)
+    onepp.set_t2(tau)
+
+    return onepp
 
 
 class TestPumpProbe(unittest.TestCase):
@@ -224,3 +361,38 @@ class TestPumpProbe(unittest.TestCase):
         t2 = qr.TimeAxis(30, 10, 10.0)
 
         twod_calc = qr.TwoDResponseCalculator(t1, t2, t3)
+
+    def test_pump_probe_rdm_reference_formula(self):
+        """Compare current pump-probe RDM calculation with a copied reference."""
+        t2_axis = qr.TimeAxis(0.0, 3, 10.0)
+        t3_axis = qr.TimeAxis(0.0, 32, 5.0)
+        agg = _reference_pump_probe_aggregate()
+
+        calc = qr.PumpProbeSpectrumCalculator(t2_axis, t3_axis, system=agg)
+        lab = qr.LabSetup()
+        lab.set_pulse_polarizations(
+            pulse_polarizations=(X, X, X), detection_polarization=X
+        )
+        with qr.energy_units("1/cm"):
+            calc.bootstrap(rwa=12100.0, lab=lab)
+
+        rdm0 = numpy.zeros((calc.system.Ntot, calc.system.Ntot), dtype=numpy.float64)
+        rdm0[1, 1] = 0.65
+        rdm0[2, 2] = 0.35
+
+        rdm = numpy.zeros((calc.system.Ntot, calc.system.Ntot), dtype=numpy.float64)
+        rdm[1, 1] = 0.55
+        rdm[2, 2] = 0.25
+        rdm[1, 2] = 0.05
+        rdm[2, 1] = 0.05
+
+        tau = 20.0
+        calc.goft_matrix = None
+        current = calc.calculate_pathways_rdm(rdm0, rdm, tau, lab)
+
+        calc.goft_matrix = None
+        reference = _reference_calculate_pathways_rdm(calc, rdm0, rdm, tau, lab)
+
+        npt.assert_allclose(current.axis.data, reference.axis.data)
+        npt.assert_allclose(current.data, reference.data, rtol=1.0e-12, atol=1.0e-12)
+        self.assertEqual(current.get_t2(), reference.get_t2())

--- a/tests/unit/spectroscopy/responses_test.py
+++ b/tests/unit/spectroscopy/responses_test.py
@@ -267,7 +267,11 @@ class TestResponses(unittest.TestCase):
         twod0.set_axis_1(t1_axis)
         twod0.set_axis_3(t3_axis)
 
-        npt.assert_allclose(twod0.data, twod.data)
+        # The stored reference was generated before 2D FFTs carried explicit
+        # integral factors.  Keep this compatibility scaling until the
+        # reference data are regenerated; then remove this factor.
+        fft_integral_scale = Nt1 * dt1 * dt3
+        npt.assert_allclose(twod0.data * fft_integral_scale, twod.data)
 
     def test_LouvillePathway(self):
         """Testing basic functions of the TwoDSpectrumCalculator class"""

--- a/tests/unit/spectroscopy/responses_test.py
+++ b/tests/unit/spectroscopy/responses_test.py
@@ -252,3 +252,59 @@ class TestResponses(unittest.TestCase):
         self.assertEqual(response.Uee.shape, (2, 2, t2.length))
         self.assertEqual(response.U1_t2.shape, (2, 2, t2.length))
         npt.assert_allclose(response.U1_t2[:, :, 0], numpy.eye(2))
+
+    def test_response_rate_matrix_relaxation_theory(self):
+        """Testing response setup from OpenSystem rate matrix theory names"""
+
+        class RateMatrix:
+            data = numpy.array(
+                [
+                    [0.0, 0.0, 0.0],
+                    [0.0, -0.002, 0.001],
+                    [0.0, 0.002, -0.001],
+                ],
+                dtype=numpy.float64,
+            )
+
+        class System:
+            Nb = [1, 2, 0]
+            Ntot = 3
+            mult = 1
+            requested_theory = None
+
+            def get_band(self, band):
+                if band == 1:
+                    return (1, 2)
+                return (0,)
+
+            def get_RateMatrix(
+                self,
+                relaxation_theory=None,
+                time_dependent=False,
+                relaxation_cutoff_time=None,
+            ):
+                self.requested_theory = relaxation_theory
+                self.requested_time_dependent = time_dependent
+                self.requested_cutoff_time = relaxation_cutoff_time
+                return RateMatrix()
+
+        t1 = qr.TimeAxis(0.0, 10, 1.0)
+        t2 = qr.TimeAxis(0.0, 11, 1.0)
+        t3 = qr.TimeAxis(0.0, 10, 1.0)
+        system = System()
+
+        response = NonLinearResponse(
+            None,
+            system,
+            "R1g",
+            t1,
+            t2,
+            t3,
+            relaxation_theory="standard_Foerster",
+            relaxation_cutoff_time=100.0,
+        )
+
+        self.assertEqual(system.requested_theory, "standard_Foerster")
+        self.assertFalse(system.requested_time_dependent)
+        self.assertEqual(system.requested_cutoff_time, 100.0)
+        npt.assert_allclose(response.KK, RateMatrix.data[1:3, 1:3])

--- a/tests/unit/spectroscopy/responses_test.py
+++ b/tests/unit/spectroscopy/responses_test.py
@@ -5,6 +5,7 @@ import numpy
 import numpy.testing as npt
 
 import quantarhei as qr
+from quantarhei.spectroscopy.response_implementations import get_implementation
 from quantarhei.spectroscopy.responses import RESPONSE_DIAGRAMS, NonLinearResponse
 from quantarhei.symbolic.cumulant import GFInitiator
 from quantarhei.utils.vectors import X
@@ -116,6 +117,10 @@ class TestResponses(unittest.TestCase):
         self.assertEqual(RESPONSE_DIAGRAMS["R1g_scM0g"]["process"], "SE")
         self.assertTrue(RESPONSE_DIAGRAMS["R2f_scM0e"]["transfer"])
         self.assertEqual(RESPONSE_DIAGRAMS["R2f_scM0e"]["process"], "ESA")
+        self.assertTrue(RESPONSE_DIAGRAMS["R1g_scM1g"]["transfer"])
+        self.assertEqual(RESPONSE_DIAGRAMS["R1g_scM1g"]["process"], "SE")
+        self.assertTrue(RESPONSE_DIAGRAMS["R2f_scM1e"]["transfer"])
+        self.assertEqual(RESPONSE_DIAGRAMS["R2f_scM1e"]["process"], "ESA")
 
     def test_Responses(self):
         """Testing basic functions of the TwoDSpectrumBase class"""
@@ -303,6 +308,57 @@ class TestResponses(unittest.TestCase):
         npt.assert_allclose(response.U1_t2[0, 0], numpy.exp(KK[0, 0] * t2.data))
         npt.assert_allclose(response.Uremainder_t2, response.Uee - response.U1_t2)
         npt.assert_allclose(response.Utransfer_t2, response.Uremainder_t2)
+
+    def test_single_jump_transfer_channel(self):
+        """Testing one-jump transfer channel and remainder bookkeeping"""
+
+        class LineshapeStorage:
+            time_mapping = {"t1": 0, "t2": 1, "s2": 2}
+
+        class System:
+            Nb = [0, 2, 0]
+            Ntot = 2
+            mult = 1
+
+            def get_lineshape_functions(self):
+                return LineshapeStorage()
+
+        t1 = qr.TimeAxis(0.0, 10, 1.0)
+        t2 = qr.TimeAxis(0.0, 6, 2.0)
+        t3 = qr.TimeAxis(0.0, 10, 1.0)
+
+        response0 = NonLinearResponse(None, System(), "R1g_scM0g", t1, t2, t3)
+        response1 = NonLinearResponse(None, System(), "R1g_scM1g", t1, t2, t3)
+
+        KK = numpy.array([[-0.002, 0.003], [0.002, -0.003]], dtype=numpy.float64)
+        response0.set_rate_matrix(KK)
+        response1.set_rate_matrix(KK)
+
+        self.assertEqual(len(response0.Ujump_t2), 2)
+        npt.assert_allclose(
+            response0.Uremainder_t2,
+            response0.Uee - response0.U1_t2 - response0.Usingle_t2,
+        )
+        npt.assert_allclose(
+            response0._get_transfer_matrix(1), response0.Uremainder_t2[:, :, 1]
+        )
+        npt.assert_allclose(
+            response1._get_transfer_matrix(1), response1.Usingle_t2[:, :, 1]
+        )
+
+    def test_single_jump_response_requires_storage_labels(self):
+        """Testing storage validation for single-jump response functions"""
+
+        class LineshapeStorage:
+            time_mapping = {"t1": 0, "t2": 1, "t3": 2}
+
+        class System:
+            def get_lineshape_functions(self):
+                return LineshapeStorage()
+
+        response = get_implementation("R1g_scM1g")
+        with self.assertRaisesRegex(Exception, "FunctionStorage\\(config=1\\)"):
+            response(0.0, numpy.zeros(1), numpy.zeros(1), None, System(), None, None)
 
     def test_response_rate_matrix_relaxation_theory(self):
         """Testing response setup from OpenSystem rate matrix theory names"""

--- a/tests/unit/spectroscopy/responses_test.py
+++ b/tests/unit/spectroscopy/responses_test.py
@@ -5,7 +5,10 @@ import numpy
 import numpy.testing as npt
 
 import quantarhei as qr
-from quantarhei.spectroscopy.response_implementations import get_implementation
+from quantarhei.spectroscopy.response_implementations import (
+    _truncate_single_jump_times,
+    get_implementation,
+)
 from quantarhei.spectroscopy.responses import RESPONSE_DIAGRAMS, NonLinearResponse
 from quantarhei.symbolic.cumulant import GFInitiator
 from quantarhei.utils.vectors import X
@@ -121,6 +124,20 @@ class TestResponses(unittest.TestCase):
         self.assertEqual(RESPONSE_DIAGRAMS["R1g_scM1g"]["process"], "SE")
         self.assertTrue(RESPONSE_DIAGRAMS["R2f_scM1e"]["transfer"])
         self.assertEqual(RESPONSE_DIAGRAMS["R2f_scM1e"]["process"], "ESA")
+
+    def test_single_jump_kernel_truncation(self):
+        """Testing s2 integration truncation by one-jump kernel norm"""
+        s2s = numpy.arange(0.0, 10.0)
+        norms = [0.0, 0.001, 0.2, 1.0, 0.3, 0.01, 0.0001, 0.0, 0.0, 0.0]
+        transfers = [numpy.array([[norm]]) for norm in norms]
+        evol = (None, None, None, None, {"jump_kernel_cutoff": 1.0e-2})
+
+        truncated_s2s, truncated_transfers = _truncate_single_jump_times(
+            9.0, s2s, transfers, evol
+        )
+
+        npt.assert_allclose(truncated_s2s, numpy.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))
+        self.assertEqual(len(truncated_transfers), 6)
 
     def test_Responses(self):
         """Testing basic functions of the TwoDSpectrumBase class"""

--- a/tests/unit/spectroscopy/responses_test.py
+++ b/tests/unit/spectroscopy/responses_test.py
@@ -244,8 +244,15 @@ class TestResponses(unittest.TestCase):
         else:
             print("Calculating", Nt2, "spectra")
             tcont = calc.calculate()
-            tcont = tcont.get_TwoDSpectrumContainer()
-            twod = tcont.get_spectrum(T2)
+            pp_from_response = tcont.get_PumpProbeSpectrumContainer()
+            scont = tcont.get_TwoDSpectrumContainer()
+            pp_from_spectrum = scont.get_PumpProbeSpectrumContainer()
+            for t2 in t2_axis.data:
+                npt.assert_allclose(
+                    pp_from_response.spectra[t2].data,
+                    pp_from_spectrum.spectra[t2].data,
+                )
+            twod = scont.get_spectrum(T2)
 
         file_path_1 = TEST_DIR / "responses_test_twod_0.dat"
         save_data = False

--- a/tests/unit/spectroscopy/responses_test.py
+++ b/tests/unit/spectroscopy/responses_test.py
@@ -326,6 +326,59 @@ class TestResponses(unittest.TestCase):
         npt.assert_allclose(response.Uremainder_t2, response.Uee - response.U1_t2)
         npt.assert_allclose(response.Utransfer_t2, response.Uremainder_t2)
 
+    def test_external_population_propagator_full_conditional(self):
+        """Testing endpoint classification of an external population propagator"""
+
+        class System:
+            Nb = [0, 2, 0]
+            Ntot = 2
+            mult = 1
+
+        t1 = qr.TimeAxis(0.0, 10, 1.0)
+        t2 = qr.TimeAxis(0.0, 6, 2.0)
+        t3 = qr.TimeAxis(0.0, 10, 1.0)
+
+        Uee = numpy.zeros((2, 2, t2.length), dtype=numpy.float64)
+        for ii, time in enumerate(t2.data):
+            transfer = 0.1 * (1.0 - numpy.exp(-0.01 * time))
+            Uee[:, :, ii] = numpy.array(
+                [[1.0 - transfer, 0.5 * transfer], [transfer, 1.0 - 0.5 * transfer]]
+            )
+
+        response = NonLinearResponse(
+            None,
+            System(),
+            "R1g_scM0g",
+            t1,
+            t2,
+            t3,
+            population_propagator=Uee,
+            population_dynamics_mode="full_conditional",
+        )
+
+        expected_diag = numpy.zeros_like(Uee)
+        for ii in range(t2.length):
+            expected_diag[:, :, ii] = numpy.diag(numpy.diag(Uee[:, :, ii]))
+
+        npt.assert_allclose(response.Uee, Uee)
+        npt.assert_allclose(response.U1_t2, expected_diag)
+        npt.assert_allclose(response.Uremainder_t2, Uee - expected_diag)
+        npt.assert_allclose(response.Utransfer_t2, response.Uremainder_t2)
+        npt.assert_allclose(response.U0_t1, numpy.ones_like(response.U0_t1))
+        npt.assert_allclose(response.U0_t3, numpy.ones_like(response.U0_t3))
+        npt.assert_allclose(response.U0_t2**2, numpy.diagonal(Uee).T)
+
+        response_time_first = NonLinearResponse(
+            None,
+            System(),
+            "R1g_scM0g",
+            t1,
+            t2,
+            t3,
+            population_propagator=numpy.transpose(Uee, (2, 0, 1)),
+        )
+        npt.assert_allclose(response_time_first.Uee, Uee)
+
     def test_single_jump_transfer_channel(self):
         """Testing one-jump transfer channel and remainder bookkeeping"""
 

--- a/tests/unit/spectroscopy/responses_test.py
+++ b/tests/unit/spectroscopy/responses_test.py
@@ -5,7 +5,7 @@ import numpy
 import numpy.testing as npt
 
 import quantarhei as qr
-from quantarhei.spectroscopy.responses import NonLinearResponse
+from quantarhei.spectroscopy.responses import RESPONSE_DIAGRAMS, NonLinearResponse
 from quantarhei.symbolic.cumulant import GFInitiator
 from quantarhei.utils.vectors import X
 
@@ -94,6 +94,28 @@ class TestResponses(unittest.TestCase):
 
     def setUp(self, verbose=False):
         pass
+
+    def test_response_diagram_mapping(self):
+        """Testing explicit response diagram metadata"""
+        self.assertEqual(RESPONSE_DIAGRAMS["R1g"]["process"], "SE")
+        self.assertEqual(RESPONSE_DIAGRAMS["R1g"]["signal"], qr.signal_NONR)
+        self.assertEqual(RESPONSE_DIAGRAMS["R2g"]["process"], "SE")
+        self.assertEqual(RESPONSE_DIAGRAMS["R2g"]["signal"], qr.signal_REPH)
+
+        self.assertEqual(RESPONSE_DIAGRAMS["R3g"]["process"], "GSB")
+        self.assertEqual(RESPONSE_DIAGRAMS["R3g"]["signal"], qr.signal_REPH)
+        self.assertEqual(RESPONSE_DIAGRAMS["R4g"]["process"], "GSB")
+        self.assertEqual(RESPONSE_DIAGRAMS["R4g"]["signal"], qr.signal_NONR)
+
+        self.assertEqual(RESPONSE_DIAGRAMS["R1f"]["process"], "ESA")
+        self.assertEqual(RESPONSE_DIAGRAMS["R1f"]["signal"], qr.signal_NONR)
+        self.assertEqual(RESPONSE_DIAGRAMS["R2f"]["process"], "ESA")
+        self.assertEqual(RESPONSE_DIAGRAMS["R2f"]["signal"], qr.signal_REPH)
+
+        self.assertTrue(RESPONSE_DIAGRAMS["R1g_scM0g"]["transfer"])
+        self.assertEqual(RESPONSE_DIAGRAMS["R1g_scM0g"]["process"], "SE")
+        self.assertTrue(RESPONSE_DIAGRAMS["R2f_scM0e"]["transfer"])
+        self.assertEqual(RESPONSE_DIAGRAMS["R2f_scM0e"]["process"], "ESA")
 
     def test_Responses(self):
         """Testing basic functions of the TwoDSpectrumBase class"""

--- a/tests/unit/spectroscopy/responses_test.py
+++ b/tests/unit/spectroscopy/responses_test.py
@@ -274,6 +274,35 @@ class TestResponses(unittest.TestCase):
         self.assertEqual(response.Uee.shape, (2, 2, t2.length))
         self.assertEqual(response.U1_t2.shape, (2, 2, t2.length))
         npt.assert_allclose(response.U1_t2[:, :, 0], numpy.eye(2))
+        npt.assert_allclose(response.Uremainder_t2, response.Uee - response.U1_t2)
+        npt.assert_allclose(response.Utransfer_t2, response.Uremainder_t2)
+
+    def test_zero_jump_dephasing_factors(self):
+        """Testing half-rate damping factors on all response time axes"""
+
+        class System:
+            Nb = [0, 2, 0]
+            Ntot = 2
+            mult = 1
+
+        t1 = qr.TimeAxis(0.0, 10, 1.0)
+        t2 = qr.TimeAxis(0.0, 6, 2.0)
+        t3 = qr.TimeAxis(0.0, 10, 1.0)
+
+        response = NonLinearResponse(None, System(), "R1g", t1, t2, t3)
+
+        KK = numpy.zeros((2, 2), dtype=numpy.float64)
+        KK[0, 0] = -0.002
+        KK[1, 1] = -0.004
+
+        response.set_rate_matrix(KK)
+
+        npt.assert_allclose(response.U0_t1[0], numpy.exp(0.5 * KK[0, 0] * t1.data))
+        npt.assert_allclose(response.U0_t2[1], numpy.exp(0.5 * KK[1, 1] * t2.data))
+        npt.assert_allclose(response.U0_t3[0], numpy.exp(0.5 * KK[0, 0] * t3.data))
+        npt.assert_allclose(response.U1_t2[0, 0], numpy.exp(KK[0, 0] * t2.data))
+        npt.assert_allclose(response.Uremainder_t2, response.Uee - response.U1_t2)
+        npt.assert_allclose(response.Utransfer_t2, response.Uremainder_t2)
 
     def test_response_rate_matrix_relaxation_theory(self):
         """Testing response setup from OpenSystem rate matrix theory names"""

--- a/tests/unit/spectroscopy/responses_test.py
+++ b/tests/unit/spectroscopy/responses_test.py
@@ -379,6 +379,140 @@ class TestResponses(unittest.TestCase):
         )
         npt.assert_allclose(response_time_first.Uee, Uee)
 
+    def test_external_density_matrix_propagator_full_conditional(self):
+        """Testing endpoint classification of an external RDM superoperator"""
+
+        class System:
+            Nb = [0, 2, 0]
+            Ntot = 2
+            mult = 1
+
+        t1 = qr.TimeAxis(0.0, 10, 1.0)
+        t2 = qr.TimeAxis(0.0, 6, 2.0)
+        t3 = qr.TimeAxis(0.0, 10, 1.0)
+
+        Ueeee = numpy.zeros((2, 2, 2, 2, t2.length), dtype=numpy.complex128)
+        for ii, time in enumerate(t2.data):
+            Ueeee[0, 0, 0, 0, ii] = 1.0 - 0.01 * time
+            Ueeee[1, 1, 1, 1, ii] = 1.0 - 0.02 * time
+            Ueeee[0, 1, 0, 1, ii] = numpy.exp(-0.01 * time)
+            Ueeee[1, 0, 1, 0, ii] = numpy.exp(-0.015 * time)
+            Ueeee[1, 0, 0, 1, ii] = 0.2j * (1.0 - numpy.exp(-0.01 * time))
+
+        response = NonLinearResponse(
+            None,
+            System(),
+            "R1g_scM0g",
+            t1,
+            t2,
+            t3,
+            density_matrix_propagator=Ueeee,
+        )
+
+        npt.assert_allclose(response.Udm_zero_t2[0, 1], Ueeee[0, 1, 0, 1])
+        npt.assert_allclose(response.Uremainder_t2[1, 0], Ueeee[1, 0, 0, 1])
+        npt.assert_allclose(response.Uremainder_t2[0, 1], numpy.zeros(t2.length))
+
+        response_no_nonsec = NonLinearResponse(
+            None,
+            System(),
+            "R1g_scM0g",
+            t1,
+            t2,
+            t3,
+            density_matrix_propagator=Ueeee,
+            include_nonsecular_remainder=False,
+        )
+        npt.assert_allclose(
+            response_no_nonsec.Uremainder_t2,
+            numpy.zeros_like(response_no_nonsec.Uremainder_t2),
+        )
+
+        response_time_first = NonLinearResponse(
+            None,
+            System(),
+            "R1g_scM0g",
+            t1,
+            t2,
+            t3,
+            density_matrix_propagator=numpy.transpose(Ueeee, (4, 0, 1, 2, 3)),
+        )
+        npt.assert_allclose(response_time_first.Udm_zero_t2, response.Udm_zero_t2)
+
+    def test_density_matrix_trajectory_endpoint_weights(self):
+        """Testing RDM trajectory normalization by transition dipole lengths"""
+
+        class System:
+            Nb = [1, 2, 0]
+            Ntot = 3
+            mult = 1
+            DD = numpy.zeros((3, 3, 3), dtype=numpy.float64)
+
+            def __init__(self):
+                self.DD[1, 0, 0] = 2.0
+                self.DD[2, 0, 1] = 4.0
+
+            def diagonalize(self):
+                pass
+
+            def get_band(self, band):
+                if band == 0:
+                    return (0,)
+                if band == 1:
+                    return (1, 2)
+                return ()
+
+        t1 = qr.TimeAxis(0.0, 1, 1.0)
+        t2 = qr.TimeAxis(0.0, 4, 2.0)
+        t3 = qr.TimeAxis(0.0, 5, 1.0)
+
+        rho = numpy.zeros((2, 2, t2.length), dtype=numpy.complex128)
+        rho[0, 0, :] = 4.0
+        rho[1, 1, :] = 16.0
+        rho[0, 1, :] = 8.0j
+
+        response = NonLinearResponse(
+            None,
+            System(),
+            "R1g",
+            t1,
+            t2,
+            t3,
+            density_matrix_trajectory=rho,
+        )
+
+        npt.assert_allclose(response.Udm_zero_t2[0, 0], numpy.ones(t2.length))
+        npt.assert_allclose(response.Udm_zero_t2[1, 1], numpy.ones(t2.length))
+        npt.assert_allclose(response.Udm_zero_t2[0, 1], 1.0j * numpy.ones(t2.length))
+        npt.assert_allclose(response.Uremainder_t2, numpy.zeros_like(response.Uee))
+
+        with self.assertRaisesRegex(ValueError, "t1 = 0"):
+            NonLinearResponse(
+                None,
+                System(),
+                "R1g",
+                qr.TimeAxis(0.0, 2, 1.0),
+                t2,
+                t3,
+                density_matrix_trajectory=rho,
+            )
+
+        class ZeroDipoleSystem(System):
+            def __init__(self):
+                super().__init__()
+                self.DD[2, 0, :] = 0.0
+
+        with self.assertRaisesRegex(ValueError, "zero transition dipole"):
+            NonLinearResponse(
+                None,
+                ZeroDipoleSystem(),
+                "R1g",
+                t1,
+                t2,
+                t3,
+                density_matrix_trajectory=rho,
+            )
+
     def test_single_jump_transfer_channel(self):
         """Testing one-jump transfer channel and remainder bookkeeping"""
 

--- a/tests/unit/spectroscopy/twod_test.py
+++ b/tests/unit/spectroscopy/twod_test.py
@@ -232,22 +232,21 @@ class TestTwod(unittest.TestCase):
         )
         self.assertEqual(twod_calc.relaxation_theory, "standard_Foerster")
 
-    def test_TwoDResponseCalculator_rejects_time_dependent_rates(self):
-        """Testing that 2D spectra reject time-dependent rate matrices"""
+    def test_TwoDResponseCalculator_accepts_time_dependent_rates(self):
+        """Testing that 2D spectra accept time-dependent rate matrices"""
         t1 = qr.TimeAxis(0.0, 1000, 1.0)
         t3 = qr.TimeAxis(0.0, 1000, 1.0)
         t2 = qr.TimeAxis(30, 10, 10.0)
 
-        with self.assertRaises(NotImplementedError) as context:
-            qr.TwoDResponseCalculator(
-                t1,
-                t2,
-                t3,
-                relaxation_theory="standard_Redfield",
-                rate_matrix_time_dependent=True,
-            )
+        twod_calc = qr.TwoDResponseCalculator(
+            t1,
+            t2,
+            t3,
+            relaxation_theory="standard_Redfield",
+            rate_matrix_time_dependent=True,
+        )
 
-        self.assertIn("Time-dependent rate matrices", str(context.exception))
+        self.assertTrue(twod_calc.rate_matrix_time_dependent)
 
     def test_TwoDResponseCalculator_F2DES_options(self):
         """Testing F-2DES option validation"""
@@ -274,7 +273,6 @@ class TestTwod(unittest.TestCase):
         self.assertIn("state-resolved ESA", str(context.exception))
 
         rate_matrix = numpy.zeros((t2.length, 2, 2), dtype=numpy.float64)
-        with self.assertRaises(NotImplementedError) as context:
-            qr.TwoDResponseCalculator(t1, t2, t3, rate_matrix=rate_matrix)
+        twod_calc = qr.TwoDResponseCalculator(t1, t2, t3, rate_matrix=rate_matrix)
 
-        self.assertIn("Time-dependent rate matrices", str(context.exception))
+        self.assertEqual(twod_calc._rate_matrix.shape, rate_matrix.shape)

--- a/tests/unit/spectroscopy/twod_test.py
+++ b/tests/unit/spectroscopy/twod_test.py
@@ -299,3 +299,32 @@ class TestTwod(unittest.TestCase):
             qr.TwoDResponseCalculator(t1, t2, t3, jump_kernel_cutoff=-1.0)
         with assert_raises(ValueError):
             qr.TwoDResponseCalculator(t1, t2, t3, jump_kernel_zero_cutoff=-1.0)
+
+    def test_TwoDResponseCalculator_external_population_propagator_option(self):
+        """Testing external population propagator option validation"""
+        t1 = qr.TimeAxis(0.0, 1000, 1.0)
+        t3 = qr.TimeAxis(0.0, 1000, 1.0)
+        t2 = qr.TimeAxis(30, 10, 10.0)
+        Uee = numpy.zeros((2, 2, t2.length), dtype=numpy.float64)
+
+        twod_calc = qr.TwoDResponseCalculator(t1, t2, t3, population_propagator=Uee)
+        self.assertEqual(twod_calc.population_dynamics_mode, "full_conditional")
+        self.assertIs(twod_calc.population_propagator, Uee)
+
+        with assert_raises(ValueError):
+            qr.TwoDResponseCalculator(
+                t1,
+                t2,
+                t3,
+                population_propagator=Uee,
+                population_dynamics_mode="unknown",
+            )
+
+        with assert_raises(ValueError):
+            qr.TwoDResponseCalculator(
+                t1,
+                t2,
+                t3,
+                rate_matrix=numpy.zeros((2, 2), dtype=numpy.float64),
+                population_propagator=Uee,
+            )

--- a/tests/unit/spectroscopy/twod_test.py
+++ b/tests/unit/spectroscopy/twod_test.py
@@ -328,3 +328,43 @@ class TestTwod(unittest.TestCase):
                 rate_matrix=numpy.zeros((2, 2), dtype=numpy.float64),
                 population_propagator=Uee,
             )
+        with assert_raises(ValueError):
+            qr.TwoDResponseCalculator(
+                t1,
+                t2,
+                t3,
+                population_propagator=Uee,
+                jump_order=1,
+            )
+
+        Ueeee = numpy.zeros((2, 2, 2, 2, t2.length), dtype=numpy.complex128)
+        twod_calc = qr.TwoDResponseCalculator(
+            t1,
+            t2,
+            t3,
+            density_matrix_propagator=Ueeee,
+            include_nonsecular_remainder=False,
+        )
+        self.assertEqual(twod_calc.population_dynamics_mode, "full_conditional")
+        self.assertIs(twod_calc.density_matrix_propagator, Ueeee)
+        self.assertFalse(twod_calc.include_nonsecular_remainder)
+
+        with assert_raises(ValueError):
+            qr.TwoDResponseCalculator(
+                t1,
+                t2,
+                t3,
+                population_propagator=Uee,
+                density_matrix_propagator=Ueeee,
+            )
+
+        t1_zero = qr.TimeAxis(0.0, 1, 1.0)
+        rho = numpy.zeros((2, 2, t2.length), dtype=numpy.complex128)
+        twod_calc = qr.TwoDResponseCalculator(
+            t1_zero, t2, t3, density_matrix_trajectory=rho
+        )
+        self.assertIs(twod_calc.density_matrix_trajectory, rho)
+        self.assertEqual(twod_calc.population_dynamics_mode, "full_conditional")
+
+        with assert_raises(ValueError):
+            qr.TwoDResponseCalculator(t1, t2, t3, density_matrix_trajectory=rho)

--- a/tests/unit/spectroscopy/twod_test.py
+++ b/tests/unit/spectroscopy/twod_test.py
@@ -284,12 +284,12 @@ class TestTwod(unittest.TestCase):
         t2 = qr.TimeAxis(30, 10, 10.0)
 
         twod_calc = qr.TwoDResponseCalculator(
-            t1, t2, t3, jump_order=1, jump_integration_steps=3
+            t1, t2, t3, jump_order=1, jump_time_graining=3
         )
         self.assertEqual(twod_calc.jump_order, 1)
-        self.assertEqual(twod_calc.jump_integration_steps, 3)
+        self.assertEqual(twod_calc.jump_time_graining, 3)
 
         with assert_raises(ValueError):
             qr.TwoDResponseCalculator(t1, t2, t3, jump_order=2)
         with assert_raises(ValueError):
-            qr.TwoDResponseCalculator(t1, t2, t3, jump_integration_steps=0)
+            qr.TwoDResponseCalculator(t1, t2, t3, jump_time_graining=0)

--- a/tests/unit/spectroscopy/twod_test.py
+++ b/tests/unit/spectroscopy/twod_test.py
@@ -231,3 +231,50 @@ class TestTwod(unittest.TestCase):
             t1, t2, t3, relaxation_theory="standard_Foerster"
         )
         self.assertEqual(twod_calc.relaxation_theory, "standard_Foerster")
+
+    def test_TwoDResponseCalculator_rejects_time_dependent_rates(self):
+        """Testing that 2D spectra reject time-dependent rate matrices"""
+        t1 = qr.TimeAxis(0.0, 1000, 1.0)
+        t3 = qr.TimeAxis(0.0, 1000, 1.0)
+        t2 = qr.TimeAxis(30, 10, 10.0)
+
+        with self.assertRaises(NotImplementedError) as context:
+            qr.TwoDResponseCalculator(
+                t1,
+                t2,
+                t3,
+                relaxation_theory="standard_Redfield",
+                rate_matrix_time_dependent=True,
+            )
+
+        self.assertIn("Time-dependent rate matrices", str(context.exception))
+
+    def test_TwoDResponseCalculator_F2DES_options(self):
+        """Testing F-2DES option validation"""
+        t1 = qr.TimeAxis(0.0, 1000, 1.0)
+        t3 = qr.TimeAxis(0.0, 1000, 1.0)
+        t2 = qr.TimeAxis(30, 10, 10.0)
+
+        twod_calc = qr.TwoDResponseCalculator(
+            t1, t2, t3, twodtype="F-2DES", gamma_factor=0.5
+        )
+        self.assertEqual(twod_calc.twodtype, "F-2DES")
+        self.assertEqual(twod_calc.gamma_factor, 0.5)
+
+        with self.assertRaises(Exception) as context:
+            qr.TwoDResponseCalculator(t1, t2, t3, twodtype="F-2DES")
+
+        self.assertIn("Not enough parameters for F-2DES", str(context.exception))
+
+        with self.assertRaises(NotImplementedError) as context:
+            qr.TwoDResponseCalculator(
+                t1, t2, t3, twodtype="F-2DES", population_factors=(1.0, 1.0, 1.0)
+            )
+
+        self.assertIn("state-resolved ESA", str(context.exception))
+
+        rate_matrix = numpy.zeros((t2.length, 2, 2), dtype=numpy.float64)
+        with self.assertRaises(NotImplementedError) as context:
+            qr.TwoDResponseCalculator(t1, t2, t3, rate_matrix=rate_matrix)
+
+        self.assertIn("Time-dependent rate matrices", str(context.exception))

--- a/tests/unit/spectroscopy/twod_test.py
+++ b/tests/unit/spectroscopy/twod_test.py
@@ -227,4 +227,7 @@ class TestTwod(unittest.TestCase):
 
         t2 = qr.TimeAxis(30, 10, 10.0)
 
-        twod_calc = qr.TwoDResponseCalculator(t1, t2, t3)
+        twod_calc = qr.TwoDResponseCalculator(
+            t1, t2, t3, relaxation_theory="standard_Foerster"
+        )
+        self.assertEqual(twod_calc.relaxation_theory, "standard_Foerster")

--- a/tests/unit/spectroscopy/twod_test.py
+++ b/tests/unit/spectroscopy/twod_test.py
@@ -283,8 +283,13 @@ class TestTwod(unittest.TestCase):
         t3 = qr.TimeAxis(0.0, 1000, 1.0)
         t2 = qr.TimeAxis(30, 10, 10.0)
 
-        twod_calc = qr.TwoDResponseCalculator(t1, t2, t3, jump_order=1)
+        twod_calc = qr.TwoDResponseCalculator(
+            t1, t2, t3, jump_order=1, jump_integration_steps=3
+        )
         self.assertEqual(twod_calc.jump_order, 1)
+        self.assertEqual(twod_calc.jump_integration_steps, 3)
 
         with assert_raises(ValueError):
             qr.TwoDResponseCalculator(t1, t2, t3, jump_order=2)
+        with assert_raises(ValueError):
+            qr.TwoDResponseCalculator(t1, t2, t3, jump_integration_steps=0)

--- a/tests/unit/spectroscopy/twod_test.py
+++ b/tests/unit/spectroscopy/twod_test.py
@@ -288,8 +288,14 @@ class TestTwod(unittest.TestCase):
         )
         self.assertEqual(twod_calc.jump_order, 1)
         self.assertEqual(twod_calc.jump_time_graining, 3)
+        self.assertEqual(twod_calc.jump_kernel_cutoff, 0.0)
+        self.assertEqual(twod_calc.jump_kernel_zero_cutoff, 0.0)
 
         with assert_raises(ValueError):
             qr.TwoDResponseCalculator(t1, t2, t3, jump_order=2)
         with assert_raises(ValueError):
             qr.TwoDResponseCalculator(t1, t2, t3, jump_time_graining=0)
+        with assert_raises(ValueError):
+            qr.TwoDResponseCalculator(t1, t2, t3, jump_kernel_cutoff=-1.0)
+        with assert_raises(ValueError):
+            qr.TwoDResponseCalculator(t1, t2, t3, jump_kernel_zero_cutoff=-1.0)

--- a/tests/unit/spectroscopy/twod_test.py
+++ b/tests/unit/spectroscopy/twod_test.py
@@ -276,3 +276,15 @@ class TestTwod(unittest.TestCase):
         twod_calc = qr.TwoDResponseCalculator(t1, t2, t3, rate_matrix=rate_matrix)
 
         self.assertEqual(twod_calc._rate_matrix.shape, rate_matrix.shape)
+
+    def test_TwoDResponseCalculator_jump_order_option(self):
+        """Testing 2D response jump-order option validation"""
+        t1 = qr.TimeAxis(0.0, 1000, 1.0)
+        t3 = qr.TimeAxis(0.0, 1000, 1.0)
+        t2 = qr.TimeAxis(30, 10, 10.0)
+
+        twod_calc = qr.TwoDResponseCalculator(t1, t2, t3, jump_order=1)
+        self.assertEqual(twod_calc.jump_order, 1)
+
+        with assert_raises(ValueError):
+            qr.TwoDResponseCalculator(t1, t2, t3, jump_order=2)

--- a/tests/unit/spectroscopy/twodspectrum_test.py
+++ b/tests/unit/spectroscopy/twodspectrum_test.py
@@ -378,8 +378,12 @@ class TestTwoDSpectrum(unittest.TestCase):
         #
         #    plt.show()
 
-        npt.assert_allclose(twod01.data, twod1.data)
-        npt.assert_allclose(twod02.data, twod2.data)
+        # The stored references were generated before 2D FFTs carried explicit
+        # integral factors.  Keep this compatibility scaling until the
+        # reference data are regenerated; then remove this factor.
+        fft_integral_scale = Nt1 * dt1 * dt3
+        npt.assert_allclose(twod01.data * fft_integral_scale, twod1.data)
+        npt.assert_allclose(twod02.data * fft_integral_scale, twod2.data)
 
     def test_get_cut_along_line_uses_correct_y_coordinate(self):
         """get_cut_along_line must use point2[1] not point2[0] for vy2"""

--- a/tests/unit/spectroscopy/twodspectrum_test.py
+++ b/tests/unit/spectroscopy/twodspectrum_test.py
@@ -295,6 +295,31 @@ class TestTwoDSpectrum(unittest.TestCase):
         # print("Calculating", Nt2,"spectra")
         # t1 = time.time()
         tcont = calc.calculate()
+        resp0 = tcont.get_response(0.0)
+        self.assertEqual(resp0.get_resolution(), "types")
+        resp0.set_data_flag("GSB")
+        self.assertIsNotNone(resp0.d__data)
+        resp0.set_data_flag("SE")
+        self.assertIsNotNone(resp0.d__data)
+        resp0.set_data_flag("ESA")
+        esa = resp0.d__data.copy()
+
+        gamma_factor = 0.25
+        fcalc = qr.TwoDResponseCalculator(
+            t1_axis,
+            t2_axis,
+            t3_axis,
+            system=sys,
+            twodtype="F-2DES",
+            gamma_factor=gamma_factor,
+        )
+        with qr.energy_units("1/cm"):
+            fcalc.bootstrap(rwa=rwa, pad=0, lab=lab, verbose=True)
+
+        fcont = fcalc.calculate()
+        fresp0 = fcont.get_response(0.0)
+        fresp0.set_data_flag("ESA")
+        npt.assert_allclose(fresp0.d__data, (gamma_factor - 1.0) * esa)
         # t2 = time.time()
         # print("...done in", t2-t1,"sec")
 


### PR DESCRIPTION
Adds more flexibility to the calculation of 2D spectrum. It allows choice of various relaxation theories for the calculation of 2D spectrum.


## Summary
Brief description of what this PR does and why.

## Related issues
Closes #408

## Changes
-

## Checklist
- [ ] Tests added or updated
- [ ] All tests pass locally (`pytest tests/unit`)
- [ ] Documentation updated if needed
- [ ] Changelog entry added if applicable
