### PR TITLE
#222 Add input validation to Molecule and Aggregate constructors

### DIFF
--- a/quantarhei/builders/aggregate_base.py
+++ b/quantarhei/builders/aggregate_base.py
@@ -62,6 +62,13 @@ class AggregateBase(UnitsManaged, Saveable, OpenSystem):
 
     def __init__(self, molecules: list | None = None, name: str = "") -> None:
 
+        if molecules is not None:
+            if not isinstance(molecules, (list, tuple)):
+                raise TypeError(
+                    "'molecules' must be a list of Molecule instances, "
+                    f"got {type(molecules).__name__}."
+                )
+
         # OpenSystem.__init__(self)
 
         self.mnames: dict[str, int] = {}  #

--- a/quantarhei/builders/molecules.py
+++ b/quantarhei/builders/molecules.py
@@ -130,6 +130,19 @@ class Molecule(UnitsManaged, Saveable, OpenSystem):
         if elenergies is None:
             elenergies = [0.0, 1.0]
 
+        if not isinstance(elenergies, (list, tuple, numpy.ndarray)):
+            raise TypeError(
+                "'elenergies' must be a list or array of numbers, "
+                f"got {type(elenergies).__name__}. "
+                "Example: Molecule(elenergies=[0.0, 12000.0])"
+            )
+        if len(elenergies) < 2:
+            raise ValueError(
+                "'elenergies' must have at least 2 elements "
+                "(ground state + one excited state), "
+                f"got {len(elenergies)}."
+            )
+
         OpenSystem.__init__(self, elenergies)
         # self.manager = Manager()
 


### PR DESCRIPTION
Closes #222

Add lightweight validation at the entry points of the two most commonly used constructors:

- `Molecule.__init__`: validates `elenergies` is a sequence with at least 2 elements
- `AggregateBase.__init__`: validates `molecules` is a list/tuple

Users now get clear error messages at the call site instead of confusing tracebacks deep in numpy internals:

```
TypeError: 'elenergies' must be a list or array of numbers, got str.
           Example: Molecule(elenergies=[0.0, 12000.0])
```