### PR TITLE
#402 Replace explicit Any with concrete types

### DIFF
--- a/quantarhei/builders/aggregate_spectroscopy.py
+++ b/quantarhei/builders/aggregate_spectroscopy.py
@@ -267,7 +267,7 @@ class AggregateSpectroscopy(AggregateBase):
 
 
 def generate_R1g(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -332,7 +332,7 @@ def generate_R1g(
 
 
 def _generate_R1g(
-    self: Any,
+    self: AggregateSpectroscopy,
     i1g: int,
     i2e: int,
     i3e: int,
@@ -391,7 +391,7 @@ def _generate_R1g(
 
 
 def generate_R1gE(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -528,7 +528,7 @@ def generate_R1gE(
 
 
 def generate_R2g(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -660,7 +660,7 @@ def generate_R2g(
 
 
 def generate_R2gE(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -801,7 +801,7 @@ def generate_R2gE(
 
 
 def generate_R3g(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -911,7 +911,7 @@ def generate_R3g(
 
 
 def generate_R4g(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1021,7 +1021,7 @@ def generate_R4g(
 
 
 def generate_R1f(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1162,7 +1162,7 @@ def generate_R1f(
 
 
 def generate_R2f(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1303,7 +1303,7 @@ def generate_R2f(
 
 
 def generate_R1fE(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1438,7 +1438,7 @@ def generate_R1fE(
 
 
 def generate_R2fE(
-    self: Any,
+    self: AggregateSpectroscopy,
     lst: list,
     eUt2: numpy.ndarray,
     pop_tol: float,
@@ -1572,7 +1572,11 @@ def generate_R2fE(
 
 
 def generate_1orderP_sec(
-    self: Any, lst: list, pop_tol: float, dip_tol: float, verbose: int = 0
+    self: AggregateSpectroscopy,
+    lst: list,
+    pop_tol: float,
+    dip_tol: float,
+    verbose: int = 0,
 ) -> None:
 
     ngs = self.get_electronic_groundstate()

--- a/quantarhei/builders/molecules.py
+++ b/quantarhei/builders/molecules.py
@@ -2434,7 +2434,7 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
 
 
 def generate_1orderP_sec(
-    self: Any, lst: list, pop_tol: float, dip_tol: float, verbose: int
+    self: Molecule, lst: list, pop_tol: float, dip_tol: float, verbose: int
 ) -> None:
     from ..spectroscopy import diagramatics as diag
 

--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -53,6 +53,7 @@ property needs to be basis managed, one should use a predefined type
 from __future__ import annotations
 
 import os
+import types
 import warnings
 from typing import Any
 
@@ -577,7 +578,9 @@ class Manager(metaclass=Singleton):
         raise UnitsError("Unknown type of units")
 
     #    @deprecated
-    def cu_energy(self, val: float | numpy.ndarray, units: str = "1/cm") -> Any:
+    def cu_energy(  # type: ignore[return]
+        self, val: float | numpy.ndarray, units: str = "1/cm"
+    ) -> float | numpy.ndarray | None:
         """Converst to current energy units"""
         if units in self.units["energy"]:
             x = conversion_facs_energy[units]
@@ -591,7 +594,9 @@ class Manager(metaclass=Singleton):
             return i_val
 
     #    @deprecated
-    def iu_energy(self, val: float | numpy.ndarray, units: str = "1/cm") -> Any:
+    def iu_energy(  # type: ignore[return]
+        self, val: float | numpy.ndarray, units: str = "1/cm"
+    ) -> float | numpy.ndarray | None:
         """Converst to internal energy units"""
         if units in self.units["energy"]:
             x = conversion_facs_energy[units]
@@ -906,7 +911,12 @@ class units_context_manager:
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
         pass
 
 
@@ -943,7 +953,12 @@ class energy_units(units_context_manager):
         self.manager._in_energy_units_context = True
         self.manager._in_eu_count += 1
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
         if exc_val is not None and self.units != self.units_backup:
             warnings.warn(
                 f"An exception exited a 'with energy_units(\"{self.units}\")' block. "
@@ -999,7 +1014,12 @@ class length_units(units_context_manager):
         self.units_backup = self.manager.get_current_units("length")
         self.manager.set_current_units(self.utype, self.units)
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
         if exc_val is not None and self.units != self.units_backup:
             warnings.warn(
                 f"An exception exited a 'with length_units(\"{self.units}\")' block. "
@@ -1019,7 +1039,12 @@ class basis_context_manager:
     def __enter__(self) -> None:
         pass
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
         pass
 
 
@@ -1063,7 +1088,12 @@ class eigenbasis_of(basis_context_manager):
         if self.manager.warn_about_basis_change:
             print("\nQr >>>  ... setting context done")
 
-    def __exit__(self, ext_ty: Any, exc_val: Any, tb: Any) -> None:
+    def __exit__(
+        self,
+        ext_ty: type[BaseException] | None,
+        exc_val: BaseException | None,
+        tb: types.TracebackType | None,
+    ) -> None:
 
         if self.manager.warn_about_basis_change:
             print("\nQr >>> Returning from basis context manager. Cleaning ...")

--- a/quantarhei/qm/hilbertspace/dmoment.py
+++ b/quantarhei/qm/hilbertspace/dmoment.py
@@ -13,7 +13,9 @@ from .operators import SelfAdjointOperator
 
 
 class TransitionDipoleMoment(SelfAdjointOperator, BasisManaged):
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:
+    def __init__(
+        self, dim: int | None = None, data: numpy.ndarray | None = None
+    ) -> None:
 
         if not ((dim is None) and (data is None)):
             # Set the currently used basis

--- a/quantarhei/qm/hilbertspace/hamiltonian.py
+++ b/quantarhei/qm/hilbertspace/hamiltonian.py
@@ -36,7 +36,9 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
 
     data = ManagedRealArray("data")
 
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:
+    def __init__(
+        self, dim: int | None = None, data: numpy.ndarray | None = None
+    ) -> None:
         # self.data = data
         # FIXME: how to avoid the Operator breaking the EnergyUnits management ????
         if not ((dim is None) and (data is None)):
@@ -48,14 +50,16 @@ class Hamiltonian(SelfAdjointOperator, BasisManaged, EnergyUnitsManaged):
                 )
 
         self.rwa_indices: numpy.ndarray | None = None
-        self.rwa_energies: Any = None
+        self.rwa_energies: numpy.ndarray | None = None
         self.has_rwa = False
         # In future, the Hamiltonian should have a block structure
         # reflected in the data storage, for now we are fine just with
         # knowing that the blocks are there
         self.Nblocks = 1
 
-    def set_rwa(self, rwa_indices: Any, rwa_energy: float | None = None) -> None:
+    def set_rwa(
+        self, rwa_indices: list[int] | numpy.ndarray, rwa_energy: float | None = None
+    ) -> None:
         """Set the block indices for the Rotating Wave Approximation (RWA).
 
         Parameters

--- a/quantarhei/qm/hilbertspace/operators.py
+++ b/quantarhei/qm/hilbertspace/operators.py
@@ -42,7 +42,7 @@ class Operator(MatrixData, BasisManaged, Saveable):
     def __init__(
         self,
         dim: int | None = None,
-        data: Any = None,
+        data: numpy.ndarray | None = None,
         real: bool = False,
         name: str = "",
     ) -> None:

--- a/quantarhei/qm/hilbertspace/statevector.py
+++ b/quantarhei/qm/hilbertspace/statevector.py
@@ -45,7 +45,9 @@ class StateVector(BasisManaged):
     data = BasisManagedComplexArray("data")
     _data: numpy.ndarray
 
-    def __init__(self, dim: int | None = None, data: Any = None) -> None:
+    def __init__(
+        self, dim: int | None = None, data: numpy.ndarray | None = None
+    ) -> None:
 
         self._initialized = False
 

--- a/quantarhei/qm/liouvillespace/systembathinteraction.py
+++ b/quantarhei/qm/liouvillespace/systembathinteraction.py
@@ -16,7 +16,7 @@ from ...core.saveable import Saveable
 from ...core.time import TimeAxis
 from ...exceptions import QuantarheiError
 from ...qm.corfunctions.cfmatrix import CorrelationFunctionMatrix
-from ...qm.corfunctions.correlationfunctions import c2g
+from ...qm.corfunctions.correlationfunctions import CorrelationFunction, c2g
 from ...qm.corfunctions.functionstorage import FunctionStorage
 
 if TYPE_CHECKING:
@@ -207,7 +207,7 @@ class SystemBathInteraction(Saveable):
             self.orates = orates
             self.osites = osites
 
-    def set_system(self, system: Any) -> None:
+    def set_system(self, system: Aggregate | Molecule | OpenSystem | None) -> None:
         """Sets the system attribute"""
         from ...builders.aggregates import Aggregate
         from ...builders.molecules import Molecule
@@ -254,15 +254,15 @@ class SystemBathInteraction(Saveable):
                     "Operators in the list are not of the same dimension"
                 )
 
-    def get_time_axis(self) -> Any:
+    def get_time_axis(self) -> TimeAxis:
         """Returns the time axis of the storred correlation functions"""
         return self.TimeAxis
 
-    def get_correlation_function(self, where: Any) -> Any:
+    def get_correlation_function(self, where: tuple[int, int]) -> CorrelationFunction:
         """Returns the bath correlation function object defined by a pair of sites (tuple)"""
         return self.CC.get_correlation_function(where[0], where[1])
 
-    def get_coft(self, n: int, m: int) -> Any:
+    def get_coft(self, n: int, m: int) -> numpy.ndarray:
         """Returns bath correlation function corresponding to sites n and m"""
         if self.sbitype != "Linear_Coupling":
             raise QuantarheiError(
@@ -421,7 +421,9 @@ class SystemBathInteraction(Saveable):
         """Returns temperature associated with the bath"""
         return self.CC.get_temperature()
 
-    def get_reorganization_energy(self, i: int, j: int | None = None) -> Any:
+    def get_reorganization_energy(
+        self, i: int, j: int | None = None
+    ) -> float | numpy.ndarray | None:
         """Returns reorganization energy associated with a given site
 
         If one index `i` is specified, the function returns reorganization
@@ -439,7 +441,9 @@ class SystemBathInteraction(Saveable):
             j = i
         return self.CC.get_reorganization_energy(i, j)
 
-    def get_correlation_time(self, i: int, j: int | None = None) -> Any:
+    def get_correlation_time(
+        self, i: int, j: int | None = None
+    ) -> float | numpy.ndarray | None:
 
         if (
             self.sbitype == "Lindblad_Form"

--- a/quantarhei/qm/propagators/dmevolution.py
+++ b/quantarhei/qm/propagators/dmevolution.py
@@ -8,10 +8,10 @@ import numpy
 from ...core.managers import BasisManaged
 from ...core.matrixdata import MatrixData
 from ...core.saveable import Saveable
+from ...core.time import TimeAxis
 from ...exceptions import QuantarheiError
-
-# from ...core.time import TimeAxis
 from ...utils.types import BasisManagedComplexArray
+from ..hilbertspace.hamiltonian import Hamiltonian
 from ..hilbertspace.operators import DensityMatrix, ReducedDensityMatrix
 
 
@@ -43,7 +43,9 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
 
         self.is_in_rwa = is_in_rwa
 
-    def set_initial_condition(self, rhoi: Any) -> None:
+    def set_initial_condition(
+        self, rhoi: ReducedDensityMatrix | DensityMatrix | numpy.ndarray
+    ) -> None:
         """ """
         self.dim = rhoi.data.shape[1]
         self._data = numpy.zeros(
@@ -99,11 +101,11 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
         tr = numpy.trace(self.data[0, :, :])
         self.data = self.data / tr
 
-    def get_TimeAxis(self) -> Any:
+    def get_TimeAxis(self) -> TimeAxis:
         """Returns the TimeAxis of the present evolution"""
         return self.TimeAxis
 
-    def convert_from_RWA(self, ham: Any, sgn: int = 1) -> None:
+    def convert_from_RWA(self, ham: Hamiltonian, sgn: int = 1) -> None:
         """Converts density matrix evolution from RWA to standard repre
 
 
@@ -130,7 +132,7 @@ class DensityMatrixEvolution(MatrixData, BasisManaged, Saveable):
         if sgn == 1:
             self.is_in_rwa = False
 
-    def convert_to_RWA(self, ham: Any) -> None:
+    def convert_to_RWA(self, ham: Hamiltonian) -> None:
         """Converts density matrix evolution from standard repre to RWA
 
 

--- a/quantarhei/qm/propagators/oqssvevolution.py
+++ b/quantarhei/qm/propagators/oqssvevolution.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
-
 import numpy
 
 from ... import REAL
+from ...core.time import TimeAxis
 from ...exceptions import ImplementationError
+from ..hilbertspace.oqsstatevector import OQSStateVector
 from ..propagators.dmevolution import ReducedDensityMatrixEvolution
 
 
@@ -26,7 +26,9 @@ class OQSStateVectorEvolution:
         Default is ``None``.
     """
 
-    def __init__(self, timeaxis: Any = None, psii: Any = None) -> None:
+    def __init__(
+        self, timeaxis: TimeAxis | None = None, psii: OQSStateVector | None = None
+    ) -> None:
 
         if timeaxis is not None:
             self.TimeAxis = timeaxis
@@ -38,7 +40,7 @@ class OQSStateVectorEvolution:
             else:
                 self.dim = 0
 
-    def set_initial_condition(self, psii: Any) -> None:
+    def set_initial_condition(self, psii: OQSStateVector) -> None:
         """ """
         self.dim = psii.data.shape[0]
         self.data = numpy.zeros((self.TimeAxis.length, self.dim), dtype=numpy.float64)

--- a/quantarhei/qm/propagators/poppropagator.py
+++ b/quantarhei/qm/propagators/poppropagator.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy
 
+from ...core.time import TimeAxis
 from ...exceptions import QuantarheiError
 from ..liouvillespace.rates.ratematrix import RateMatrix
 
@@ -29,7 +30,7 @@ class PopulationPropagator:
 
     """
 
-    def __init__(self, timeaxis: Any, rate_matrix: Any = None) -> None:
+    def __init__(self, timeaxis: TimeAxis, rate_matrix: Any = None) -> None:
 
         self.timeAxis = timeaxis
         self.Nref = 1
@@ -95,7 +96,7 @@ class PopulationPropagator:
         return KKD, KKT
 
     def _integrateK0(
-        self, timeaxis: Any, Kab: float, Ka: float, Kb: float
+        self, timeaxis: TimeAxis, Kab: float, Ka: float, Kb: float
     ) -> numpy.ndarray:
         """Returns an integral of transfer matrix element"""
         expK = numpy.exp((Ka - Kb) * timeaxis.data)
@@ -105,7 +106,7 @@ class PopulationPropagator:
         return Kab * integ * timeaxis.step
 
     def _integrateKn(
-        self, timeaxis: Any, Kab: float, Ka: float, Kb: float, Kbc: numpy.ndarray
+        self, timeaxis: TimeAxis, Kab: float, Ka: float, Kb: float, Kbc: numpy.ndarray
     ) -> numpy.ndarray:
         """Returns an integral of transfer matrix element multiplied by
         a result of previous order of expansion
@@ -118,7 +119,7 @@ class PopulationPropagator:
             integ[i] = numpy.sum(expK[0:i] * Kbc[0:i])
         return Kab * integ * timeaxis.step
 
-    def _time_indices(self, timeaxis: Any) -> numpy.ndarray:
+    def _time_indices(self, timeaxis: TimeAxis) -> numpy.ndarray:
         """Returns indices of ``timeaxis`` points on the internal time axis"""
         if not timeaxis.is_subset_of(self.timeAxis):
             raise Exception(
@@ -222,7 +223,7 @@ class PopulationPropagator:
 
         return U0, KI
 
-    def _propagation_matrix_time_dependent(self, timeaxis: Any) -> numpy.ndarray:
+    def _propagation_matrix_time_dependent(self, timeaxis: TimeAxis) -> numpy.ndarray:
         """Returns propagation matrix for time-dependent rates by RK4."""
         indices = self._time_indices(timeaxis)
         rates = self._rate_matrix_time_series()
@@ -247,7 +248,7 @@ class PopulationPropagator:
 
         return self._to_matrix_time_order(U[indices])
 
-    def get_JumpExpansion(self, timeaxis: Any = None, max_order: int = 3) -> tuple:
+    def get_JumpExpansion(self, timeaxis: TimeAxis = None, max_order: int = 3) -> tuple:
         """Returns jump-expansion terms of the population propagator.
 
         The returned tuple contains matrices ``(U0, U1, ..., Un)`` in the
@@ -290,13 +291,13 @@ class PopulationPropagator:
         return tuple(propagators)
 
     def get_KineticDecomposition(
-        self, timeaxis: Any = None, max_order: int = 3
+        self, timeaxis: TimeAxis = None, max_order: int = 3
     ) -> tuple:
         """Alias for :meth:`get_JumpExpansion`."""
         return self.get_JumpExpansion(timeaxis=timeaxis, max_order=max_order)
 
     def get_PropagationMatrix(
-        self, timeaxis: Any, corrections: int = -1, exact: bool = False
+        self, timeaxis: TimeAxis, corrections: int = -1, exact: bool = False
     ) -> Any:
         """Returns propagation matrix corresponding to the present propagator
 

--- a/quantarhei/qm/propagators/rdmpropagator.py
+++ b/quantarhei/qm/propagators/rdmpropagator.py
@@ -82,9 +82,9 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
     def __init__(
         self,
         timeaxis: Any = None,
-        Ham: Any = None,
-        RTensor: Any = None,
-        Iterm: Any = None,
+        Ham: Hamiltonian | None = None,
+        RTensor: RelaxationTensor | None = None,
+        Iterm: numpy.ndarray | None = None,
         Efield: Any = None,
         Trdip: Any = None,
         PDeph: Any = None,
@@ -541,7 +541,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def _INIT_EXP(self, rhoi: Any) -> tuple:
+    def _INIT_EXP(self, rhoi: ReducedDensityMatrix) -> tuple:
         """Parameters
         ----------
         rhoi : TYPE
@@ -587,7 +587,7 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return HH
 
-    def _CLOSE_RWA(self, pr: Any) -> None:
+    def _CLOSE_RWA(self, pr: ReducedDensityMatrixEvolution) -> None:
         """Closes the RWA treatment
 
         Parameters
@@ -1192,7 +1192,9 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_TDrelax_field_oper(self, rhoi: Any, L: int = 4) -> Any:
+    def __propagate_short_exp_TDrelax_field_oper(
+        self, rhoi: ReducedDensityMatrix, L: int = 4
+    ) -> ReducedDensityMatrixEvolution:
         """ """
         debug("(7)")
         return None
@@ -1312,7 +1314,9 @@ class ReducedDensityMatrixPropagator(MatrixData, Saveable):
 
         return pr
 
-    def __propagate_short_exp_TDrelax_EField_oper(self, rhoi: Any, L: int = 4) -> Any:
+    def __propagate_short_exp_TDrelax_EField_oper(
+        self, rhoi: ReducedDensityMatrix, L: int = 4
+    ) -> ReducedDensityMatrixEvolution:
         """ """
         debug("(9)")
         return None

--- a/quantarhei/qm/propagators/statevectorevolution.py
+++ b/quantarhei/qm/propagators/statevectorevolution.py
@@ -10,7 +10,9 @@ from ...core.matrixdata import MatrixData
 from ...core.time import TimeAxis
 from ...exceptions import QuantarheiError
 from ...utils.types import BasisManagedComplexArray
+from ..hilbertspace.hamiltonian import Hamiltonian
 from ..hilbertspace.operators import DensityMatrix
+from ..hilbertspace.statevector import StateVector
 from .dmevolution import DensityMatrixEvolution
 
 
@@ -19,7 +21,7 @@ class StateVectorEvolution(MatrixData, BasisManaged):
     _data: numpy.ndarray
     is_in_rwa: bool = False
 
-    def __init__(self, timeaxis: Any, psii: Any) -> None:
+    def __init__(self, timeaxis: TimeAxis, psii: StateVector) -> None:
 
         if not isinstance(timeaxis, TimeAxis):
             raise QuantarheiError
@@ -32,7 +34,7 @@ class StateVectorEvolution(MatrixData, BasisManaged):
         self.dim = psii.data.shape[0]
         self.data[0, :] = psii.data
 
-    def convert_from_RWA(self, ham: Any, sgn: int = 1) -> None:
+    def convert_from_RWA(self, ham: Hamiltonian, sgn: int = 1) -> None:
         """Converts density matrix evolution from RWA to standard repre
 
 

--- a/quantarhei/spectroscopy/labsetup.py
+++ b/quantarhei/spectroscopy/labsetup.py
@@ -497,7 +497,7 @@ class LabSetup:
 
         self.detection_polarization = detection_polarization
 
-    def get_pulse_polarizations(self) -> list[Any]:
+    def get_pulse_polarizations(self) -> list[numpy.ndarray]:
         """Returns polarizations of the laser pulses
 
 
@@ -519,7 +519,7 @@ class LabSetup:
 
         return pols
 
-    def get_detection_polarization(self) -> Any:
+    def get_detection_polarization(self) -> numpy.ndarray:
         """Returns detection polarizations
 
 
@@ -889,7 +889,7 @@ class LabSetup:
                 + " required"
             )
 
-    def get_pulse_frequency(self, k: int) -> Any:
+    def get_pulse_frequency(self, k: int) -> float:
         """Returns frequency of the pulse with index k
 
         Parameters
@@ -943,7 +943,7 @@ class LabSetup:
                 + " required"
             )
 
-    def get_pulse_arrival_times(self) -> Any:
+    def get_pulse_arrival_times(self) -> numpy.ndarray:
         """Returns frequency of the pulse with index k
 
 
@@ -957,7 +957,7 @@ class LabSetup:
         """
         return self.pulse_centers
 
-    def get_pulse_arrival_time(self, k: int) -> Any:
+    def get_pulse_arrival_time(self, k: int) -> float:
         """Returns frequency of the pulse with index k
 
         Parameters
@@ -1007,7 +1007,7 @@ class LabSetup:
                 "Wrong number of phases: " + str(self.number_of_pulses) + " required"
             )
 
-    def get_pulse_phases(self) -> Any:
+    def get_pulse_phases(self) -> numpy.ndarray:
         """Returns frequency of the pulse with index k
 
 
@@ -1021,7 +1021,7 @@ class LabSetup:
         """
         return self.phases
 
-    def get_pulse_phase(self, k: int) -> Any:
+    def get_pulse_phase(self, k: int) -> float:
         """Returns frequency of the pulse with index k
 
         Parameters

--- a/quantarhei/testing/behave.py
+++ b/quantarhei/testing/behave.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import tempfile
+import types
 
 # non-standard imports
 from importlib.resources import files
@@ -139,7 +140,12 @@ class testdir:
         self.context.cwd = os.getcwd()
         os.chdir(self.context.tempdir.name)
 
-    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: types.TracebackType | None,
+    ) -> None:
         os.chdir(self.context.cwd)
         if exc_type is not None:
             cleanup_temp_dir(self.context)


### PR DESCRIPTION
## Summary
- Replaces `Any` with concrete types in 15 files across core, hilbertspace, propagators, liouvillespace, spectroscopy, and testing
- No global mypy rule change — just targeted improvements where types are clearly bounded
- Key replacements:
  - `__exit__` signatures → standard `type[BaseException] | None, BaseException | None, TracebackType | None`
  - `self: Any` in module-level functions → `AggregateSpectroscopy` / `Molecule`
  - `data: Any` → `numpy.ndarray | None` in Hamiltonian, Operator, StateVector, TransitionDipoleMoment
  - `timeaxis: Any` → `TimeAxis` in propagators
  - `ham: Any` → `Hamiltonian` in evolution classes
  - `set_system(system: Any)` → `Aggregate | Molecule | OpenSystem | None`
  - Getter return types in LabSetup → `float`, `numpy.ndarray`

Supersedes #403 (closed) — dropped the `disallow_any_explicit` rule which added 1500+ noise comments due to `numpy.ndarray` internally containing `Any`.

Closes #402

## Test plan
- [x] All 287 unit tests pass
- [x] mypy passes (no new errors)
- [x] ruff lint + format clean
- [ ] CI