### PR TITLE
#419 Clean up QuTiP HEOM bridge

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -106,7 +106,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: uv sync --extra dev
+      run: uv sync --extra dev --extra qutip
 
     - name: Select unit test paths
       id: paths
@@ -206,7 +206,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: uv sync --extra dev
+      run: uv sync --extra dev --extra qutip
 
     - name: Select behave features
       id: features
@@ -296,7 +296,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Install dependencies
-      run: uv sync --extra dev
+      run: uv sync --extra dev --extra qutip
     - name: Run examples
       working-directory: examples
       run: |
@@ -332,7 +332,7 @@ jobs:
       with:
         python-version: "3.12"
     - name: Install dependencies
-      run: uv sync --extra docs
+      run: uv sync --extra docs --extra qutip
     - name: Execute notebooks with papermill
       run: |
         for nb in examples/notebooks/*.ipynb; do

--- a/examples/notebooks/06_heom_qutip.ipynb
+++ b/examples/notebooks/06_heom_qutip.ipynb
@@ -1,0 +1,261 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# HEOM with QuTiP Backend\n",
+    "\n",
+    "This notebook demonstrates how to use [QuTiP](https://qutip.org/)'s HEOM solver\n",
+    "as a backend for quantarhei. The `QuTip_KTHierarchyPropagator` provides the same\n",
+    "interface as the native `KTHierarchyPropagator`, but delegates the actual\n",
+    "computation to QuTiP's optimised `HEOMSolver` with Padé bath decomposition.\n",
+    "\n",
+    "**Advantages of the QuTiP backend:**\n",
+    "- Padé decomposition converges faster than Matsubara — fewer hierarchy levels needed\n",
+    "- Optimised ODE integrators (adaptive Runge-Kutta, DOP853, etc.)\n",
+    "- Access to QuTiP's progress reporting and options\n",
+    "\n",
+    "**Requirements:** `pip install quantarhei[qutip]`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "%config InlineBackend.figure_format = 'svg'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Define the model\n",
+    "\n",
+    "We use the same strongly coupled dimer as in the native HEOM notebook\n",
+    "(notebook 05): two molecules with $J = 100$ cm$^{-1}$ coupling and an\n",
+    "overdamped Brownian bath ($\\lambda = 100$ cm$^{-1}$, $\\tau_c = 50$ fs, $T = 300$ K)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import quantarhei as qr\n",
+    "\n",
+    "# Time axis: 500 steps of 1 fs = 500 fs total\n",
+    "timea = qr.TimeAxis(0.0, 500, 1.0)\n",
+    "\n",
+    "# Two two-level molecules\n",
+    "with qr.energy_units(\"1/cm\"):\n",
+    "    m1 = qr.Molecule([0.0, 10000.0])\n",
+    "    m2 = qr.Molecule([0.0, 10100.0])\n",
+    "\n",
+    "# Build dimer aggregate with J = 100 cm-1\n",
+    "agg = qr.Aggregate([m1, m2])\n",
+    "with qr.energy_units(\"1/cm\"):\n",
+    "    agg.set_resonance_coupling(0, 1, 100.0)\n",
+    "\n",
+    "# Bath: overdamped Brownian oscillator\n",
+    "cpar = dict(\n",
+    "    ftype=\"OverdampedBrownian-HighTemperature\",\n",
+    "    reorg=100,    # cm-1\n",
+    "    cortime=50,   # fs\n",
+    "    T=300,        # K\n",
+    ")\n",
+    "with qr.energy_units(\"1/cm\"):\n",
+    "    cfce = qr.CorrelationFunction(timea, cpar)\n",
+    "\n",
+    "m1.set_transition_environment((0, 1), cfce)\n",
+    "m2.set_transition_environment((0, 1), cfce)\n",
+    "\n",
+    "agg.build()\n",
+    "\n",
+    "ham = agg.get_Hamiltonian()\n",
+    "sbi = agg.get_SystemBathInteraction()\n",
+    "\n",
+    "print(\"Hamiltonian (cm-1):\")\n",
+    "with qr.energy_units(\"1/cm\"):\n",
+    "    print(np.round(ham.data).astype(int))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Propagate with the QuTiP backend\n",
+    "\n",
+    "The `QuTip_KTHierarchyPropagator` is a drop-in replacement for\n",
+    "`KTHierarchyPropagator`. It uses QuTiP's `DrudeLorentzPadeBath` for\n",
+    "faster convergence."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Build hierarchy\n",
+    "depth = 3\n",
+    "Hy = qr.KTHierarchy(ham, sbi, depth)\n",
+    "print(f\"Hierarchy depth {Hy.depth} — auxiliary matrices: {Hy.hsize}\")\n",
+    "\n",
+    "# Initial condition: all population on site 2\n",
+    "rhoi = qr.ReducedDensityMatrix(dim=ham.dim)\n",
+    "rhoi.data[2, 2] = 1.0\n",
+    "\n",
+    "# QuTiP-backed propagator\n",
+    "kprop_qt = qr.QuTip_KTHierarchyPropagator(timea, Hy)\n",
+    "rhot_qt = kprop_qt.propagate(rhoi, report_hierarchy=False)\n",
+    "print(\"QuTiP HEOM propagation done\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Compare with native implementation\n",
+    "\n",
+    "We run the same calculation with the native quantarhei HEOM solver\n",
+    "and overlay the results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Native propagator (same hierarchy)\n",
+    "kprop_native = qr.KTHierarchyPropagator(timea, Hy)\n",
+    "rhot_native = kprop_native.propagate(rhoi, report_hierarchy=False)\n",
+    "print(\"Native HEOM propagation done\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "N = timea.length\n",
+    "t = timea.data\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "\n",
+    "# Native (solid lines)\n",
+    "ax.plot(t, np.real(rhot_native.data[:N, 1, 1]), 'b-', label='Site 1 (native)', lw=2)\n",
+    "ax.plot(t, np.real(rhot_native.data[:N, 2, 2]), 'r-', label='Site 2 (native)', lw=2)\n",
+    "\n",
+    "# QuTiP (dashed lines)\n",
+    "ax.plot(t, np.real(rhot_qt.data[:N, 1, 1]), 'b--', label='Site 1 (QuTiP)', lw=2)\n",
+    "ax.plot(t, np.real(rhot_qt.data[:N, 2, 2]), 'r--', label='Site 2 (QuTiP)', lw=2)\n",
+    "\n",
+    "ax.set_xlabel('Time [fs]')\n",
+    "ax.set_ylabel(r'Population $\\rho_{ii}$')\n",
+    "ax.set_title('HEOM: Native vs QuTiP backend (depth = 3)')\n",
+    "ax.legend()\n",
+    "ax.set_xlim(0, 500)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The dashed (QuTiP) and solid (native) lines should overlap closely.\n",
+    "Small differences arise from different ODE integrators and the Padé vs\n",
+    "Matsubara bath decomposition — both converge to the exact result as\n",
+    "hierarchy depth increases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Convergence advantage of Padé decomposition\n",
+    "\n",
+    "The QuTiP backend uses the Padé decomposition (`DrudeLorentzPadeBath`)\n",
+    "instead of the Matsubara expansion. For the same number of exponential\n",
+    "terms $N_k$, Padé converges faster. This means you can use a **shallower\n",
+    "hierarchy** (less memory, faster runtime) for the same accuracy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare depth 2 (shallow) between native and QuTiP\n",
+    "Hy2 = qr.KTHierarchy(ham, sbi, 2)\n",
+    "print(f\"Hierarchy depth {Hy2.depth} — auxiliary matrices: {Hy2.hsize}\")\n",
+    "\n",
+    "kprop_qt2 = qr.QuTip_KTHierarchyPropagator(timea, Hy2)\n",
+    "rhot_qt2 = kprop_qt2.propagate(rhoi, report_hierarchy=False)\n",
+    "\n",
+    "kprop_native2 = qr.KTHierarchyPropagator(timea, Hy2)\n",
+    "rhot_native2 = kprop_native2.propagate(rhoi, report_hierarchy=False)\n",
+    "\n",
+    "# Reference: native at depth 4\n",
+    "Hy4 = qr.KTHierarchy(ham, sbi, 4)\n",
+    "kprop_ref = qr.KTHierarchyPropagator(timea, Hy4)\n",
+    "rhot_ref = kprop_ref.propagate(rhoi, report_hierarchy=False)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 5))\n",
+    "ax.plot(t, np.real(rhot_ref.data[:N, 2, 2]), 'k-', label='Reference (native, depth 4)', lw=2)\n",
+    "ax.plot(t, np.real(rhot_native2.data[:N, 2, 2]), 'r-', label='Native (depth 2)', lw=1.5)\n",
+    "ax.plot(t, np.real(rhot_qt2.data[:N, 2, 2]), 'b--', label='QuTiP Padé (depth 2)', lw=1.5)\n",
+    "\n",
+    "ax.set_xlabel('Time [fs]')\n",
+    "ax.set_ylabel(r'$\\rho_{22}(t)$')\n",
+    "ax.set_title('Convergence: Padé (QuTiP) vs Matsubara (native) at depth 2')\n",
+    "ax.legend()\n",
+    "ax.set_xlim(0, 500)\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "| Feature | Native HEOM | QuTiP backend |\n",
+    "|---------|-------------|---------------|\n",
+    "| Bath decomposition | Matsubara | Padé (faster convergence) |\n",
+    "| ODE integrator | Fixed-step short-time expansion | Adaptive (vern9, dop853, etc.) |\n",
+    "| Dependency | None | `pip install quantarhei[qutip]` |\n",
+    "| API | `KTHierarchyPropagator` | `QuTip_KTHierarchyPropagator` |\n",
+    "\n",
+    "Both produce the same physics — choose the QuTiP backend when you need\n",
+    "faster convergence or want to leverage QuTiP's solver options."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dependencies = [
 symbolic = [
   "sympy>=1.12,<2",
 ]
+qutip = [
+  "qutip>=5.0",
+]
 docs = [
   "sphinx>=7.0",
   "pydata-sphinx-theme>=0.16",

--- a/quantarhei/implementations/qutip/qutip_heom.py
+++ b/quantarhei/implementations/qutip/qutip_heom.py
@@ -1,22 +1,13 @@
 from __future__ import annotations
 
-import contextlib
-import time
-from collections.abc import Generator
 from typing import Any
 
 import numpy as np
-from matplotlib import pyplot as plt
 
 try:
     from qutip import (
         Qobj,
-        basis,
-        expect,
         liouvillian,
-    )
-    from qutip.core.dimensions import (
-        to_tensor_rep,
     )
     from qutip.solver.heom import (
         DrudeLorentzPadeBath,
@@ -29,34 +20,19 @@ except ImportError:
 
 import quantarhei as qr
 
+_K_TO_INVCM = 0.6949
+_INVFS_TO_INVCM = 1e15 / (2 * np.pi * 3e10)
+_PS_TO_INVCM_TIME = 1e-12 * 2 * np.pi * 3e10
 
-@contextlib.contextmanager
-def timer(label: str) -> Generator[None, None, None]:
-    """Simple utility for timing functions:
-
-    with timer("name"):
-        ... code to time ...
-    """
-    start = time.time()
-    yield
-    end = time.time()
-    print(f"{label}: {end - start}")
-
-
-import time
-
-"""
-fmo_ham = numpy.array([
-            [410.0,  -87.7,    5.5,   -5.9,    6.7,  -13.7,   -9.9],
-            [-87.7,  530.0,   30.8,    8.2,    0.7,   11.8,    4.3],
-            [  5.5,   30.8,  210.0,  -53.5,   -2.2,   -9.6,    6.0],
-            [ -5.9,    8.2,  -53.5,  320.0,  -70.7,  -17.0,  -63.3],
-            [  6.7,    0.7,   -2.2,  -70.7,  480.0,   81.1,   -1.3],
-            [-13.7,   11.8,   -9.6,  -17.0,   81.1,  630.0,   39.7],
-            [ -9.9,    4.3,    6.0,  -63.3,   -1.3,   39.7,  440.0]
-        ], dtype=qr.REAL)
-
-"""
+_DEFAULT_SOLVER_OPTIONS: dict[str, Any] = {
+    "nsteps": 5000,
+    "store_states": True,
+    "rtol": 1e-12,
+    "atol": 1e-12,
+    "min_step": 1e-18,
+    "method": "vern9",
+    "progress_bar": "enhanced",
+}
 
 
 def prepare_simulation(Ham: Any, sbi: Any, depth: int) -> dict[str, Any]:
@@ -66,598 +42,50 @@ def prepare_simulation(Ham: Any, sbi: Any, depth: int) -> dict[str, Any]:
             "Install it with: pip install quantarhei[qutip]"
         )
 
-    qutip_data: dict[str, Any] = dict(depth=depth)
-
-    # number of states
-    Ngr = 1
-
-    # FIXME: we have to base it on
-    Ndim = Ham.dim
-    Nex = Ndim - Ngr  # This has to be checked when we use aggregate
+    Nex = Ham.dim - 1
 
     with qr.energy_units("1/cm"):
-        hdata = Ham.data
+        Hsys = Qobj(Ham.data)
 
-    #
-    # Use Quantarhei data
-    #
-    Hsys = Qobj(hdata)  # cm^-1
-    T_qr = sbi.get_temperature()  # 300 # from cfce
-
-    Q_list = []
+    T = sbi.get_temperature() * _K_TO_INVCM
+    Ltot = liouvillian(Hsys)
     baths = []
 
-    Ltot = liouvillian(Hsys)
-    Nk = 0  # bath exponential terms (0 = single correlation term) + we can add terminator
-
     for m in range(Nex):
-        #
-        # projector
-        #
-        # Q = basis(Ndim, m+Ngr) * basis(Ndim, m+Ngr).dag()
-        Qalt = Qobj(sbi.KK[m, :, :])
-        Q_list.append(Qalt)
-
-        #
-        # bath correlation function
-        #
+        Q = Qobj(sbi.KK[m, :, :])
         cfce = sbi.get_correlation_function((m, m))
         with qr.energy_units("1/cm"):
-            lam_qr = cfce.get_reorganization_energy()  # from cfce
-        gamma_qr = 1.0 / cfce.get_correlation_time()  # from cfce
+            lam = cfce.get_reorganization_energy()
+        gamma = (1.0 / cfce.get_correlation_time()) * _INVFS_TO_INVCM
 
-        T = T_qr * 0.6949  # K -> cm^-1
-        gamma = gamma_qr * (1e15 / (2 * np.pi * 3e10))  # fs^-1 -> cm^-1
-        lam = lam_qr  # cm^-1
-
-        baths.append(
-            DrudeLorentzPadeBath(Qalt, lam=lam, gamma=gamma, T=T, Nk=Nk, tag=str(m))
-        )
-        _, terminator = baths[-1].terminator()
+        bath = DrudeLorentzPadeBath(Q, lam=lam, gamma=gamma, T=T, Nk=0, tag=str(m))
+        baths.append(bath)
+        _, terminator = bath.terminator()
         Ltot += terminator
 
-    qutip_data["Ltot"] = Ltot
-    qutip_data["baths"] = baths
-
-    return qutip_data
+    return {"depth": depth, "Ltot": Ltot, "baths": baths}
 
 
 def run_simulation(
     kthprop: Any, rhoi: Any, options: dict[str, Any] | None = None
 ) -> Any:
-
     timea = kthprop.hy.sbi.get_time_axis()
-
-    # numerical options
-    if options is None:
-        # default options
-        loc_options = {
-            "nsteps": 5000,
-            "store_states": True,
-            "rtol": 1e-12,
-            "atol": 1e-12,
-            "min_step": 1e-18,
-            "method": "vern9",
-            "progress_bar": "enhanced",
-        }
-
-    else:
-        loc_options = options
+    loc_options = options if options is not None else _DEFAULT_SOLVER_OPTIONS
 
     NC = kthprop.qutip_data["depth"]
     Ltot = kthprop.qutip_data["Ltot"]
     baths = kthprop.qutip_data["baths"]
 
-    # initial excitation on site 1
-    rho0 = Qobj(rhoi.data)  # basis(Ndim, 1) * basis(Ndim, 1).dag()
-
+    rho0 = Qobj(rhoi.data)
     Nt = timea.length
-    end_fs = timea.data[Nt - 1]
+    end_time_ps = timea.data[Nt - 1] / 1000
+    tlist = np.linspace(0, end_time_ps * _PS_TO_INVCM_TIME, Nt)
 
-    t_slices = Nt  # 1000 # at which time points to evaluate (how many)
-    end_time_ps = end_fs / 1000  # 0.5
-
-    # times to calculate
-    tlist = np.linspace(
-        0, end_time_ps * 1e-12 * 2 * np.pi * 3e10, t_slices
-    )  # 1e-12 s -> cm^-1
-
-    """
-
-    NC = depth #4 # max hierarchy level
-
-    # number of states
-    Ngr = 1
-    Ndim = Ham.dim
-    Nex = Ndim  - Ngr  # This has to be checked when we use aggregate
-
-    with qr.energy_units("1/cm"):
-        hdata = Ham.data
-
-    #
-    # Use Quantarhei data
-    #
-    Hsys = Qobj(hdata) # cm^-1
-    T_qr = sbi.get_temperature() #300 # from cfce
-
-    Nt = timea.length
-    end_fs = timea.data[Nt-1]
-
-    t_slices = Nt #1000 # at which time points to evaluate (how many)
-    end_time_ps = end_fs / 1000 # 0.5
-
-    # times to calculate
-    tlist = np.linspace(0, end_time_ps * 1e-12 * 2*np.pi*3e10, t_slices) # 1e-12 s -> cm^-1
-
-    # initial excitation on site 1
-    rho0 = Qobj(rhoi.data) #basis(Ndim, 1) * basis(Ndim, 1).dag()
-
-    Q_list = []
-    baths = []
-
-    Ltot = liouvillian(Hsys)
-    Nk = 0 # bath exponential terms (0 = single correlation term) + we can add terminator
-
-    for m in range(Nex):
-
-        #
-        # projector
-        #
-        #Q = basis(Ndim, m+Ngr) * basis(Ndim, m+Ngr).dag()
-        Qalt = Qobj(sbi.KK[m,:,:])
-        Q_list.append(Qalt)
-
-        #
-        # bath correlation function
-        #
-        cfce = sbi.get_correlation_function((m,m))
-        with qr.energy_units("1/cm"):
-            lam_qr = cfce.get_reorganization_energy() # from cfce
-        gamma_qr = 1.0/cfce.get_correlation_time() # from cfce
-
-        T = T_qr * 0.6949 # K -> cm^-1
-        gamma = gamma_qr * (1e15/ (2*np.pi*3e10))  # fs^-1 -> cm^-1
-        lam = lam_qr # cm^-1
-
-        baths.append(
-            DrudeLorentzPadeBath(
-                Qalt, lam=lam, gamma=gamma, T=T, Nk=Nk,
-                tag=str(m)
-            )
-        )
-        _, terminator = baths[-1].terminator()
-        Ltot += terminator
-
-    """
-
-    # with timer("RHS construction time"):
-    HEOMMats = HEOMSolver(Ltot, baths, NC, options=loc_options)
-
-    # with timer("ODE solver time"):
-    output = HEOMMats.run(rho0, tlist)
+    solver = HEOMSolver(Ltot, baths, NC, options=loc_options)
+    output = solver.run(rho0, tlist)
 
     rho_t = qr.DensityMatrixEvolution(timeaxis=timea, rhoi=rhoi)
-    for t in range(t_slices):
+    for t in range(Nt):
         rho_t.data[t, :, :] = output.states[t][:, :]
 
     return rho_t
-
-    #
-    # CONSTRUCTING EVOLUTION SUPEROPERATOR
-    # (dead code below - variables declared to satisfy type checker)
-    #
-    Ndim: Any = None
-    Nk: Any = None
-    Hsys: Any = None
-
-    evosuperops = []
-    for t in range(t_slices):
-        evosuperops.append(np.zeros((Ndim, Ndim, Ndim, Ndim), dtype=complex))
-
-    for m in range(Ndim):
-        for n in range(m + 1):
-            rho0_nm = basis(Ndim, n) * basis(Ndim, m).dag()
-            print(rho0_nm)
-            with timer("ODE solver time"):
-                outputFMO_HEOM = HEOMMats.run(rho0_nm, tlist)
-
-            for t in range(t_slices):
-                evosuperops[t][n, m] += to_tensor_rep(outputFMO_HEOM.states[t])
-                evosuperops[t][m, n] += to_tensor_rep(outputFMO_HEOM.states[t].dag())
-
-    for n in range(Ndim):
-        for t in range(t_slices):
-            evosuperops[t][n, n] /= 2
-
-    evosuperops_transformed = []
-    for t in range(t_slices):
-        evosuperops_transformed.append(
-            np.zeros((Ndim, Ndim, Ndim, Ndim), dtype=complex)
-        )
-
-    #
-    #   TRANSFORMATIONS
-    #
-
-    # eigen energies and eigen states
-    eigenenergies, ekets = Hsys.eigenstates()
-
-    # make transformation matrices
-    vs = []
-    for i in range(Ndim):
-        vs.append(to_tensor_rep(ekets[i]))
-
-    Smatrix = np.hstack(vs)
-    SmatrixInv = np.linalg.inv(Smatrix)
-
-    # example usage of transformation matrices and transform function
-    """
-    Hsysnp = to_tensor_rep(Hsys)
-    print(Hsysnp)
-    # second parameter is "Inverse", i.e. Inverse = False -> transform into said basis, Inverse = True -> transform from said basis
-    HsysDiag = Hsys.transform(ekets, False).tidyup(1e-10)
-    print(HsysDiag)
-    ham_np = SmatrixInv @ Hsysnp @ Smatrix
-    ham_np[ham_np < 1e-10] = 0
-    print(ham_np)
-    print(np.allclose(ham_np, to_tensor_rep(HsysDiag)))
-    quit()
-    """
-
-    S = Smatrix
-    S_inv = SmatrixInv
-
-    for t in range(t_slices):
-        print("t: ", t)
-        dim = S.shape[0]
-        """evosuperops_copy = evosuperops[t]
-        evosuperops_reshaped = evosuperops_copy.reshape(dim**2, dim**2)
-        S_kron = np.kron(S, S)
-        S_inv_kron = np.kron(S_inv, S_inv)
-        evosuperops_transformed[t] = S_kron @ evosuperops_reshaped @ S_inv_kron.T
-        evosuperops_transformed[t] = evosuperops_transformed[t].reshape(dim, dim, dim, dim)
-        """
-        """
-        for k_prime in range(dim):
-            for l_prime in range(dim):
-                for i_prime in range(dim):
-                    for j_prime in range(dim):
-                        for k in range(dim):
-                            for l in range(dim):
-                                for i in range(dim):
-                                    for j in range(dim):
-                                        evosuperops_transformed[t][k_prime, l_prime, i_prime, j_prime] += (
-                                            np.conj(S[k, k_prime])
-                                            * np.conj(S[l, l_prime])
-                                            * evosuperops[t][k, l, i, j]
-                                            * S[i, i_prime]
-                                            * S[j, j_prime]
-                                        )
-        """
-        evosuperops_transformed[t] = np.einsum(
-            "km,ln,klij,ip,jq->mnpq",
-            np.conj(S),  # Transformation for the first input index
-            np.conj(S),  # Transformation for the second input index
-            evosuperops[t],  # Original evosuperops
-            S,  # Transformation for the first output index
-            S,  # Transformation for the second output index
-        )
-
-    #
-    #    PLOTTING
-    #
-
-    id = int(time.time())
-
-    # describe what to put in graphs
-    POPSONLY = True
-    COHERENCESONLY = not POPSONLY
-
-    xlims = [0, end_time_ps * 1000]  # in femto seconds
-    ylims = [0, 1]
-    colors = ["r", "g", "b", "y", "c", "m", "k"]
-
-    rho_final = []
-    # Transformed
-    fig, axes = plt.subplots(1, 1, figsize=(12, 8))
-    fig2, axes2 = plt.subplots(1, 1, figsize=(12, 8))
-
-    rho0numpy = SmatrixInv @ to_tensor_rep(rho0) @ Smatrix
-
-    for t in range(t_slices):
-        rho_f = np.zeros((Ndim, Ndim), dtype=complex)
-        for i in range(Ndim):
-            for j in range(Ndim):
-                for k in range(Ndim):
-                    for l in range(Ndim):
-                        rho_f[i, j] += (
-                            evosuperops_transformed[t][k, l, i, j] * rho0numpy[k, l]
-                        )
-
-        rho_f_to_append = rho_f
-        rho_final.append(rho_f_to_append)
-
-    for n in range(Ndim):
-        for m in range(Ndim):
-            if POPSONLY == True and (n != m):
-                continue
-
-            if COHERENCESONLY == True:
-                if n == m:
-                    continue
-
-                # only coherences with first site/exc)
-                if n != 0:
-                    continue
-
-            # sitebasis == True
-            # excbasis == False
-
-            """
-            # qutip calculation
-            Q = basis(7, n) * basis(7, m).dag()
-            vals = []
-            for t in range(t_slices):
-                # transform rho back into site basis
-                vals.append(expect(Qobj(rho_final[t]).transform(ekets, True), Q))
-            """
-
-            # numpy calculation
-            Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
-            vals = []
-            for t in range(t_slices):
-                # transform rho back into site basis
-                vals.append(np.trace(Smatrix @ rho_final[t] @ SmatrixInv @ Q_np))
-
-            ls = "-"
-            axes.plot(
-                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                np.real(vals),
-                label=f"{n + 1}{m + 1}",
-                color=colors[m % len(colors)],
-                linestyle=ls,
-            )
-            axes.set_xlabel(r"$t$ (fs)", fontsize=30)
-            axes.set_ylabel(r"vals", fontsize=30)
-            axes.locator_params(axis="y", nbins=6)
-            axes.locator_params(axis="x", nbins=6)
-            axes.set_xlim(xlims)
-            axes.set_ylim(ylims)
-
-            # sitebasis == False
-            # excbasis == True
-
-            """
-            # qutip calculation
-            Q = basis(7, n) * basis(7, m).dag()
-            vals = []
-            for t in range(t_slices):
-                vals.append(expect(Qobj(rho_final[t]), Q))
-            """
-
-            # numpy calculation
-            Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
-            vals = []
-            for t in range(t_slices):
-                vals.append(np.trace(rho_final[t] @ Q_np))
-
-            ls = "-"
-            axes2.plot(
-                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                np.real(vals),
-                label=f"{n + 1}{m + 1}",
-                color=colors[m % len(colors)],
-                linestyle=ls,
-            )
-            axes2.set_xlabel(r"$t$ (fs)", fontsize=30)
-            axes2.set_ylabel(r"vals", fontsize=30)
-            axes2.locator_params(axis="y", nbins=6)
-            axes2.locator_params(axis="x", nbins=6)
-            axes2.set_xlim(xlims)
-            axes2.set_ylim(ylims)
-
-    axes.legend(loc=1)
-    fig.savefig("fullevo_sitebasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")
-    axes2.legend(loc=1)
-    fig2.savefig(
-        "fullevo_exctbasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png"
-    )
-
-    evosuperops_transformed_secular = []
-    for t in range(t_slices):
-        evosuperops_transformed_secular.append(
-            np.zeros((Ndim, Ndim, Ndim, Ndim), dtype=complex)
-        )
-
-    for t in range(t_slices):
-        for i in range(Ndim):
-            for j in range(Ndim):
-                for k in range(Ndim):
-                    for l in range(Ndim):
-                        if (k == l) and (i == j):
-                            evosuperops_transformed_secular[t][k, l, i, j] += (
-                                evosuperops_transformed[t][k, l, i, j]
-                            )
-                        if (k == i) and (l == j):
-                            evosuperops_transformed_secular[t][k, l, i, j] += (
-                                evosuperops_transformed[t][k, l, i, j]
-                            )
-                            if (k == l) and (i == j):
-                                evosuperops_transformed_secular[t][k, l, i, j] -= (
-                                    evosuperops_transformed[t][k, l, i, j]
-                                )
-
-    rho_final = []
-    # Transformed SECULAR
-
-    fig, axes = plt.subplots(1, 1, figsize=(12, 8))
-    fig2, axes2 = plt.subplots(1, 1, figsize=(12, 8))
-
-    rho0numpy = SmatrixInv @ to_tensor_rep(rho0) @ Smatrix
-
-    for t in range(t_slices):
-        rho_f = np.zeros((Ndim, Ndim), dtype=complex)
-        for i in range(Ndim):
-            for j in range(Ndim):
-                for k in range(Ndim):
-                    for l in range(Ndim):
-                        rho_f[i, j] += (
-                            evosuperops_transformed_secular[t][k, l, i, j]
-                            * rho0numpy[k, l]
-                        )
-        rho_f_to_append = rho_f
-        rho_final.append(rho_f_to_append)
-
-    for n in range(Ndim):
-        for m in range(Ndim):
-            if POPSONLY == True and (n != m):
-                continue
-
-            if COHERENCESONLY == True:
-                if n == m:
-                    continue
-
-                # only coherences with first site/exc)
-                if n != 0:
-                    continue
-
-            # sitebasis == True
-            # excbasis == False
-
-            """
-            # qutip calculation
-            Q = basis(7, n) * basis(7, m).dag()
-            vals = []
-            for t in range(t_slices):
-                # transform rho back into site basis
-                vals.append(expect(Qobj(rho_final[t]).transform(ekets, True), Q))
-            """
-
-            # numpy calculation
-            Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
-            vals = []
-            for t in range(t_slices):
-                vals.append(np.trace(Smatrix @ rho_final[t] @ SmatrixInv @ Q_np))
-
-            ls = "--"
-            axes.plot(
-                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                np.real(vals),
-                label=f"{n + 1}{m + 1}",
-                color=colors[m % len(colors)],
-                linestyle=ls,
-            )
-            axes.set_xlabel(r"$t$ (fs)", fontsize=30)
-            axes.set_ylabel(r"vals", fontsize=30)
-            axes.locator_params(axis="y", nbins=6)
-            axes.locator_params(axis="x", nbins=6)
-            axes.set_xlim(xlims)
-            axes.set_ylim(ylims)
-
-            # sitebasis == False
-            # excbasis == True
-
-            """
-            # qutip calculation
-            Q = basis(7, n) * basis(7, m).dag()
-            vals = []
-            for t in range(t_slices):
-                vals.append(expect(Qobj(rho_final[t]), Q))
-            """
-
-            # numpy calculation
-            Q_np = to_tensor_rep(basis(Ndim, n) * basis(Ndim, m).dag())
-            vals = []
-            for t in range(t_slices):
-                vals.append(np.trace(rho_final[t] @ Q_np))
-
-            ls = "--"
-            axes2.plot(
-                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                np.real(vals),
-                label=f"{n + 1}{m + 1}",
-                color=colors[m % len(colors)],
-                linestyle=ls,
-            )
-            axes2.set_xlabel(r"$t$ (fs)", fontsize=30)
-            axes2.set_ylabel(r"vals", fontsize=30)
-            axes2.locator_params(axis="y", nbins=6)
-            axes2.locator_params(axis="x", nbins=6)
-            axes2.set_xlim(xlims)
-            axes2.set_ylim(ylims)
-
-    axes.legend(loc=1)
-    fig.savefig("secexc_sitebasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")
-    axes2.legend(loc=1)
-    fig2.savefig("secexc_exctbasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")
-
-    # Normal HEOM
-    fig, axes = plt.subplots(1, 1, figsize=(12, 8))
-    fig2, axes2 = plt.subplots(1, 1, figsize=(12, 8))
-    with timer("ODE solver time"):
-        outputFMO_HEOM = HEOMMats.run(rho0, tlist)
-
-    for n in range(Ndim):
-        for m in range(Ndim):
-            if POPSONLY == True and (n != m):
-                continue
-
-            if COHERENCESONLY == True:
-                if n == m:
-                    continue
-
-                # only coherences with first site/exc)
-                if n != 0:
-                    continue
-
-            # sitebasis == True
-            # excbasis == False
-
-            # qutip calculation
-            Q = basis(Ndim, n) * basis(Ndim, m).dag()
-            vals = []
-            for t in range(t_slices):
-                vals.append(expect(outputFMO_HEOM.states[t], Q))
-
-            axes.plot(
-                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                np.real(vals),
-                label=f"{m + 1}{n + 1}",
-                color=colors[n % len(colors)],
-                linestyle=ls,
-            )
-            axes.set_xlabel(r"$t$ (fs)", fontsize=30)
-            axes.set_ylabel(r"vals", fontsize=30)
-            axes.locator_params(axis="y", nbins=6)
-            axes.locator_params(axis="x", nbins=6)
-            axes.set_xlim(xlims)
-            axes.set_ylim(ylims)
-
-            # sitebasis == False
-            # excbasis == True
-
-            # qutip calculation
-            Q = basis(Ndim, n) * basis(Ndim, m).dag()
-            vals = []
-            for t in range(t_slices):
-                # transform into exc basis
-                vals.append(expect(outputFMO_HEOM.states[t].transform(ekets, False), Q))
-
-            axes2.plot(
-                np.array(tlist) * 1e15 / 3e10 / 2 / np.pi,
-                np.real(vals),
-                label=f"{m + 1}{n + 1}",
-                color=colors[n % len(colors)],
-                linestyle=ls,
-            )
-            axes2.set_xlabel(r"$t$ (fs)", fontsize=30)
-            axes2.set_ylabel(r"vals", fontsize=30)
-            axes2.locator_params(axis="y", nbins=6)
-            axes2.locator_params(axis="x", nbins=6)
-            axes2.set_xlim(xlims)
-            axes2.set_ylim(ylims)
-
-    axes.legend(loc=1)
-    fig.savefig("heom_sitebasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")
-    axes2.legend(loc=1)
-    fig2.savefig("heom_exctbasis_" + str(NC) + "_" + str(Nk) + "_" + str(id) + ".png")

--- a/quantarhei/implementations/qutip/qutip_heom.py
+++ b/quantarhei/implementations/qutip/qutip_heom.py
@@ -7,19 +7,25 @@ from typing import Any
 
 import numpy as np
 from matplotlib import pyplot as plt
-from qutip import (
-    Qobj,
-    basis,
-    expect,
-    liouvillian,
-)
-from qutip.core.dimensions import (
-    to_tensor_rep,
-)
-from qutip.solver.heom import (
-    DrudeLorentzBath,
-    HEOMSolver,
-)
+
+try:
+    from qutip import (
+        Qobj,
+        basis,
+        expect,
+        liouvillian,
+    )
+    from qutip.core.dimensions import (
+        to_tensor_rep,
+    )
+    from qutip.solver.heom import (
+        DrudeLorentzPadeBath,
+        HEOMSolver,
+    )
+
+    _QUTIP_AVAILABLE = True
+except ImportError:
+    _QUTIP_AVAILABLE = False
 
 import quantarhei as qr
 
@@ -54,6 +60,11 @@ fmo_ham = numpy.array([
 
 
 def prepare_simulation(Ham: Any, sbi: Any, depth: int) -> dict[str, Any]:
+    if not _QUTIP_AVAILABLE:
+        raise ImportError(
+            "QuTiP is required for the HEOM bridge but is not installed. "
+            "Install it with: pip install quantarhei[qutip]"
+        )
 
     qutip_data: dict[str, Any] = dict(depth=depth)
 
@@ -100,7 +111,7 @@ def prepare_simulation(Ham: Any, sbi: Any, depth: int) -> dict[str, Any]:
         lam = lam_qr  # cm^-1
 
         baths.append(
-            DrudeLorentzBath(Qalt, lam=lam, gamma=gamma, T=T, Nk=Nk, tag=str(m))
+            DrudeLorentzPadeBath(Qalt, lam=lam, gamma=gamma, T=T, Nk=Nk, tag=str(m))
         )
         _, terminator = baths[-1].terminator()
         Ltot += terminator
@@ -209,7 +220,7 @@ def run_simulation(
         lam = lam_qr # cm^-1
 
         baths.append(
-            DrudeLorentzBath(
+            DrudeLorentzPadeBath(
                 Qalt, lam=lam, gamma=gamma, T=T, Nk=Nk,
                 tag=str(m)
             )


### PR DESCRIPTION
## Summary
- Removes ~560 lines of unreachable dead code (evolution superoperator construction, plotting, basis transforms left from the original research script)
- Removes unused imports (`contextlib`, `time`, `basis`, `expect`, `to_tensor_rep`)
- Extracts unit conversion magic numbers into named constants (`_K_TO_INVCM`, `_INVFS_TO_INVCM`, `_PS_TO_INVCM_TIME`)
- Extracts default solver options into `_DEFAULT_SOLVER_OPTIONS`
- **No behavioral change** — the bridge produces identical results

File went from 650 lines to 91 lines.

Depends on PR #418 (optional dependency + Padé bath).

Closes #419

## Test plan
- [x] All 287 unit tests pass
- [x] QuTiP HEOM notebook (`06_heom_qutip.ipynb`) executes successfully
- [x] mypy clean
- [x] ruff clean
- [ ] CI