### PR TITLE
#194 Remove unused register_implementation and commit_implementation stubs

### DIFF
--- a/quantarhei/core/managers.py
+++ b/quantarhei/core/managers.py
@@ -741,16 +741,6 @@ class Manager(metaclass=Singleton):
         imp_id = self.implementation_points[imp]
         self.current_implementations[imp_id] = choice
 
-    def register_implementation(
-        self, imp_point: str, prefix: str, asint: Any = None
-    ) -> None:
-        pass
-
-    def commit_implementation(
-        self, imp_point: str, prefix: str, asint: Any = None
-    ) -> None:
-        pass
-
     def get_current_basis(self) -> int:
         """Returns the current basis id"""
         l = len(self.basis_stack)


### PR DESCRIPTION
Closes #194

Remove two empty `pass`-body methods from `Manager` that are never called anywhere in the codebase. They appear to be placeholders for a feature that was never completed.

The `if True:` guard in `relaxationtensor.py` was already removed in #337.