### PR TITLE
#214 Add str-based unit enums for IDE autocomplete and typo prevention

### DIFF
--- a/quantarhei/__init__.py
+++ b/quantarhei/__init__.py
@@ -285,6 +285,11 @@ from .core.saveable import Saveable as Saveable
 # Core classes
 #
 from .core.time import TimeAxis as TimeAxis
+from .core.unit_enums import EnergyUnit as EnergyUnit
+from .core.unit_enums import FrequencyUnit as FrequencyUnit
+from .core.unit_enums import LengthUnit as LengthUnit
+from .core.unit_enums import TemperatureUnit as TemperatureUnit
+from .core.unit_enums import TimeUnit as TimeUnit
 from .core.units import convert as convert
 from .core.units import in_current_units as in_current_units
 from .core.valueaxis import ValueAxis as ValueAxis

--- a/quantarhei/core/unit_enums.py
+++ b/quantarhei/core/unit_enums.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import enum
+
+
+class EnergyUnit(str, enum.Enum):
+    INT = "int"
+    PER_FS = "1/fs"
+    PER_CM = "1/cm"
+    EV = "eV"
+    MEV = "meV"
+    THZ = "THz"
+    J = "J"
+    SI = "SI"
+    NM = "nm"
+    HA = "Ha"
+    AU = "a.u."
+
+
+class FrequencyUnit(str, enum.Enum):
+    INT = "int"
+    PER_FS = "1/fs"
+    PER_CM = "1/cm"
+    THZ = "THz"
+    HZ = "Hz"
+    SI = "SI"
+    NM = "nm"
+    HA = "Ha"
+    AU = "a.u."
+
+
+class LengthUnit(str, enum.Enum):
+    INT = "int"
+    ANGSTROM = "A"
+    NM = "nm"
+    BOHR = "Bohr"
+    AU = "a.u."
+    METER = "m"
+    SI = "SI"
+
+
+class TimeUnit(str, enum.Enum):
+    INT = "int"
+    FS = "fs"
+    AS = "as"
+    PS = "ps"
+    NS = "ns"
+    MS = "ms"
+    US = "Ms"
+    S = "s"
+    SI = "SI"
+
+
+class TemperatureUnit(str, enum.Enum):
+    INT = "int"
+    PER_FS = "1/fs"
+    KELVIN = "Kelvin"
+    CELSIUS = "Celsius"
+    PER_CM = "1/cm"
+    EV = "eV"
+    MEV = "meV"
+    THZ = "Thz"
+    SI = "SI"

--- a/quantarhei/core/unit_enums.py
+++ b/quantarhei/core/unit_enums.py
@@ -5,8 +5,8 @@ import enum
 
 class EnergyUnit(str, enum.Enum):
     INT = "int"
-    PER_FS = "1/fs"
-    PER_CM = "1/cm"
+    INV_FS = "1/fs"
+    INV_CM = "1/cm"
     EV = "eV"
     MEV = "meV"
     THZ = "THz"
@@ -19,8 +19,8 @@ class EnergyUnit(str, enum.Enum):
 
 class FrequencyUnit(str, enum.Enum):
     INT = "int"
-    PER_FS = "1/fs"
-    PER_CM = "1/cm"
+    INV_FS = "1/fs"
+    INV_CM = "1/cm"
     THZ = "THz"
     HZ = "Hz"
     SI = "SI"
@@ -53,10 +53,10 @@ class TimeUnit(str, enum.Enum):
 
 class TemperatureUnit(str, enum.Enum):
     INT = "int"
-    PER_FS = "1/fs"
+    INV_FS = "1/fs"
     KELVIN = "Kelvin"
     CELSIUS = "Celsius"
-    PER_CM = "1/cm"
+    INV_CM = "1/cm"
     EV = "eV"
     MEV = "meV"
     THZ = "Thz"


### PR DESCRIPTION
Closes #214

Introduce `EnergyUnit`, `FrequencyUnit`, `LengthUnit`, `TimeUnit`, and `TemperatureUnit` enums in `quantarhei/core/unit_enums.py`.

These inherit from `str`, making them fully backward-compatible with all existing string comparisons and dict lookups. Users get IDE autocomplete and typos become `AttributeError` at definition time.

```python
import quantarhei as qr

with qr.energy_units(qr.EnergyUnit.PER_CM):
    mol = qr.Molecule(elenergies=[0.0, 12000.0])
```

Existing code using raw strings continues to work unchanged.