### PR TITLE
#199 Add @deprecated decorator for graceful API evolution

### DIFF
--- a/quantarhei/utils/deprecation.py
+++ b/quantarhei/utils/deprecation.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import functools
+import warnings
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def deprecated(message: str) -> Callable[[F], F]:
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            warnings.warn(
+                f"{func.__qualname__} is deprecated and will be removed in a "
+                f"future version. {message}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/tests/unit/utils/test_deprecation.py
+++ b/tests/unit/utils/test_deprecation.py
@@ -1,0 +1,51 @@
+import warnings
+
+from quantarhei.utils.deprecation import deprecated
+
+
+class TestDeprecated:
+    def test_emits_deprecation_warning(self):
+        @deprecated("Use bar() instead.")
+        def foo():
+            return 42
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = foo()
+
+        assert result == 42
+        assert len(w) == 1
+        assert w[0].category is DeprecationWarning
+        assert "foo is deprecated" in str(w[0].message)
+        assert "Use bar() instead." in str(w[0].message)
+
+    def test_preserves_function_metadata(self):
+        @deprecated("Gone.")
+        def documented_func():
+            """My docstring."""
+            return 1
+
+        assert documented_func.__name__ == "documented_func"
+        assert documented_func.__doc__ == "My docstring."
+
+    def test_passes_arguments(self):
+        @deprecated("Use add() instead.")
+        def legacy_add(a, b, offset=0):
+            return a + b + offset
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            assert legacy_add(2, 3, offset=10) == 15
+
+    def test_works_on_methods(self):
+        class MyClass:
+            @deprecated("Use new_method().")
+            def old_method(self):
+                return "old"
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = MyClass().old_method()
+
+        assert result == "old"
+        assert "old_method is deprecated" in str(w[0].message)


### PR DESCRIPTION
Closes #199

Add a simple `@deprecated` decorator to `quantarhei/utils/deprecation.py` that emits `DeprecationWarning` with a custom message.

This is a prerequisite for the larger architectural refactors (#191, #192, #193) that will need to deprecate old APIs before removal. Includes unit tests.

```python
from quantarhei.utils.deprecation import deprecated

@deprecated("Use new_func() instead.")
def old_func():
    ...
```