### PR TITLE
#404 Make QuTiP an optional dependency and use Padé bath decomposition

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -106,7 +106,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: uv sync --extra dev
+      run: uv sync --extra dev --extra qutip
 
     - name: Select unit test paths
       id: paths
@@ -206,7 +206,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: uv sync --extra dev
+      run: uv sync --extra dev --extra qutip
 
     - name: Select behave features
       id: features
@@ -296,7 +296,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Install dependencies
-      run: uv sync --extra dev
+      run: uv sync --extra dev --extra qutip
     - name: Run examples
       working-directory: examples
       run: |
@@ -332,7 +332,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Install dependencies
-      run: uv sync --extra docs
+      run: uv sync --extra docs --extra qutip
     - name: Execute notebooks with papermill
       run: |
         for nb in examples/notebooks/*.ipynb; do

--- a/examples/notebooks/06_heom_qutip.ipynb
+++ b/examples/notebooks/06_heom_qutip.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# HEOM with QuTiP Backend\n",
+    "\n",
+    "This notebook demonstrates how to use [QuTiP](https://qutip.org/)'s HEOM solver\n",
+    "as a backend for quantarhei. The `QuTip_KTHierarchyPropagator` provides the same\n",
+    "interface as the native `KTHierarchyPropagator`, but delegates the actual\n",
+    "computation to QuTiP's optimised `HEOMSolver` with Padé bath decomposition.\n",
+    "\n",
+    "**Advantages of the QuTiP backend:**\n",
+    "- Padé decomposition converges faster than Matsubara — fewer hierarchy levels needed\n",
+    "- Optimised ODE integrators (adaptive Runge-Kutta, DOP853, etc.)\n",
+    "- Access to QuTiP's progress reporting and options\n",
+    "\n",
+    "**Requirements:** `pip install quantarhei[qutip]`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "%config InlineBackend.figure_format = 'svg'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Define the model\n",
+    "\n",
+    "We use the same strongly coupled dimer as in the native HEOM notebook\n",
+    "(notebook 05): two molecules with $J = 100$ cm$^{-1}$ coupling and an\n",
+    "overdamped Brownian bath ($\\lambda = 100$ cm$^{-1}$, $\\tau_c = 50$ fs, $T = 300$ K)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import quantarhei as qr\n",
+    "\n",
+    "# Time axis: 500 steps of 1 fs = 500 fs total\n",
+    "timea = qr.TimeAxis(0.0, 500, 1.0)\n",
+    "\n",
+    "# Two two-level molecules\n",
+    "with qr.energy_units(\"1/cm\"):\n",
+    "    m1 = qr.Molecule([0.0, 10000.0])\n",
+    "    m2 = qr.Molecule([0.0, 10100.0])\n",
+    "\n",
+    "# Build dimer aggregate with J = 100 cm-1\n",
+    "agg = qr.Aggregate([m1, m2])\n",
+    "with qr.energy_units(\"1/cm\"):\n",
+    "    agg.set_resonance_coupling(0, 1, 100.0)\n",
+    "\n",
+    "# Bath: overdamped Brownian oscillator\n",
+    "cpar = dict(\n",
+    "    ftype=\"OverdampedBrownian-HighTemperature\",\n",
+    "    reorg=100,    # cm-1\n",
+    "    cortime=50,   # fs\n",
+    "    T=300,        # K\n",
+    ")\n",
+    "with qr.energy_units(\"1/cm\"):\n",
+    "    cfce = qr.CorrelationFunction(timea, cpar)\n",
+    "\n",
+    "m1.set_transition_environment((0, 1), cfce)\n",
+    "m2.set_transition_environment((0, 1), cfce)\n",
+    "\n",
+    "agg.build()\n",
+    "\n",
+    "ham = agg.get_Hamiltonian()\n",
+    "sbi = agg.get_SystemBathInteraction()\n",
+    "\n",
+    "print(\"Hamiltonian (cm-1):\")\n",
+    "with qr.energy_units(\"1/cm\"):\n",
+    "    print(np.round(ham.data).astype(int))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Propagate with the QuTiP backend\n",
+    "\n",
+    "The `QuTip_KTHierarchyPropagator` is a drop-in replacement for\n",
+    "`KTHierarchyPropagator`. It uses QuTiP's `DrudeLorentzPadeBath` for\n",
+    "faster convergence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build hierarchy\n",
+    "depth = 3\n",
+    "Hy = qr.KTHierarchy(ham, sbi, depth)\n",
+    "print(f\"Hierarchy depth {Hy.depth} — auxiliary matrices: {Hy.hsize}\")\n",
+    "\n",
+    "# Initial condition: all population on site 2\n",
+    "rhoi = qr.ReducedDensityMatrix(dim=ham.dim)\n",
+    "rhoi.data[2, 2] = 1.0\n",
+    "\n",
+    "# QuTiP-backed propagator\n",
+    "kprop_qt = qr.QuTip_KTHierarchyPropagator(timea, Hy)\n",
+    "rhot_qt = kprop_qt.propagate(rhoi, report_hierarchy=False)\n",
+    "print(\"QuTiP HEOM propagation done\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Compare with native implementation\n",
+    "\n",
+    "We run the same calculation with the native quantarhei HEOM solver\n",
+    "and overlay the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Native propagator (same hierarchy)\n",
+    "kprop_native = qr.KTHierarchyPropagator(timea, Hy)\n",
+    "rhot_native = kprop_native.propagate(rhoi, report_hierarchy=False)\n",
+    "print(\"Native HEOM propagation done\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "N = timea.length\n",
+    "t = timea.data\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "\n",
+    "# Native (solid lines)\n",
+    "ax.plot(t, np.real(rhot_native.data[:N, 1, 1]), 'b-', label='Site 1 (native)', lw=2)\n",
+    "ax.plot(t, np.real(rhot_native.data[:N, 2, 2]), 'r-', label='Site 2 (native)', lw=2)\n",
+    "\n",
+    "# QuTiP (dashed lines)\n",
+    "ax.plot(t, np.real(rhot_qt.data[:N, 1, 1]), 'b--', label='Site 1 (QuTiP)', lw=2)\n",
+    "ax.plot(t, np.real(rhot_qt.data[:N, 2, 2]), 'r--', label='Site 2 (QuTiP)', lw=2)\n",
+    "\n",
+    "ax.set_xlabel('Time [fs]')\n",
+    "ax.set_ylabel(r'Population $\\rho_{ii}$')\n",
+    "ax.set_title('HEOM: Native vs QuTiP backend (depth = 3)')\n",
+    "ax.legend()\n",
+    "ax.set_xlim(0, 500)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The dashed (QuTiP) and solid (native) lines should overlap closely.\n",
+    "Small differences arise from different ODE integrators and the Padé vs\n",
+    "Matsubara bath decomposition — both converge to the exact result as\n",
+    "hierarchy depth increases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Convergence advantage of Padé decomposition\n",
+    "\n",
+    "The QuTiP backend uses the Padé decomposition (`DrudeLorentzPadeBath`)\n",
+    "instead of the Matsubara expansion. For the same number of exponential\n",
+    "terms $N_k$, Padé converges faster. This means you can use a **shallower\n",
+    "hierarchy** (less memory, faster runtime) for the same accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare depth 2 (shallow) between native and QuTiP\n",
+    "Hy2 = qr.KTHierarchy(ham, sbi, 2)\n",
+    "print(f\"Hierarchy depth {Hy2.depth} — auxiliary matrices: {Hy2.hsize}\")\n",
+    "\n",
+    "kprop_qt2 = qr.QuTip_KTHierarchyPropagator(timea, Hy2)\n",
+    "rhot_qt2 = kprop_qt2.propagate(rhoi, report_hierarchy=False)\n",
+    "\n",
+    "kprop_native2 = qr.KTHierarchyPropagator(timea, Hy2)\n",
+    "rhot_native2 = kprop_native2.propagate(rhoi, report_hierarchy=False)\n",
+    "\n",
+    "# Reference: native at depth 4\n",
+    "Hy4 = qr.KTHierarchy(ham, sbi, 4)\n",
+    "kprop_ref = qr.KTHierarchyPropagator(timea, Hy4)\n",
+    "rhot_ref = kprop_ref.propagate(rhoi, report_hierarchy=False)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "ax.plot(t, np.real(rhot_ref.data[:N, 2, 2]), 'k-', label='Reference (native, depth 4)', lw=2)\n",
+    "ax.plot(t, np.real(rhot_native2.data[:N, 2, 2]), 'r-', label='Native (depth 2)', lw=1.5)\n",
+    "ax.plot(t, np.real(rhot_qt2.data[:N, 2, 2]), 'b--', label='QuTiP Padé (depth 2)', lw=1.5)\n",
+    "\n",
+    "ax.set_xlabel('Time [fs]')\n",
+    "ax.set_ylabel(r'$\\rho_{22}(t)$')\n",
+    "ax.set_title('Convergence: Padé (QuTiP) vs Matsubara (native) at depth 2')\n",
+    "ax.legend()\n",
+    "ax.set_xlim(0, 500)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Feature | Native HEOM | QuTiP backend |\n",
+    "|---------|-------------|---------------|\n",
+    "| Bath decomposition | Matsubara | Padé (faster convergence) |\n",
+    "| ODE integrator | Fixed-step short-time expansion | Adaptive (vern9, dop853, etc.) |\n",
+    "| Dependency | None | `pip install quantarhei[qutip]` |\n",
+    "| API | `KTHierarchyPropagator` | `QuTip_KTHierarchyPropagator` |\n",
+    "\n",
+    "Both produce the same physics — choose the QuTiP backend when you need\n",
+    "faster convergence or want to leverage QuTiP's solver options."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dependencies = [
 symbolic = [
   "sympy>=1.12,<2",
 ]
+qutip = [
+  "qutip>=5.0",
+]
 docs = [
   "sphinx>=7.0",
   "pydata-sphinx-theme>=0.16",

--- a/quantarhei/implementations/qutip/qutip_heom.py
+++ b/quantarhei/implementations/qutip/qutip_heom.py
@@ -7,19 +7,25 @@ from typing import Any
 
 import numpy as np
 from matplotlib import pyplot as plt
-from qutip import (
-    Qobj,
-    basis,
-    expect,
-    liouvillian,
-)
-from qutip.core.dimensions import (
-    to_tensor_rep,
-)
-from qutip.solver.heom import (
-    DrudeLorentzBath,
-    HEOMSolver,
-)
+
+try:
+    from qutip import (
+        Qobj,
+        basis,
+        expect,
+        liouvillian,
+    )
+    from qutip.core.dimensions import (
+        to_tensor_rep,
+    )
+    from qutip.solver.heom import (
+        DrudeLorentzPadeBath,
+        HEOMSolver,
+    )
+
+    _QUTIP_AVAILABLE = True
+except ImportError:
+    _QUTIP_AVAILABLE = False
 
 import quantarhei as qr
 
@@ -54,6 +60,11 @@ fmo_ham = numpy.array([
 
 
 def prepare_simulation(Ham: Any, sbi: Any, depth: int) -> dict[str, Any]:
+    if not _QUTIP_AVAILABLE:
+        raise ImportError(
+            "QuTiP is required for the HEOM bridge but is not installed. "
+            "Install it with: pip install quantarhei[qutip]"
+        )
 
     qutip_data: dict[str, Any] = dict(depth=depth)
 
@@ -100,7 +111,7 @@ def prepare_simulation(Ham: Any, sbi: Any, depth: int) -> dict[str, Any]:
         lam = lam_qr  # cm^-1
 
         baths.append(
-            DrudeLorentzBath(Qalt, lam=lam, gamma=gamma, T=T, Nk=Nk, tag=str(m))
+            DrudeLorentzPadeBath(Qalt, lam=lam, gamma=gamma, T=T, Nk=Nk, tag=str(m))
         )
         _, terminator = baths[-1].terminator()
         Ltot += terminator
@@ -209,7 +220,7 @@ def run_simulation(
         lam = lam_qr # cm^-1
 
         baths.append(
-            DrudeLorentzBath(
+            DrudeLorentzPadeBath(
                 Qalt, lam=lam, gamma=gamma, T=T, Nk=Nk,
                 tag=str(m)
             )


### PR DESCRIPTION
## Summary
- Adds `qutip` as a proper optional dependency (`pip install quantarhei[qutip]`) — same pattern as the `symbolic` extra for SymPy
- Guards the QuTiP import with try/except so quantarhei doesn't crash if QuTiP is not installed; raises a clear `ImportError` with install instructions when the HEOM bridge is actually used
- Switches from `DrudeLorentzBath` (Matsubara decomposition) to `DrudeLorentzPadeBath` (Padé decomposition) — same API, faster convergence with fewer hierarchy levels needed

The `DrudeLorentzPadeBath` is a drop-in replacement with identical parameters. The Padé approximation converges significantly faster than the Matsubara expansion for the same number of exponential terms (`Nk`), meaning users can achieve the same accuracy with a shallower hierarchy (less memory, faster runtime).

This is the first step from the roadmap in issue #404.

## Test plan
- [x] All 287 unit tests pass
- [x] QuTiP detection works (`_QUTIP_AVAILABLE = True` when installed)
- [x] `DrudeLorentzPadeBath` imports and instantiates correctly
- [ ] CI (QuTiP not in CI deps yet — existing HEOM tests use the native implementation)