### PR TITLE
#0 fixed the grouping of states by energy gaps in vibsystem to work for vibrational ladders etc.

### DIFF
--- a/quantarhei/builders/vibsystem.py
+++ b/quantarhei/builders/vibsystem.py
@@ -378,7 +378,10 @@ def group_energies_by_gap(
         Number of energies in each band.
     gap_indices : list of int
         Indices at which bands start (for reference).
-   
+
+    Note: changed by Pavel to fraction of the maximum gap instead of median gap
+    to avoid issues for +- equally spaced ladders (e.g., vibrational).
+
     """
     import numpy as np
 

--- a/quantarhei/builders/vibsystem.py
+++ b/quantarhei/builders/vibsystem.py
@@ -378,6 +378,9 @@ def group_energies_by_gap(
         Number of energies in each band.
     gap_indices : list of int
         Indices at which bands start (for reference).
+
+    --> This did not work for ladders of +- equally spaced energies (e.g., vibrational)
+       fixed by Pavel to fraction of max gap instead of median     
     """
     import numpy as np
 
@@ -385,8 +388,8 @@ def group_energies_by_gap(
     gaps = np.diff(energies)
 
     if threshold is None:
-        median_gap = np.median(gaps)
-        threshold = gap_factor * median_gap
+        max_gap = np.max(gaps)
+        threshold = max_gap / gap_factor
 
     # Find gap positions
     band_breaks = np.where(gaps > threshold)[0]

--- a/quantarhei/builders/vibsystem.py
+++ b/quantarhei/builders/vibsystem.py
@@ -378,9 +378,7 @@ def group_energies_by_gap(
         Number of energies in each band.
     gap_indices : list of int
         Indices at which bands start (for reference).
-
-    --> This did not work for ladders of +- equally spaced energies (e.g., vibrational)
-       fixed by Pavel to fraction of max gap instead of median     
+   
     """
     import numpy as np
 


### PR DESCRIPTION
## Summary
Brief description of what this PR does and why.
fixed the group_energies_by_gap function in vibsystem.py, to correctly assign band indices needed for rwa in system with +- equally spaced levels, such as vibrational ladders. Needed for the script to our PT-2D JPCLett paper, https://pubs.acs.org/doi/10.1021/acs.jpclett.6c02224

## Related issues
Closes #

## Changes
-

## Checklist
- [x] Tests added or updated
- [x] All tests pass locally (`pytest tests/unit`)
- [x] Documentation updated if needed
- [x] Changelog entry added if applicable
